### PR TITLE
Increase maximum git stdout buffer size

### DIFF
--- a/lib/git-process.js
+++ b/lib/git-process.js
@@ -30,7 +30,8 @@ export default class GitProcess extends EventEmitter {
       const opts = {
         cwd: this.options.cwd,
         encoding: 'utf8',
-        env: {...process.env, ...this.options.env}
+        env: {...process.env, ...this.options.env},
+        maxBuffer: 10 * 1024 * 1024
       }
 
       const child = cp.execFile(resolveGit(), this.args, opts, (...args) => {


### PR DESCRIPTION
Currently, when the working directory has a large number of changes, the git commit panel fails to show anything, because the `git` command produces too much output. 

Repro:
1. Open a project in Atom
2. From the command line, check out old versions of a large number of files
3. Open the commit panel.
4. See an empty changes list, and the following error in the console:

```
child_process.js:267 Uncaught (in promise) Error: stdout maxBuffer exceeded
```

[By default](https://github.com/nodejs/node/blob/99f45b24763b80e116abaf5699082785d92e2d42/lib/child_process.js#L119), node will only store 200kb of output from a command's stdout. This just increases that limit to a modest 10MB.

/cc @kuychaco @BinaryMuse We could probably make it even higher, since Atom already assumes there's lots of RAM, and the string will only be stored for a short time. I just chose 10MB because it seemed like a lot.

For comparison, the diff between Atom master and Atom v0.30.0 is about 2MB.

```
$ git diff --staged | wc -c
 2139851
```
