### PR TITLE
Disable commit.gpgsign in fixture repositories

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -31,6 +31,7 @@ export async function cloneRepository(repoName = 'three-files') {
     const git = new GitShellOutStrategy(cachedPath);
     await git.clone(path.join(__dirname, 'fixtures', `repo-${repoName}`, 'dot-git'), {noLocal: true});
     await git.exec(['config', '--local', 'core.autocrlf', 'false']);
+    await git.exec(['config', '--local', 'commit.gpgsign', 'false']);
     await git.exec(['checkout', '--', '.']); // discard \r in working directory
     cachedClonedRepos[repoName] = cachedPath;
   }
@@ -68,6 +69,7 @@ export async function setUpLocalAndRemoteRepositories(repoName = 'multiple-commi
   const localGit = new GitShellOutStrategy(localRepoPath);
   await localGit.clone(baseRepoPath, {noLocal: true});
   await localGit.exec(['remote', 'set-url', 'origin', remoteRepoPath]);
+  await localGit.exec(['config', '--local', 'commit.gpgsign', 'false']);
   return {baseRepoPath, remoteRepoPath, localRepoPath};
 }
 


### PR DESCRIPTION
If you have `commit.gpgsign` configured to "true" globally (like I do), some tests that use `repository.git.exec(['commit', ...])` directly to create commits in fixture repositories will fail with a 128. (Other tests will likely fail or produce a prompt if you don't have the default signing key unlocked in your GPG agent.) By explicitly configuring it to `false` for freshly cloned repositories, we'll override that setting and have a little more reliable local tests.

Note that the actual GPG server tests will be unaffected because they use stubs to simulate GPG signing rather than an actual GPG binary.