### PR TITLE
Make `git status` parallelizable

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -283,7 +283,7 @@ export default class GitShellOutStrategy {
    * File Status and Diffs
    */
   async getStatusesForChangedFiles() {
-    const output = await this.exec(['status', '--untracked-files=all', '-z'], {writeOperation: true});
+    const output = await this.exec(['status', '--untracked-files=all', '-z']);
 
     const statusMap = {
       'A': 'added',
@@ -392,7 +392,7 @@ export default class GitShellOutStrategy {
 
   async isPartiallyStaged(filePath) {
     const args = ['status', '--short', '--', filePath];
-    const output = await this.exec(args, {writeOperation: true});
+    const output = await this.exec(args);
     const results = output.trim().split(LINE_ENDING_REGEX);
     if (results.length === 2) {
       return true;


### PR DESCRIPTION
So it turns out that while `status` attempts to lock the index in order to write to it (for caching/performance purposes), the command still completes successfully even if it can't. Therefore we don't have to worry about contention between status operations and can run them in parallel with other read and `status` operations.

Previously we had made an assumption that running `git status` while the index was locked would cause a fatal git error because we had observed this being the case when the reverse occurred, i.e. a command accessed the index while `git status` was running and had the index locked. 

The changes made in this PR will result in performance gains by running `status` in parallel with other read operations, cutting down shell out times by the amount of time it takes to run a `status` command and also saving us on the cost of splitting up read operations because of a `status` write operation.

Before:
<img width="642" alt="fullscreen_4_27_17__2_25_pm" src="https://cloud.githubusercontent.com/assets/7910250/25505188/86e6af56-2b55-11e7-8a6e-d61d8b0a1c8f.png">
☝️ Note that `status` is not run in parallel with surrounding read operations, which have been split up so that a write operation can occur

After: 
<img width="608" alt="fullscreen_4_27_17__2_30_pm" src="https://cloud.githubusercontent.com/assets/7910250/25505318/16acec0e-2b56-11e7-808d-3b3689d6d8e2.png">


