### PR TITLE
Disable fetch, pull, and push buttons while an operation is in progress

### DIFF
--- a/lib/views/push-pull-menu-view.js
+++ b/lib/views/push-pull-menu-view.js
@@ -41,7 +41,7 @@ export default class PushPullMenuView {
             className="github-PushPullMenuView-item btn"
             ref="fetchButton"
             onclick={this.fetch}
-            disabled={!this.props.remoteName}>
+            disabled={!this.props.remoteName || this.inProgress}>
             Fetch
           </button>
 
@@ -50,7 +50,7 @@ export default class PushPullMenuView {
               ref="pullButton"
               className="btn"
               onclick={this.pull}
-              disabled={!this.props.remoteName || this.props.pullDisabled}>
+              disabled={!this.props.remoteName || this.props.pullDisabled || this.inProgress}>
               <Tooltip
                 active={this.props.pullDisabled}
                 text="Commit changes before pulling"
@@ -59,7 +59,7 @@ export default class PushPullMenuView {
                 <span ref="behindCount">Pull {this.props.behindCount ? `(${this.props.behindCount})` : ''}</span>
               </Tooltip>
             </button>
-            <button ref="pushButton" className="btn" onclick={this.push}>
+            <button ref="pushButton" className="btn" onclick={this.push} disabled={this.inProgress}>
               <span className="icon icon-arrow-up" />
               <span ref="aheadCount">Push {this.props.aheadCount ? `(${this.props.aheadCount})` : ''}</span>
             </button>


### PR DESCRIPTION
So it turns out that the `inProgress` flag was already there and being set properly, it just wasn't being used for button enablement. The `etch.update(this)` calls were even there.

Fixes #322. /cc @kuychaco @BinaryMuse 