### PR TITLE
Test the schema as merged from `origin/master`

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -72,7 +72,7 @@ function checkForSchemaChanges {
 
     # Move the updated schema to a new branch created from master, commit, and push.
     git stash --all
-    git checkout --no-track -B ${SCHEMA_BRANCH_NAME} upstream/master
+    git checkout --no-track -B ${SCHEMA_BRANCH_NAME} origin/master
     git stash pop
 
     git config user.name "Travis CI"


### PR DESCRIPTION
Fetch and merge `origin/master` _before_ performing the schema freshness check, so the check won't create an update PR if it's already been updated on master or as part of this branch.

This will cause a failure if the branch doesn't merge cleanly, but the `pr` build will fail then, anyway, so I don't think that's a big deal. It'll prevent a failure I've seen a few times now where there's a merge conflict popping the new schema onto the new branch.