### PR TITLE
Use the "spec" reporter from Mocha instead of dot

### DIFF
--- a/test/runner.js
+++ b/test/runner.js
@@ -6,5 +6,6 @@ chai.use(chaiAsPromised);
 global.assert = chai.assert;
 
 module.exports = createRunner({
+  reporter: 'spec',
   overrideTestPaths: [/spec$/, /test/],
 });


### PR DESCRIPTION
When we encounter nsfw crashes or indefinite hangs, this will allow us to see which spec is triggering that behavior even if the runner process doesn't live long enough to report its results.