### PR TITLE
Add serialize method to FilePatchController to avoid uncaught error when copying pane items

### DIFF
--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -20,6 +20,10 @@ export default class FilePatchController {
     etch.initialize(this);
   }
 
+  serialize() {
+    return null;
+  }
+
   update(props) {
     this.props = {...this.props, ...props};
     this.emitter.emit('did-change-title', this.getTitle());


### PR DESCRIPTION
Fixes https://github.com/atom/github/issues/328

Currently, we allow only a single file diff to be viewed at a time. In the future we'd like to have a more sophisticated system for viewing file diffs and support having more than one open at a time, where file diffs have the behavior of regular pane items (including the pending state behavior).

For now, in order to address the uncaught error documented in #328 when attempting to copy a FilePatchController pane item, we'll simply return null from the FilePatchController serialize method. The result will be to open an empty pane.