### PR TITLE
Diff restyling

### DIFF
--- a/styles/diff.less
+++ b/styles/diff.less
@@ -57,6 +57,10 @@ git-patch-view, .git-file-diff {
     display:flex;
     align-items:stretch;
 
+    &.selected {
+      color: inherit;
+    }
+
     & > div {
       flex:1 1 auto;
       cursor:default;
@@ -68,7 +72,7 @@ git-patch-view, .git-file-diff {
         width:42px;
         text-align: center;
         vertical-align:top;
-        color: @syntax-gutter-text-color;
+        color: inherit;
         box-shadow:inset contrast(@syntax-background-color, rgba(0,0,0,0.1), rgba(0,0,0,0.35)) -1px 0 0;
       }
 
@@ -108,25 +112,20 @@ git-patch-view, .git-file-diff {
     box-shadow:inset @separator-border-color 0 -1px 0, inset @separator-border-color 0 1px 0;
   }
 
-  @hunk-color: contrast(@syntax-background-color, fade(#4A90E2, 5%), fade(#4A90E2, 10%));
+  @hunk-color: @syntax-gutter-text-color;
 
   .diff-hunk-header > div {
-    color:fade(@syntax-text-color, 50%);
-    background:@hunk-color;
+    color: fade(@hunk-color, 50%);
+    background-color: darken(@syntax-background-color, 2%);;
     height:1.8em;
     line-height:1.8em;
     overflow:hidden;
     white-space:nowrap;
   }
 
-  .diff-hunk-header .old-line-number, .diff-hunk-header .new-line-number {
-    background-color:fade(#4A90E2, 3%);
-    border-color:darken(@hunk-color, 100%);
-  }
-
   .git-diff-hunk {
     white-space: pre;
-    color:@syntax-text-color;
+    color: @hunk-color;
     padding:0;
     margin: @component-padding;
     border-collapse:collapse;
@@ -135,7 +134,9 @@ git-patch-view, .git-file-diff {
   }
 
   @staged-color: @syntax-color-renamed;
-  @staged-number-color:contrast(@syntax-background-color, fade(@staged-color, 65%), fade(@staged-color, 85%));
+  @staged-number-color: darken(@staged-color, 20%);
+  @staged-number-selected-color: darken(@staged-color, 8%);
+  @staged-number-text-color: contrast(@staged-number-color, darken(@staged-number-color, 75%), lighten(@staged-number-color, 75%));
 
   @deletion-color:contrast(@syntax-background-color, fade(@syntax-color-removed, 8%), fade(@syntax-color-removed, 15%));
   @addition-color:contrast(@syntax-background-color, fade(@syntax-color-added, 8%), fade(@syntax-color-added, 15%));
@@ -163,12 +164,8 @@ git-patch-view, .git-file-diff {
   }
 
   .staged div.old-line-number, .staged div.new-line-number {
-    background-color:fade(@staged-number-color, 70%);
-    color: darken(@staged-color, 30%);
-
-    :focus & {
-      background-color:@staged-number-color;
-    }
+    background-color: @staged-number-color;
+    color: @staged-number-text-color;
   }
 
   .active, .keyboard-active {
@@ -208,12 +205,12 @@ git-patch-view, .git-file-diff {
 
       &.staged {
         div.old-line-number, div.new-line-number {
-          background-color:fade(@staged-number-color, 80%);
-          color: darken(@staged-color, 40%);
+          background-color: @staged-number-color;
+          color: @staged-number-text-color;
           box-shadow:inset contrast(@syntax-background-color, rgba(0,0,0,0.1), rgba(0,0,0,0.35)) -1px 0 0;
 
           :focus & {
-            background-color:lighten(@staged-number-color, 4%);
+            background-color: @staged-number-selected-color;
           }
         }
       }


### PR DESCRIPTION
To closer match #31.
- [x] Add padding around hunks. That way it feels less like an editor and more "read-only". Also easier to see where hunks start and end.
- [x] Improve staged/unstaged indicators.
