### PR TITLE
Disallow assert.async.* calls as expression statements

### DIFF
--- a/assert-async-plugin.js
+++ b/assert-async-plugin.js
@@ -46,6 +46,11 @@ module.exports = function({types: t, template}) {
         // "something"
         const meth = callee.property.name;
 
+        if (t.isExpressionStatement(path.parent)) {
+          const error = `${assert}.async.${meth} can not be used as a statement (did you forget to 'await' it?)`;
+          throw path.buildCodeFrameError(error);
+        }
+
         // assert.something
         const assertDotMethod = t.memberExpression(t.identifier(assert), t.identifier(meth));
         // assert.something(arg1, arg2)


### PR DESCRIPTION
As I mentioned in https://github.com/atom/github/pull/410#pullrequestreview-15519258, it's pretty easy to accidentally use `assert.async.*` calls without `await`ing them, resulting in tests that pass even if the assertions actually eventually fail. This PR throws an exception *during transpilation* of `assert.async.*` if the call is used as an expression statement. That means that...

...the following lines generate transpile-time errors:

```javascript
assert.async.equal(myVar, 1)
() => { assert.async.equal(myVar, 1) }
```

...the following lines are fine:

```javascript
await assert.async.equal(myVar, 1)
let p = assert.async.equal(myVar, 1)
let promises = [ assert.async.equal(myVar, 1) ]
[ assert.async.equal(myVar, 1) ]
() => assert.async.equal(myVar, 1)
return assert.async.equal(myVar, 1)
cb(assert.async.equal(myVar, 1))
```

Are there edge cases I might have forgotten about here? Here's an interactive version you can play with: http://astexplorer.net/#/Bvw3z8OKZv

/cc @kuychaco @smashwilson 