### PR TITLE
Fix mouseup handler in StagingView

### DIFF
--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -162,9 +162,11 @@ export default class StagingView {
   }
 
   mouseup () {
-    this.mouseSelectionInProgress = false
-    this.selection.coalesce()
-    this.onDidChangeSelectedItem()
+    if (this.mouseSelectionInProgress) {
+      this.mouseSelectionInProgress = false
+      this.selection.coalesce()
+      this.onDidChangeSelectedItem()
+    }
   }
 
   render () {


### PR DESCRIPTION
Previously, clicking in an empty area of the staging view would cause a FilePatch view to open for the current selection. This changes the mouseup handler to only report that the selection changed if there is a drag operation in progress.

/cc @kuychaco 
