### PR TITLE
Fix list scrolling

### DIFF
--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -189,7 +189,7 @@ export default class StagingView {
           <span className={'git-FilePatchListView-icon icon icon-alert status-modified'} />
         </header>
         <ListView
-          className='git-FilePatchListView'
+          className='git-StagingView-list git-FilePatchListView'
           ref='mergeConflictListView'
           didConfirmItem={this.stageFilePatch}
           items={this.multiListCollection.getItemsForKey(ListTypes.CONFLICTS)}
@@ -206,7 +206,7 @@ export default class StagingView {
             onmousedown={() => this.selectList(ListTypes.UNSTAGED)} >
           <header className='git-StagingView-header'>Unstaged Changes</header>
           <ListView
-            className='git-FilePatchListView'
+            className='git-StagingView-list git-FilePatchListView'
             ref='unstagedChangesView'
             didConfirmItem={this.stageFilePatch}
             items={this.multiListCollection.getItemsForKey(ListTypes.UNSTAGED)}
@@ -219,7 +219,7 @@ export default class StagingView {
             onmousedown={() => this.selectList(ListTypes.STAGED)} >
           <header className='git-StagingView-header'>Staged Changes</header>
           <ListView
-            className='git-FilePatchListView'
+            className='git-StagingView-list git-FilePatchListView'
             ref='stagedChangesView'
             didConfirmItem={this.unstageFilePatch}
             items={this.multiListCollection.getItemsForKey(ListTypes.STAGED)}

--- a/styles/staging-view.less
+++ b/styles/staging-view.less
@@ -2,12 +2,13 @@
 
 .git-StagingView {
   flex: 1;
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
 
   &-group {
     flex: 1;
+    display: flex;
+    flex-direction: column;
   }
 
   &-header {
@@ -21,5 +22,10 @@
     font-size: @font-size;
     font-weight:bold;
     box-shadow:inset @separator-border-color 0 -1px 0, inset @separator-border-color 0 1px 0;
+  }
+
+  &-list {
+    flex: 1 1 0;
+    overflow-x: auto;
   }
 }


### PR DESCRIPTION
This moves the scrolling area to each StagingView list so that the lists stay visible even if there are many list items.

![lists](https://cloud.githubusercontent.com/assets/378023/17885978/a9153f74-695a-11e6-9098-1ba76173a8da.gif)

Fixes #194 /cc @nathansobo 
