### PR TITLE
Update atom mocha test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "test": "apm test",
     "lint": "eslint spec lib"
   },
-  "atomTestRunner": "atom-mocha-test-runner",
+  "atomTestRunner": "./test/runner",
   "dependencies": {
     "etch": "0.6.0"
   },
   "devDependencies": {
+    "atom-mocha-test-runner": "github:binarymuse/atom-mocha-test-runner#5d863460edca74e5b63469974a947e1372a97caf",
     "babel-eslint": "^6.0.4",
     "chai": "^3.5.0",
     "eslint": "2.10.2",

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,0 +1,9 @@
+'use babel'
+
+import {createRunner} from 'atom-mocha-test-runner'
+import {assert} from 'chai'
+global.assert = assert
+
+module.exports = createRunner({
+  overrideTestPaths: [/spec$/, /test/]
+})


### PR DESCRIPTION
This implements a few changes to the test runner:
- Pulls it from GitHub (via a specific SHA)
- Uses the API to customize the runner instead of using the default runner
- Adds chai since it's no longer included in `atom-mocha-test-runner`
- Customizes the test path to `test` instead of `spec`
