### PR TITLE
Fix pull/push buttons

### DIFF
--- a/lib/views/push-pull-view.js
+++ b/lib/views/push-pull-view.js
@@ -23,7 +23,7 @@ export default class PushPullView {
 
           <div className='git-PushPull-item is-flexible btn-group'>
             <button className='btn' onclick={this.props.pull} disabled={this.props.pullDisabled}>
-              <Tooltip active={this.props.pullDisabled} text='Commit changes before props.pulling' className='btn-wrapper'>
+              <Tooltip active={this.props.pullDisabled} text='Commit changes before props.pulling' className='btn-tooltip-wrapper'>
                 <span className='icon icon-arrow-down'/>
                 Pull {this.props.behindCount !== 0 ? `(${this.props.behindCount})` : ''}
               </Tooltip>

--- a/styles/push-pull.less
+++ b/styles/push-pull.less
@@ -21,9 +21,13 @@
   // since they're more important than Fetch
   .btn-group {
     display: flex;
-    .btn-wrapper, .btn {
-      display: flex;
+    .btn {
       flex: 1;
     }
+  }
+
+  // Removes flickering of the toolip if there is an icon inside
+  .btn-tooltip-wrapper .icon {
+    pointer-events: none;
   }
 }


### PR DESCRIPTION
This moves the `<Tooltip>` wrapper **inside** the `<button>`. It should fix https://github.com/atom/github/pull/163/commits/cd3f5d37cbdfa9e25540617e8551dc29155a5e30:
- [x] pull button text isn't centered
- [x] tooltip shows up only when you mouseover the arrow icon

The only issue: Because the button has some padding on the sides, the tooltip doesn't show up there, but maybe ok? It's only like 10px or so.

![pull-button](https://cloud.githubusercontent.com/assets/378023/16646355/93bca9fc-4464-11e6-9715-601d07ad320c.gif)

Or is it possible to attach a tooltip directly to the button (without needing an extra wrapper element)? Like the find + replace buttons?

/cc @kuychaco
