### PR TITLE
Remove .npmrc file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-runtime = electron
-target = 0.37.8
-disturl = https://atom.io/download/atom-shell
-progress = true


### PR DESCRIPTION
Atom on Windows is currently 32bit and specifying 64bit caused native
modules to compile incorrectly. Removing the target_arch allows npm to
determine the correct architecture to build against.

/cc @as-cii who introduced the `target_arch` in https://github.com/atom/github/commit/8ce25aa160a80108e91a42c91b37e270275fd55f
