### PR TITLE
Use "pr" instead of "pull_request" for pull request schema statuses

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -18,6 +18,11 @@ function updateStatus {
 function checkForSchemaChanges {
   CTX="$TRAVIS_EVENT_TYPE"
 
+  # Consistency with other CI integration statuses
+  if [ "${CTX}" = "pull_request" ]; then
+    CTX="pr"
+  fi
+
   updateStatus "pending" $CTX "Checking for GraphQL Schema Changes"
   time npm install
   echo "Fetching schema..."


### PR DESCRIPTION
Fix up the inconsistency in pull request statuses:

<img width="465" alt="screen shot 2017-02-02 at 3 44 30 pm" src="https://cloud.githubusercontent.com/assets/17565/22553977/d51baf3e-e95e-11e6-9d29-c523bf5390a0.png">

Why yes, I am _exactly_ this OCD.

![monk](http://www.americanenglishdoctor.com/IMAGES/Media/monk-show.jpg)