### PR TITLE
Move tooltip wrapper inside the button

### DIFF
--- a/lib/views/push-pull-view.js
+++ b/lib/views/push-pull-view.js
@@ -32,12 +32,12 @@ export default class PushPullView {
           <button className='git-PushPull-item btn' onclick={this.fetch}>Fetch</button>
 
           <div className='git-PushPull-item is-flexible btn-group'>
-            <Tooltip active={this.pullDisabled} text='Commit changes before pulling' className='btn-wrapper'>
-              <button className='btn' onclick={this.pull} disabled={this.pullDisabled}>
+            <button className='btn' onclick={this.pull} disabled={this.pullDisabled}>
+              <Tooltip active={this.pullDisabled} text='Commit changes before pulling' className='btn-tooltip-wrapper'>
                 <span className='icon icon-arrow-down'/>
                 Pull {this.behindCount !== 0 ? `(${this.behindCount})` : ''}
-              </button>
-            </Tooltip>
+              </Tooltip>
+            </button>
             <button className='btn' onclick={this.push}>
               <span className='icon icon-arrow-up'/>
               Push {this.aheadCount !== 0 ? `(${this.aheadCount})` : ''}

--- a/styles/push-pull.less
+++ b/styles/push-pull.less
@@ -21,9 +21,13 @@
   // since they're more important than Fetch
   .btn-group {
     display: flex;
-    .btn-wrapper, .btn {
-      display: flex;
+    .btn {
       flex: 1;
     }
+  }
+
+  // Removes flickering of the toolip if there is an icon inside
+  .btn-tooltip-wrapper .icon {
+    pointer-events: none;
   }
 }


### PR DESCRIPTION
@kuychaco is this ok?

It should fix https://github.com/atom/github/pull/163/commits/cd3f5d37cbdfa9e25540617e8551dc29155a5e30:
- [x] pull button text isn't centered
- [x] tooltip shows up only when you mouseover the arrow icon

The only issue: Because the button has some padding on the sides, the tooltip doesn't show up there, but maybe ok? It's only like 10px or so.

![pull-button](https://cloud.githubusercontent.com/assets/378023/16646355/93bca9fc-4464-11e6-9715-601d07ad320c.gif)

Or is it possible to attach a tooltip directly to the button (without needing an extra wrapper element)? Like the find + replace buttons? 
