### PR TITLE
File-summary restyling

### DIFF
--- a/lib/file-list-component.js
+++ b/lib/file-list-component.js
@@ -103,10 +103,10 @@ class FileSummaryComponent {
     return (
       <div className={`file-summary ${this.getSelectedClass()}`}>
         {this.getStagingCheckbox()}
-        {this.getIcon()}
         <span className='path'>
           {this.fileDiff.getNewPathName()}
         </span>
+        {this.getIcon()}
       </div>
     )
   }

--- a/styles/file-summary.less
+++ b/styles/file-summary.less
@@ -3,18 +3,13 @@
 .file-summary {
   -webkit-user-select: none;
   display: flex;
-  align-items: center;
-  padding: 0 10px;
+  align-items: flex-start;
+  padding: @component-padding/2 @component-padding;
   box-shadow:inset @separator-border-color 0 -1px 0;
-  line-height:2.4em;
   cursor:default;
   position:relative;
   box-sizing:border-box;
   overflow:hidden;
-
-  .icon {
-    margin-top: 2px;
-  }
 
   &.selected {
     background: @background-color-highlight;
@@ -32,6 +27,20 @@
       .meta > div {
         color:fade(@text-color-selected, 70%);
       }
+    }
+  }
+
+  .path {
+    flex: 1;
+  }
+  .stage-status-unstaged + .path {
+    color: @text-color-subtle;
+  }
+
+  .icon {
+    margin: 2px 0 0 @component-padding;
+    &::before {
+      margin-right: 0;
     }
   }
 }

--- a/styles/status-list.less
+++ b/styles/status-list.less
@@ -32,7 +32,8 @@
     height: 14px;
     border: 1px solid @base-border-color;
     border-radius: @component-border-radius;
-    margin-right: 8px;
+    margin-top: .1em;
+    margin-right: @component-padding;
     padding: 0;
 
     &:after {


### PR DESCRIPTION
This restyles the file-summary closer to #31.
- [x] Style checkbox + replace icons
- [x] Move diff icons to the right, so they don't clash as much with the checkbox
- [x] More subtle text if unstaged

Before:

![screen shot 2016-02-24 at 5 05 26 pm](https://cloud.githubusercontent.com/assets/378023/13279150/dbd06d42-db18-11e5-9b74-94687a641fed.png)

After:

![screen shot 2016-02-24 at 4 50 19 pm](https://cloud.githubusercontent.com/assets/378023/13279134/b41a9066-db18-11e5-9791-bbc4fb46bc32.png)
