### PR TITLE
[WIP] Move git-related code from status-bar

### DIFF
--- a/lib/controllers/changed-files-count-controller.js
+++ b/lib/controllers/changed-files-count-controller.js
@@ -9,11 +9,13 @@ import RepositoryWatcher from './repository-watcher-controller'
 export default class ChangedFilesCountController {
   constructor (props) {
     this.props = props
+    window.c = this
     etch.initialize(this)
   }
 
   update (props) {
     this.props = props
+    console.log('update', this.props.repository);
     return etch.update(this)
   }
 
@@ -24,6 +26,7 @@ export default class ChangedFilesCountController {
   render () {
     return (
       <RepositoryWatcher
+        ref='changedFilesCountWatcher'
         repository={this.props.repository}
         collectData={this.collectData}
       >
@@ -33,6 +36,10 @@ export default class ChangedFilesCountController {
         />
       </RepositoryWatcher>
     )
+  }
+
+  readAfterUpdate () {
+    console.log(this.props.repository, this.refs);
   }
 
   async collectData (repository) {

--- a/lib/controllers/repository-watcher-controller.js
+++ b/lib/controllers/repository-watcher-controller.js
@@ -11,8 +11,10 @@ export default class RepositoryWatcher {
     etch.initialize(this)
   }
 
-  update (props) {
+  update (props, children) {
     this.props = Object.assign({}, this.props, props)
+    this.children = children
+    console.log('update', this.props.repository);
     return this.switchRepository(props.repository)
   }
 
@@ -22,6 +24,10 @@ export default class RepositoryWatcher {
     } else {
       return <div />
     }
+  }
+
+  readAfterUpdate () {
+    console.log(this.refs);
   }
 
   destroy () {

--- a/lib/views/branch-view.js
+++ b/lib/views/branch-view.js
@@ -30,9 +30,12 @@ export default class BranchView {
         'core:confirm': this.createBranch
       })
     )
+    window.v = this
+
   }
 
   update (props) {
+    console.log('udpate');
     this.props = Object.assign({}, this.props, props)
     this.createNew = false
     this.errorMessage = ''

--- a/lib/views/changed-files-count-view.js
+++ b/lib/views/changed-files-count-view.js
@@ -15,6 +15,7 @@ export default class ChangedFilesCountView {
   }
 
   render () {
+    console.log('render', window.v = this);
     const changedFilesCount = this.getChangedFilesCount()
     if (changedFilesCount === 0) {
       return <a style={{display: 'none'}} />

--- a/test/controllers/changed-files-count-controller.test.js
+++ b/test/controllers/changed-files-count-controller.test.js
@@ -8,27 +8,29 @@ import sinon from 'sinon'
 import ChangedFilesCountController from '../../lib/controllers/changed-files-count-controller'
 
 describe('ChangedFilesCountController', () => {
-  it('shows the changed files count view when the repository data is loaded', async () => {
+  it.only('shows the changed files count view when the repository data is loaded', async () => {
     const didClick = sinon.spy()
     const view = new ChangedFilesCountController({repository: null, didClick})
-    assert.isUndefined(view.refs.changedFilesCount)
+    assert.isUndefined(view.refs.changedFilesCountWatcher.refs.changedFilesCount)
 
     const workdirPath = await cloneRepository('three-files')
     const repository = await buildRepository(workdirPath)
     view.update({repository})
-    await view.lastModelDataRefreshPromise
-    assert.deepEqual(view.refs.changedFilesCount.props.stagedChanges, [])
-    assert.deepEqual(view.refs.changedFilesCount.props.unstagedChanges, [])
+    await view.refs.changedFilesCountWatcher.lastModelDataRefreshPromise
+    window.v = view
+    debugger
+    assert.deepEqual(view.refs.changedFilesCountWatcher.refs.changedFilesCount.props.stagedChanges, [])
+    assert.deepEqual(view.refs.changedFilesCountWatcher.refs.changedFilesCount.props.unstagedChanges, [])
 
     fs.writeFileSync(path.join(workdirPath, 'a.txt'), 'a change\n')
     fs.unlinkSync(path.join(workdirPath, 'b.txt'))
     const [patchToStage] = await repository.refreshUnstagedChanges()
     await repository.applyPatchToIndex(patchToStage)
     await view.lastModelDataRefreshPromise
-    assert.deepEqual(view.refs.changedFilesCount.props.stagedChanges, await repository.refreshStagedChanges())
-    assert.deepEqual(view.refs.changedFilesCount.props.unstagedChanges, await repository.refreshUnstagedChanges())
+    assert.deepEqual(view.refs.changedFilesCountWatcher.refs.changedFilesCount.props.stagedChanges, await repository.refreshStagedChanges())
+    assert.deepEqual(view.refs.changedFilesCountWatcher.refs.changedFilesCount.props.unstagedChanges, await repository.refreshUnstagedChanges())
 
-    view.refs.changedFilesCount.props.didClick()
+    view.refs.changedFilesCountWatcher.refs.changedFilesCount.props.didClick()
     assert(didClick.calledOnce)
   })
 })


### PR DESCRIPTION
Fixes https://github.com/atom/github/issues/142

The main motivation for doing this now is to update the current branch in the status bar. When creating/checking out branches in the Git Panel, the status bar currently has no way of knowing that there was a branch change and displays the old branch.

This is super WIP and is currently way behind master. Just opening the PR and will come back to this later.
