### PR TITLE
Compare real paths to real paths

### DIFF
--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -1,6 +1,5 @@
-import {CompositeDisposable, Disposable} from 'atom';
+import {CompositeDisposable, Disposable, File} from 'atom';
 
-import fs from 'fs';
 import path from 'path';
 
 import React from 'react';
@@ -157,7 +156,7 @@ export default class GithubPackage {
 
   projectPathForItemPath(filePath) {
     if (!filePath) { return null; }
-    const realFilePath = fs.realpathSync(filePath);
+    const realFilePath = new File(filePath).getRealPathSync();
     const directory = this.project.getDirectories().find(projectDir => {
       const fixedPath = projectDir.getRealPathSync() + path.sep;
       return realFilePath.startsWith(fixedPath);


### PR DESCRIPTION
I found a minor regression in the symlinked project paths test:

```
  1) GithubPackage updateActiveRepository() handles symlinked project paths:
     AssertionError: assert.isOk(githubPackage.getActiveRepository()): expected null to be truthy
      at doAsserterAsyncAndAddThen (/Users/smashwilson/code/atom/github/node_modules/chai-as-promised/lib/chai-as-promised.js:296:33)
      at .<anonymous> (/Users/smashwilson/code/atom/github/node_modules/chai-as-promised/lib/chai-as-promised.js:286:25)
      at get (/Users/smashwilson/code/atom/github/node_modules/chai/lib/chai/utils/overwriteProperty.js:50:37)
      at Function.assert.isOk (/Users/smashwilson/code/atom/github/node_modules/chai/lib/chai/interface/assert.js:85:31)
      at Context.<anonymous> (/Users/smashwilson/code/atom/github/github-package.test.js:179:16)
      at next (<anonymous>)
      at step (/Users/smashwilson/code/atom/github/github-package.test.js:9:1)
      at /Users/smashwilson/code/atom/github/github-package.test.js:9:1
      at process._tickCallback (internal/process/next_tick.js:103:7)
```

Basically `projectPathForItemPath()` was comparing the PaneItem path as given to the real paths of the project directories, but we really want to canonicalize the PaneItem's path as well, to be sure we're comparing 🍎 to 🍎 .