### PR TITLE
Fix editor height

### DIFF
--- a/styles/commit-view.less
+++ b/styles/commit-view.less
@@ -14,6 +14,7 @@
     background-color: @syntax-background-color;
 
     atom-text-editor {
+      height: 100%;
       font-size: @font-size;
     }
   }


### PR DESCRIPTION
This adds the same height to `atom-text-editor` as its parent.

Closes #224
