### PR TITLE
Autorefresh

### DIFF
--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -320,19 +320,23 @@ export default class Repository {
 
   async stageFiles(paths) {
     await this.git.stageFiles(paths);
+    this.refresh();
   }
 
   async unstageFiles(paths) {
     await this.git.unstageFiles(paths);
+    this.refresh();
   }
 
   async stageFilesFromParentCommit(paths) {
     await this.git.unstageFiles(paths, 'HEAD~');
+    this.refresh();
   }
 
   async applyPatchToIndex(filePatch) {
     const patchStr = filePatch.getHeaderString() + filePatch.toString();
     await this.git.applyPatch(patchStr, {index: true});
+    this.refresh();
   }
 
   async applyPatchToWorkdir(filePatch) {
@@ -561,5 +565,6 @@ export default class Repository {
       const absPath = path.join(this.getWorkingDirectoryPath(), filePath);
       return deleteFileOrFolder(absPath);
     }));
+    this.refresh();
   }
 }


### PR DESCRIPTION
Automatically refresh the Repository when we perform an operation that we _know_ is going to trigger a change, like staging or unstaging a file, rather than waiting for nsfw to report it back to us.

This will cause duplicate renderings, but the second rendering should be less noticeable because it will, in all likelihood, result in no DOM changes.

Fixes #560.