### PR TITLE
Move CommitView-editor styles to atom-text-editor

### DIFF
--- a/styles/commit-view.less
+++ b/styles/commit-view.less
@@ -5,20 +5,15 @@
   border-top: 1px solid @base-border-color;
   flex: 0 0 auto;
 
-  &-editor {
+  &-editor atom-text-editor {
     height: 100px;
+    font-size: @font-size;
     border: 1px solid @input-border-color;
     border-radius: @component-border-radius;
-    overflow: auto;
     padding: @component-padding / 2;
     background-color: @syntax-background-color;
-
-    atom-text-editor {
-      height: 100%;
-      font-size: @font-size;
-      .cursor-line {
-        background-color: transparent;
-      }
+    .cursor-line.cursor-line.cursor-line {
+      background-color: transparent;
     }
   }
 


### PR DESCRIPTION
So that themes can use the `.is-focused` selector.

![commit](https://cloud.githubusercontent.com/assets/378023/24068474/f6efc4ce-0bd2-11e7-8014-318663bbba1a.gif)

Depends on https://github.com/atom/one-light-ui/pull/95