### PR TITLE
Use more specific ref names for rev-list parameters.

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -311,7 +311,7 @@ export default class GitShellOutStrategy {
   async getAheadCount(branchName) {
     const remote = await this.getRemoteForBranch(branchName);
     if (remote) {
-      const output = await this.exec(['rev-list', `${remote}/${branchName}..${branchName}`]);
+      const output = await this.exec(['rev-list', `remotes/${remote}/${branchName}..heads/${branchName}`]);
       return output.trim().split(LINE_ENDING_REGEX).filter(s => s.trim()).length;
     } else {
       return null;
@@ -321,7 +321,7 @@ export default class GitShellOutStrategy {
   async getBehindCount(branchName) {
     const remote = await this.getRemoteForBranch(branchName);
     if (remote) {
-      const output = await this.exec(['rev-list', `${branchName}..${remote}/${branchName}`]);
+      const output = await this.exec(['rev-list', `heads/${branchName}..remotes/${remote}/${branchName}`]);
       return output.trim().split(LINE_ENDING_REGEX).filter(s => s.trim()).length;
     } else {
       return null;


### PR DESCRIPTION
Generate full names for the commitish parameters to `git rev-list` to avoid ambiguities like the one that triggered #329.

From `git help rev-parse`:

> \<refname>, e.g. master, heads/master, refs/heads/master
>   A symbolic ref name. E.g.  master typically means the commit object referenced by refs/heads/master. If you happen to have both heads/master and tags/master, you can explicitly say heads/master to tell Git which one you mean. When ambiguous, a \<refname> is disambiguated by taking the first match in the following rules:
>
> 1. If $GIT_DIR/\<refname> exists, that is what you mean (this is usually useful only for HEAD, FETCH_HEAD, ORIG_HEAD, MERGE_HEAD and CHERRY_PICK_HEAD);
>
> 2. otherwise, refs/\<refname> if it exists;
>
> 3. otherwise, refs/tags/\<refname> if it exists;
>
> 4. otherwise, refs/heads/\<refname> if it exists;
>
> 5. otherwise, refs/remotes/\<refname> if it exists;
>
> 6. otherwise, refs/remotes/\<refname>/HEAD if it exists.
>
> HEAD names the commit on which you based the changes in the working tree.  FETCH_HEAD records the branch which you fetched from a remote repository with your last git fetch invocation.  ORIG_HEAD is created by commands that move your HEAD in a drastic way, to record the position of the HEAD before their operation, so that you can easily change the tip of the branch back to the state before you ran them.  MERGE_HEAD records the commit(s) which you are merging into your branch when you run git merge.  CHERRY_PICK_HEAD records the commit which you are cherry-picking when you run git cherry-pick.
>
> Note that any of the refs/* cases above may come either from the $GIT_DIR/refs directory or from the $GIT_DIR/packed-refs file. While the ref name encoding is unspecified, UTF-8 is preferred as some output processing may assume ref names in UTF-8.

I was originally intending to fully name refs with `refs/heads/${branchName}` to catch everything safely under case (1), but if I'm reading that last bit correctly, that may prevent refs from being discovered from `packed-refs` as well. Naming refs with `heads/...` and `remotes/...` should prevent ambiguities between the other cases.
