### PR TITLE
Use purple for "our" changes

### DIFF
--- a/styles/conflicting-editor.less
+++ b/styles/conflicting-editor.less
@@ -1,8 +1,8 @@
 @import "variables";
 
-@conflict-color-ours:     @syntax-color-removed;
+@conflict-color-ours:     spin(@syntax-color-renamed, 80); // usually magenta/purple-ish
 @conflict-color-theirs:   @syntax-color-renamed;
-@conflict-color-base:     desaturate( mix(@syntax-color-removed, @syntax-color-renamed), 50% );
+@conflict-color-base:     desaturate( @syntax-color-renamed, 100% );
 @conflict-color-modified: @syntax-color-modified;
 @conflict-color-resolved: @syntax-color-added;
 


### PR DESCRIPTION
This is a small follow up to #385.

Mainly changing the red to magenta/purple-ish so that it feels less like an "error". It's not a hard coded value, but instead it just spins the hue towards the magenta/purple region. Looks different in each theme but should keep a theme's characteristics:

One light | Ficus
--- | ---
![one-light](https://cloud.githubusercontent.com/assets/378023/23199758/c791282a-f913-11e6-8e88-d6b8688f1f9a.png) | ![ficus](https://cloud.githubusercontent.com/assets/378023/23199771/d78d0dd4-f913-11e6-9934-848eb1fc6967.png)

One dark | Atom Nord
--- | ---
![one-dark](https://cloud.githubusercontent.com/assets/378023/23199766/cde56e0c-f913-11e6-970c-2f1c3aa61e10.png) | ![nord-atom](https://cloud.githubusercontent.com/assets/378023/23199775/de63b39c-f913-11e6-8443-1c1525c91d1b.png)

The "base" changes are 100% desaturated.

/cc @smashwilson 