### PR TITLE
Maybe fix install?

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "diff": "^2.2.1",
     "dom-listener": "0.1.2",
     "etch": "0.3.0",
+    "nan": "^2.0.0",
     "pathwatcher": "~6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I guess we need nan? Maybe fixes #94?

/cc @kuychaco @BinaryMuse. Between this and `apm rebuild-module-cache`, it seems to `apm install` cleanly for me now?
