### PR TITLE
Require Atom >= 1.18.0 to install (to prevent accidental apm installs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "fetch-schema": "node script/fetch-schema"
   },
   "engines": {
-    "atom": ">=1.13.0"
+    "atom": ">=1.18.0"
   },
   "atomTestRunner": "./test/runner",
   "atomTranspilers": [


### PR DESCRIPTION
It's possible that when we ship, people who use stable will want to try it via `apm install github`. This sets the required version to 1.18.0 so that stable (1.17.0 at the time of ship) will not meet the version requirements (since the package will not work on 1.17 anyway, and so users don't mistakenly shadow the package).

Closes https://github.com/atom/github/issues/670