### PR TITLE
Fix commit editor padding

### DIFF
--- a/styles/commit-view.less
+++ b/styles/commit-view.less
@@ -5,13 +5,17 @@
   border-top: 1px solid @base-border-color;
   flex: 0 0 auto;
 
-  &-editor atom-text-editor {
-    height: 100px;
-    font-size: @font-size;
+  &-editor {
+    position: relative;
     border: 1px solid @input-border-color;
     border-radius: @component-border-radius;
     padding: @component-padding / 2;
+    font-size: @font-size;
     background-color: @syntax-background-color;
+  }
+
+  &-editor atom-text-editor {
+    max-height: 100px;
     .cursor-line.cursor-line.cursor-line {
       background-color: transparent;
     }
@@ -45,5 +49,32 @@
 
     &.is-warning { color: @text-color-warning; }
     &.is-error   { color: @text-color-error; }
+  }
+}
+
+
+// Hacks ---------------------------------------------------
+// TODO: Unhack if possible
+
+
+// Fix focus styles
+// Since it's not possible to add a padding to <atom-text-editor>
+// a pseudo element is used to add the border when focused.
+
+.theme-one-dark-ui,
+.theme-one-light-ui {
+  .github-CommitView-editor atom-text-editor.is-focused {
+    box-shadow: none;
+    &:before {
+      content: "";
+      position: absolute;
+      top: -2px;
+      left: -2px;
+      right: -2px;
+      bottom: -2px;
+      border: 2px solid;
+      border-color: inherit;
+      border-radius: @component-border-radius;
+    }
   }
 }


### PR DESCRIPTION
This is a follow up to #615 that fixes the padding issue noticed by @BinaryMuse:

![cursor_and_staged_changes__lib_platform_objects_pull_request_rb_______github_github_com_360](https://cloud.githubusercontent.com/assets/378023/24387684/894b00dc-13b1-11e7-8b8a-626edecb2b6f.png)
