### PR TITLE
Use the standard linter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,31 @@
     "underscore-contrib": "^0.3.0"
   },
   "devDependencies": {
+    "babel-eslint": "^4.1.8",
     "coffeelint": "^1.9.3",
     "fs-plus": "^2.8.1",
+    "standard": "^5.4.1",
     "temp": "^0.8.3"
+  },
+  "standard": {
+    "ignore": [],
+    "parser": "babel-eslint",
+    "globals": [
+      "atom",
+      "afterEach",
+      "beforeEach",
+      "describe",
+      "fdescribe",
+      "xdescribe",
+      "expect",
+      "it",
+      "fit",
+      "xit",
+      "jasmine",
+      "runs",
+      "spyOn",
+      "waitsFor",
+      "waitsForPromise"
+    ]
   }
 }


### PR DESCRIPTION
These are the same settings we use in atom/atom.

I’m not gonna bother going through all the existing source and fixing all the current lint right now, but at least we can start linting going forward.
