### PR TITLE
Improve stability of StatusBarTileController test case

### DIFF
--- a/test/controllers/status-bar-tile-controller.test.js
+++ b/test/controllers/status-bar-tile-controller.test.js
@@ -5,7 +5,7 @@ import path from 'path';
 
 import etch from 'etch';
 
-import {cloneRepository, buildRepository, setUpLocalAndRemoteRepositories} from '../helpers';
+import {cloneRepository, buildRepository, setUpLocalAndRemoteRepositories, until} from '../helpers';
 import StatusBarTileController from '../../lib/controllers/status-bar-tile-controller';
 
 describe('StatusBarTileController', () => {
@@ -275,9 +275,7 @@ describe('StatusBarTileController', () => {
         assert.equal(pullButton.textContent, 'Pull (2)');
 
         pushButton.dispatchEvent(new MouseEvent('click'));
-        await etch.getScheduler().getNextUpdatePromise(); // update for loading
-        await etch.getScheduler().getNextUpdatePromise(); // update for error message
-        assert.match(message.innerHTML, /Push rejected/);
+        await until('error message appears', () => /Push rejected/.test(message.innerHTML));
 
         pushButton.dispatchEvent(new MouseEvent('click', {metaKey: true}));
         await repository.refresh();


### PR DESCRIPTION
I've been seeing a sporadic failure in the `StatusBarTileController` spec recently, almost entirely when using the graphical runner:

<img width="856" alt="screen shot 2017-01-03 at 3 23 02 pm" src="https://cloud.githubusercontent.com/assets/17565/21621846/d61f817e-d1c8-11e6-95a7-1092bfb699da.png">

My guess is that relying on a specific number of renders to occur is a bit brittle. I've changed it to use an `until` pause, which is messier but seems to be a lot more reliable for me.