### PR TITLE
Remove timings view icon from status bar

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -119,6 +119,9 @@ export default class RootController extends React.Component {
   render() {
     return (
       <div>
+        <Commands registry={this.props.commandRegistry} target="atom-workspace">
+          <Command command="github:show-waterfall-diagnostics" callback={this.showWaterfallDiagnostics} />
+        </Commands>
         {this.renderStatusBarTile()}
         {this.renderGitHubPanel()}
         {(this.state.filePath && this.state.filePatch) ? this.renderFilePatchController() : null}
@@ -283,6 +286,11 @@ export default class RootController extends React.Component {
   @autobind
   initializeRepo() {
     this.props.createRepositoryForProjectPath(this.props.activeProjectPath);
+  }
+
+  @autobind
+  showWaterfallDiagnostics() {
+    this.props.workspace.open('atom-github://debug/timings');
   }
 
   @autobind

--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -126,6 +126,7 @@ export default class StatusBarTileController extends React.Component {
           trigger="click"
           className="github-StatusBarTileController-tooltipMenu">
           <PushPullMenuView
+            onMarkSpecialClick={this.handleOpenGitTimingsView}
             workspace={this.props.workspace}
             notificationManager={this.props.notificationManager}
             inProgress={this.state.inProgress}
@@ -139,16 +140,13 @@ export default class StatusBarTileController extends React.Component {
           didClick={this.props.toggleGitPanel}
           {...repoProps}
         />
-        <a style={{margin: '0 5px'}} onClick={this.handleOpenGitTimingsView}>
-          ⏰
-        </a>
       </div>
     );
   }
 
   @autobind
   handleOpenGitTimingsView(e) {
-    e.preventDefault();
+    e && e.preventDefault();
     this.props.workspace.open('atom-github://debug/timings');
   }
 

--- a/lib/views/push-pull-menu-view.js
+++ b/lib/views/push-pull-menu-view.js
@@ -13,6 +13,7 @@ export default class PushPullMenuView extends React.Component {
     aheadCount: PropTypes.number,
     behindCount: PropTypes.number,
     notificationManager: PropTypes.object,
+    onMarkSpecialClick: PropTypes.func,
     fetch: PropTypes.func,
     push: PropTypes.func,
     pull: PropTypes.func,
@@ -24,6 +25,7 @@ export default class PushPullMenuView extends React.Component {
       name: '',
       isDetached: false,
     },
+    onMarkSpecialClick: () => {},
   }
 
   constructor(props, context) {
@@ -67,7 +69,7 @@ export default class PushPullMenuView extends React.Component {
     return (
       <div className={'github-PushPullMenuView' + (this.props.inProgress ? ' in-progress' : '')}>
         <div className="github-PushPullMenuView-selector">
-          <span className="github-PushPullMenuView-item icon icon-mark-github" />
+          <span className="github-PushPullMenuView-item icon icon-mark-github" onClick={this.handleIconClick} />
           <button className="github-PushPullMenuView-item btn" onClick={this.fetch} disabled={fetchDisabled}>
             Fetch
           </button>
@@ -109,6 +111,13 @@ export default class PushPullMenuView extends React.Component {
     }
 
     return '';
+  }
+
+  @autobind
+  handleIconClick(evt) {
+    if (evt.shiftKey) {
+      this.props.onMarkSpecialClick();
+    }
   }
 
   async attemptGitOperation(operation, errorTransform = message => ({message})) {


### PR DESCRIPTION
This removes the ⏰  icon from the status bar. The waterfall timings view can now be accessed via the following ways:

1. Super-secret shift-click on the GitHub icon in the push/pull menu view (just to keep a mouse-oriented way of getting to it)
2. By activating the `github:show-waterfall-diagnostics` command