### PR TITLE
Add Repository.transact and serialize all repository interactions via ohnogit's resource pool

### DIFF
--- a/lib/controllers/git-panel-controller.js
+++ b/lib/controllers/git-panel-controller.js
@@ -72,25 +72,27 @@ export default class GitPanelController {
 
   async _refreshModelData (repository) {
     if (repository) {
-      const stagedChanges = await repository.getStagedChanges()
-      const unstagedChanges = await repository.getUnstagedChanges()
-      const branchName = await repository.getBranchName()
-      const remoteName = await repository.getBranchRemoteName(branchName)
-      let aheadCount, behindCount
-      if (remoteName) {
-        // TODO: re-enable this when authentication works
-        // await repository.fetch(branchName)
-        const counts = await repository.getAheadBehindCount(branchName)
-        aheadCount = counts.ahead
-        behindCount = counts.behind
-      }
+      await repository.transact(async () => {
+        const stagedChanges = await repository.getStagedChanges()
+        const unstagedChanges = await repository.getUnstagedChanges()
+        const branchName = await repository.getBranchName()
+        const remoteName = await repository.getBranchRemoteName(branchName)
+        let aheadCount, behindCount
+        if (remoteName) {
+          // TODO: re-enable this when authentication works
+          // await repository.fetch(branchName)
+          const counts = await repository.getAheadBehindCount(branchName)
+          aheadCount = counts.ahead
+          behindCount = counts.behind
+        }
 
-      this.unstagedChanges = unstagedChanges
-      this.stagedChanges = stagedChanges
-      this.branchName = branchName
-      this.remoteName = remoteName
-      this.aheadCount = aheadCount
-      this.behindCount = behindCount
+        this.unstagedChanges = unstagedChanges
+        this.stagedChanges = stagedChanges
+        this.branchName = branchName
+        this.remoteName = remoteName
+        this.aheadCount = aheadCount
+        this.behindCount = behindCount
+      })
     }
 
     this.repository = repository

--- a/lib/controllers/status-bar-controller.js
+++ b/lib/controllers/status-bar-controller.js
@@ -57,10 +57,12 @@ export default class StatusBarController {
 
   async _refreshModelData (repository) {
     if (repository) {
-      const stagedChanges = await repository.getStagedChanges()
-      const unstagedChanges = await repository.getUnstagedChanges()
-      this.unstagedChanges = unstagedChanges
-      this.stagedChanges = stagedChanges
+      await repository.transact(async () => {
+        const stagedChanges = await repository.getStagedChanges()
+        const unstagedChanges = await repository.getUnstagedChanges()
+        this.unstagedChanges = unstagedChanges
+        this.stagedChanges = stagedChanges
+      })
     }
 
     this.repository = repository

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -133,8 +133,8 @@ export default class GithubPackage {
       if (atomRepository == null) {
         return
       } else {
-        const rawRepository = await atomRepository.async.repo.repoPromise
-        repository = new Repository(rawRepository, projectDirectory)
+        const rawRepositoryPool = await atomRepository.async.repo.repoPool
+        repository = new Repository(rawRepositoryPool, projectDirectory)
         this.repositoriesByProjectDirectory.set(projectDirectory, repository)
       }
     }

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -13,12 +13,32 @@ const diffOpts = {flags: Git.Diff.OPTION.SHOW_UNTRACKED_CONTENT | Git.Diff.OPTIO
 const findOpts = {flags: Git.Diff.FIND.RENAMES | Git.Diff.FIND.FOR_UNTRACKED}
 
 export default class Repository {
-  constructor (rawRepository, workingDirectory) {
-    this.rawRepository = rawRepository
+  constructor (rawRepositoryPool, workingDirectory) {
+    this.rawRepositoryPool = rawRepositoryPool
     this.workingDirectory = workingDirectory
+    this.rawRepository = null
     this.emitter = new Emitter()
     this.stagedFilePatchesById = new Map()
     this.unstagedFilePatchesById = new Map()
+  }
+
+  transact (fn) {
+    if (this.rawRepository) throw new Error('A transaction is already started. Nested transactions are not supported.')
+
+    return this.rawRepositoryPool.enqueue(async (rawRepositoryPromise) => {
+      this.rawRepository = await rawRepositoryPromise
+      let result = await fn()
+      this.rawRepository = null
+      return result
+    })
+  }
+
+  autoTransact (fn) {
+    if (this.rawRepository) {
+      return fn(this.rawRepository)
+    } else {
+      return this.transact(() => fn(this.rawRepository))
+    }
   }
 
   onDidUpdate (callback) {
@@ -38,12 +58,14 @@ export default class Repository {
   }
 
   getGitDirectoryPath () {
-    return this.rawRepository.path()
+    return this.autoTransact(() => this.rawRepository.path())
   }
 
   async refresh () {
-    await this.refreshStagedChanges()
-    await this.refreshUnstagedChanges()
+    await this.autoTransact(async () => {
+      await this.refreshStagedChanges()
+      await this.refreshUnstagedChanges()
+    })
     this.didUpdate()
   }
 
@@ -65,110 +87,120 @@ export default class Repository {
     return this.stagedChangesPromise
   }
 
-  async fetchUnstagedChanges () {
-    const index = await this.rawRepository.index()
-    await index.read(1)
-    const diff = await Git.Diff.indexToWorkdir(this.rawRepository, index, diffOpts)
-    await diff.findSimilar(findOpts)
-    const validFilePatches = new Set()
-    for (let newPatch of await this.buildFilePatchesFromRawDiff(diff)) {
-      const id = newPatch.getId()
-      const existingPatch = this.unstagedFilePatchesById.get(id)
-      if (existingPatch == null) {
-        this.unstagedFilePatchesById.set(id, newPatch)
-      } else {
-        existingPatch.update(newPatch)
+  fetchUnstagedChanges () {
+    return this.autoTransact(async () => {
+      const index = await this.rawRepository.index()
+      await index.read(1)
+      const diff = await Git.Diff.indexToWorkdir(this.rawRepository, index, diffOpts)
+      await diff.findSimilar(findOpts)
+      const validFilePatches = new Set()
+      for (let newPatch of await this.buildFilePatchesFromRawDiff(diff)) {
+        const id = newPatch.getId()
+        const existingPatch = this.unstagedFilePatchesById.get(id)
+        if (existingPatch == null) {
+          this.unstagedFilePatchesById.set(id, newPatch)
+        } else {
+          existingPatch.update(newPatch)
+        }
+        validFilePatches.add(id)
       }
-      validFilePatches.add(id)
-    }
 
-    for (let [id, patch] of this.unstagedFilePatchesById) {
-      if (!validFilePatches.has(id)) {
-        this.unstagedFilePatchesById.delete(id)
-        patch.destroy()
+      for (let [id, patch] of this.unstagedFilePatchesById) {
+        if (!validFilePatches.has(id)) {
+          this.unstagedFilePatchesById.delete(id)
+          patch.destroy()
+        }
       }
-    }
 
-    return Array.from(this.unstagedFilePatchesById.values())
+      return Array.from(this.unstagedFilePatchesById.values())
+    })
   }
 
-  async fetchStagedChanges () {
-    const headCommit = await this.rawRepository.getHeadCommit()
-    let tree
-    if (headCommit) {
-      tree = await headCommit.getTree()
-    } else {
-      const builder = await Git.Treebuilder.create(this.rawRepository, null)
-      tree = await this.rawRepository.getTree(builder.write())
-    }
-
-    const index = await this.rawRepository.index()
-    await index.read(1)
-    const diff = await Git.Diff.treeToIndex(this.rawRepository, tree, index, diffOpts)
-    await diff.findSimilar(findOpts)
-    const validFilePatches = new Set()
-    for (let newPatch of await this.buildFilePatchesFromRawDiff(diff)) {
-      const id = newPatch.getId()
-      const existingPatch = this.stagedFilePatchesById.get(id)
-      if (existingPatch == null) {
-        this.stagedFilePatchesById.set(id, newPatch)
+  fetchStagedChanges () {
+    return this.autoTransact(async () => {
+      const headCommit = await this.rawRepository.getHeadCommit()
+      let tree
+      if (headCommit) {
+        tree = await headCommit.getTree()
       } else {
-        existingPatch.update(newPatch)
+        const builder = await Git.Treebuilder.create(this.rawRepository, null)
+        tree = await this.rawRepository.getTree(builder.write())
       }
-      validFilePatches.add(id)
-    }
 
-    for (let [id, patch] of this.stagedFilePatchesById) {
-      if (!validFilePatches.has(id)) {
-        this.stagedFilePatchesById.delete(id)
-        patch.destroy()
+      const index = await this.rawRepository.index()
+      await index.read(1)
+      const diff = await Git.Diff.treeToIndex(this.rawRepository, tree, index, diffOpts)
+      await diff.findSimilar(findOpts)
+      const validFilePatches = new Set()
+      for (let newPatch of await this.buildFilePatchesFromRawDiff(diff)) {
+        const id = newPatch.getId()
+        const existingPatch = this.stagedFilePatchesById.get(id)
+        if (existingPatch == null) {
+          this.stagedFilePatchesById.set(id, newPatch)
+        } else {
+          existingPatch.update(newPatch)
+        }
+        validFilePatches.add(id)
       }
-    }
 
-    return Array.from(this.stagedFilePatchesById.values())
+      for (let [id, patch] of this.stagedFilePatchesById) {
+        if (!validFilePatches.has(id)) {
+          this.stagedFilePatchesById.delete(id)
+          patch.destroy()
+        }
+      }
+
+      return Array.from(this.stagedFilePatchesById.values())
+    })
   }
 
   async applyPatchToIndex (filePatch) {
-    const index = await this.rawRepository.index()
-    if (filePatch.status === 'modified') {
-      const oldContents = await this.readFileFromIndex(filePatch.getOldPath())
-      const newContents = Buffer.from(applyPatch(oldContents, filePatch.toString()))
-      const newBlobOid = await this.rawRepository.createBlobFromBuffer(newContents)
-      await index.add(this.buildIndexEntry(newBlobOid, filePatch.getNewMode(), filePatch.getOldPath(), newContents.length))
-    } else if (filePatch.status === 'removed') {
-      await index.remove(filePatch.getOldPath(), 0)
-    } else if (filePatch.status === 'renamed') {
-      const oldContents = await this.readFileFromIndex(filePatch.getOldPath())
-      const newContents = Buffer.from(applyPatch(oldContents, filePatch.toString()))
-      const newBlobOid = await this.rawRepository.createBlobFromBuffer(newContents)
-      await index.remove(filePatch.getOldPath(), 0)
-      await index.add(this.buildIndexEntry(newBlobOid, filePatch.getNewMode(), filePatch.getNewPath(), newContents.length))
-    } else if (filePatch.status === 'added') {
-      const newContents = Buffer.from(applyPatch('', filePatch.toString()))
-      const newBlobOid = await this.rawRepository.createBlobFromBuffer(newContents)
-      await index.add(this.buildIndexEntry(newBlobOid, filePatch.getNewMode(), filePatch.getNewPath(), newContents.length))
-    }
+    await this.autoTransact(async () => {
+      const index = await this.rawRepository.index()
+      if (filePatch.status === 'modified') {
+        const oldContents = await this.readFileFromIndex(filePatch.getOldPath())
+        const newContents = Buffer.from(applyPatch(oldContents, filePatch.toString()))
+        const newBlobOid = await this.rawRepository.createBlobFromBuffer(newContents)
+        await index.add(this.buildIndexEntry(newBlobOid, filePatch.getNewMode(), filePatch.getOldPath(), newContents.length))
+      } else if (filePatch.status === 'removed') {
+        await index.remove(filePatch.getOldPath(), 0)
+      } else if (filePatch.status === 'renamed') {
+        const oldContents = await this.readFileFromIndex(filePatch.getOldPath())
+        const newContents = Buffer.from(applyPatch(oldContents, filePatch.toString()))
+        const newBlobOid = await this.rawRepository.createBlobFromBuffer(newContents)
+        await index.remove(filePatch.getOldPath(), 0)
+        await index.add(this.buildIndexEntry(newBlobOid, filePatch.getNewMode(), filePatch.getNewPath(), newContents.length))
+      } else if (filePatch.status === 'added') {
+        const newContents = Buffer.from(applyPatch('', filePatch.toString()))
+        const newBlobOid = await this.rawRepository.createBlobFromBuffer(newContents)
+        await index.add(this.buildIndexEntry(newBlobOid, filePatch.getNewMode(), filePatch.getNewPath(), newContents.length))
+      }
 
-    await index.write()
-    await this.refreshUnstagedChanges()
-    await this.refreshStagedChanges()
+      await index.write()
+      await this.refreshUnstagedChanges()
+      await this.refreshStagedChanges()
+    })
     this.didUpdate()
   }
 
   async commit (message) {
-    const index = await this.rawRepository.index()
-    const indexTree = await index.writeTree()
-    const head = await this.rawRepository.getHeadCommit()
-    const parents = head ? [head] : null
-    const author = Git.Signature.default(this.rawRepository)
-    await this.rawRepository.createCommit('HEAD', author, author, this.formatCommitMessage(message), indexTree, parents)
-    await this.refreshStagedChanges()
+    await this.autoTransact(async () => {
+      const index = await this.rawRepository.index()
+      const indexTree = await index.writeTree()
+      const head = await this.rawRepository.getHeadCommit()
+      const parents = head ? [head] : null
+      const author = Git.Signature.default(this.rawRepository)
+      await this.rawRepository.createCommit('HEAD', author, author, this.formatCommitMessage(message), indexTree, parents)
+      await this.refreshStagedChanges()
+    })
     this.didUpdate()
   }
 
-  async getLastCommitMessage () {
-    const head = await this.rawRepository.getHeadCommit()
-    return head.message()
+  getLastCommitMessage () {
+    return this.autoTransact(async () => {
+      const head = await this.rawRepository.getHeadCommit()
+      return head.message()
+    })
   }
 
   formatCommitMessage (message) {
@@ -176,11 +208,13 @@ export default class Repository {
     return matches == null ? message : matches.join('\n')
   }
 
-  async readFileFromIndex (path) {
-    const index = await this.rawRepository.index()
-    const indexEntry = await index.getByPath(path, 0)
-    const blob = await this.rawRepository.getBlob(indexEntry.id)
-    return blob.toString()
+  readFileFromIndex (path) {
+    return this.autoTransact(async () => {
+      const index = await this.rawRepository.index()
+      const indexEntry = await index.getByPath(path, 0)
+      const blob = await this.rawRepository.getBlob(indexEntry.id)
+      return blob.toString()
+    })
   }
 
   buildIndexEntry (oid, mode, path, fileSize) {
@@ -249,55 +283,68 @@ export default class Repository {
     return remote.push(refspecs)
   }
 
-  async getBranchRemoteName (branchName) {
-    const remotes = await this.rawRepository.getRemotes()
-    if (remotes.length === 0) return null
-    const config = await this.rawRepository.configSnapshot()
-    return config.getStringBuf(`branch.${branchName}.remote`)
+  getBranchRemoteName (branchName) {
+    return this.autoTransact(async () => {
+      const remotes = await this.rawRepository.getRemotes()
+      if (remotes.length === 0) return null
+      const config = await this.rawRepository.configSnapshot()
+      return config.getStringBuf(`branch.${branchName}.remote`)
+    })
   }
 
-  async fetch (branchName) {
-    const remote = await this.getRemote(branchName)
-    return remote.fetch(null)
+  fetch (branchName) {
+    return this.autoTransact(async () => {
+      const remote = await this.getRemote(branchName)
+      return remote.fetch(null)
+    })
   }
 
-  async pull (branchName) {
-    await this.fetch(branchName)
-
-    const branchRef = await this.rawRepository.getReference(branchName)
-    const upstreamRef = await Git.Branch.upstream(branchRef)
-    await this.rawRepository.mergeBranches(branchRef, upstreamRef)
+  pull (branchName) {
+    return this.autoTransact(async () => {
+      await this.fetch(branchName)
+      const branchRef = await this.rawRepository.getReference(branchName)
+      const upstreamRef = await Git.Branch.upstream(branchRef)
+      await this.rawRepository.mergeBranches(branchRef, upstreamRef)
+    })
   }
 
-  async getAheadBehindCount (branchName) {
-    const branchRef = await this.rawRepository.getReference(branchName)
-    const upstreamRef = await Git.Branch.upstream(branchRef)
-    return Git.Graph.aheadBehind(this.rawRepository, branchRef.target(), upstreamRef.target()) // {ahead, behind}
+  getAheadBehindCount (branchName) {
+    return this.autoTransact(async () => {
+      const branchRef = await this.rawRepository.getReference(branchName)
+      const upstreamRef = await Git.Branch.upstream(branchRef)
+      return Git.Graph.aheadBehind(this.rawRepository, branchRef.target(), upstreamRef.target()) // {ahead, behind}
+    })
   }
 
-  async getPushRefspecs (branchName) {
-    const remote = await this.getRemote(branchName)
-    const remoteName = await this.getBranchRemoteName(branchName)
-    const refspecs = await remote.getPushRefspecs()
-    if (refspecs.length) return refspecs
+  getPushRefspecs (branchName) {
+    return this.autoTransact(async () => {
+      const remote = await this.getRemote(branchName)
+      const remoteName = await this.getBranchRemoteName(branchName)
+      const refspecs = await remote.getPushRefspecs()
+      if (refspecs.length) return refspecs
 
-    const branchRef = await this.rawRepository.getReference(branchName)
-    const upstreamRef = await Git.Branch.upstream(branchRef)
+      const branchRef = await this.rawRepository.getReference(branchName)
+      const upstreamRef = await Git.Branch.upstream(branchRef)
 
-    // The upstream branch's name takes the form of:
-    //   refs/remotes/remote_name/BRANCH_NAME
-    // We want only the BRANCH_NAME
-    const upstreamBranchName = upstreamRef.name().replace(`refs/remotes/${remoteName}/`, '')
-    return [`refs/heads/${branchName}:refs/heads/${upstreamBranchName}`]
+      // The upstream branch's name takes the form of:
+      //   refs/remotes/remote_name/BRANCH_NAME
+      // We want only the BRANCH_NAME
+      const upstreamBranchName = upstreamRef.name().replace(`refs/remotes/${remoteName}/`, '')
+      return [`refs/heads/${branchName}:refs/heads/${upstreamBranchName}`]
+    })
   }
 
-  async getRemote (branchName) {
-    const remoteName = await this.getBranchRemoteName(branchName)
-    return this.rawRepository.getRemote(remoteName)
+  getRemote (branchName) {
+    return this.autoTransact(async () => {
+      const remoteName = await this.getBranchRemoteName(branchName)
+      return this.rawRepository.getRemote(remoteName)
+    })
   }
 
-  async getBranchName () {
-    const head = await this.rawRepository.head()
-    return head.toString().replace('refs/heads/', '')
+  getBranchName () {
+    return this.autoTransact(async () => {
+      const head = await this.rawRepository.head()
+      return head.toString().replace('refs/heads/', '')
+    })
   }
 }

--- a/lib/models/workspace-change-observer.js
+++ b/lib/models/workspace-change-observer.js
@@ -49,7 +49,7 @@ export default class WorkspaceChangeObserver {
   async watchActiveRepositoryGitDirectory () {
     if (this.activeRepository) {
       this.lastIndexChangePromise = new Promise((resolve) => { this.resolveLastIndexChangePromise = resolve })
-      this.currentFileWatcher = await nsfw(this.activeRepository.getGitDirectoryPath(), async () => {
+      this.currentFileWatcher = await nsfw(await this.activeRepository.getGitDirectoryPath(), async () => {
         this.emitter.emit('did-change')
         this.resolveLastIndexChangePromise()
         this.lastIndexChangePromise = new Promise((resolve) => { this.resolveLastIndexChangePromise = resolve })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -17,8 +17,9 @@ export function copyRepositoryDir (variant = 1) {
 }
 
 export async function buildRepository (workingDirPath) {
-  const rawRepository = await Git.Repository.open(workingDirPath)
-  return new Repository(rawRepository, new Directory(workingDirPath))
+  const atomRepository = new GitRepositoryAsync(workingDirPath, {project: null, refreshOnWindowFocus: false, subscribeToBuffers: false})
+  const rawRepositoryPool = atomRepository.repo.repoPool
+  return new Repository(rawRepositoryPool, new Directory(workingDirPath))
 }
 
 export function assertDeepPropertyVals (actual, expected) {


### PR DESCRIPTION
This PR serializes all interactions with the underlying `nodegit` repository instance via the `repoPool` on the `Repository` class from the `ohnogit` library. This ensures that any time we interact with the repository, we never operate concurrently with other interactions from elsewhere in Atom. If we were performing all interactions **via** `ohnogit` rather than reaching directly to the `nodegit` repository instance, this wouldn't be required. But we want to cut out a layer and iterate on our model layer locally in the package before worrying about maintaining the library code.

We introduce a new method, `Repository.prototype.transact`, which takes an async function and returns a promise. It treats this function like a critical section, and won't allow any Git operations to interleave with its calls until its returned promise resolves. We use `transact` in the controllers to ensure that all fetched data is consistent (at least within the confines of the GitHub package). Eventually, we should think about extending this consistency guarantee to exclude changes by _any_ well-behaved process by acquiring the appropriate file locks for the duration of the transaction when we perform reads or writes.

For convenience, one-off method calls on the `Repository` are automatically wrapped in a transaction. This avoids concurrency while keeping the API simple when consistency across calls isn't required.

/cc @as-cii @maxbrunsfeld @joshaber 
