### PR TITLE
Revert renaming git-CommitPanel

### DIFF
--- a/lib/views/commit-panel-view.js
+++ b/lib/views/commit-panel-view.js
@@ -22,17 +22,21 @@ export default class CommitPanelView {
   render () {
     if (this.repository == null) {
       return (
-        <div className='git-Panel no-repository'>
-          In order to use git features, please open a file that belongs to a git repository.
+        <div className='git-CommitPanel'>
+          <div className='git-CommitPanel-item no-repository'>
+            In order to use git features, please open a file that belongs to a git repository.
+          </div>
         </div>
       )
     } else if (this.modelData == null) {
-      <div className='git-Panel is-loading'>
-        Loading...
+      <div className='git-CommitPanel'>
+        <div className='git-CommitPanel-item is-loading'>
+          Loading...
+        </div>
       </div>
     } else {
       return (
-        <div className='git-Panel' tabIndex='-1'>
+        <div className='git-CommitPanel' tabIndex='-1'>
           <StagingView
             ref='stagingView'
             repository={this.repository}

--- a/styles/commit-panel.less
+++ b/styles/commit-panel.less
@@ -1,6 +1,6 @@
 @import "variables";
 
-.git-Panel {
+.git-CommitPanel {
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -16,14 +16,13 @@
   -webkit-user-select: none;
   cursor: default;
 
-  &.is-loading,
-  &.no-repository {
-    flex: 1;
-    display: flex;
-    justify-content: center;
+  &-item {
+    &.is-loading,
+    &.no-repository {
     padding: @component-padding * 3;
     text-align: center;
     color: @text-color-subtle;
     font-style: italic;
+    }
   }
 }


### PR DESCRIPTION
- Should resolve a merge conflict with #163
- Other parts of the code base still use the “CommitPanel” and it should be renamed everywhere.
