### PR TITLE
Fix bad repo name in GraphQL query for PR info

### DIFF
--- a/lib/controllers/pr-info-controller.js
+++ b/lib/controllers/pr-info-controller.js
@@ -40,7 +40,7 @@ export default class PrInfoController extends React.Component {
 
     const route = new PrInfoByBranchRoute({
       repoOwner: this.props.remote.getOwner(),
-      repoName: this.props.remote.getName(),
+      repoName: this.props.remote.getRepo(),
       branchName: this.props.currentBranchName,
     });
 


### PR DESCRIPTION
We want the name of the repo, not of the remote