### PR TITLE
Only you can prevent flaky tests

### DIFF
--- a/test/models/workdir-context.test.js
+++ b/test/models/workdir-context.test.js
@@ -86,12 +86,11 @@ describe('WorkdirContext', function() {
     assert.isTrue(repo.isDestroyed());
   });
 
-  it.only('stops the change observer on destroy()', async function() {
-    const observer = context.getChangeObserver();
-    await observer.start();
+  it('stops the change observer on destroy()', async function() {
+    await context.getObserverStartedPromise();
 
     await context.destroy();
-    await assert.async.isFalse(observer.isStarted());
+    await assert.isFalse(context.getChangeObserver().isStarted());
   });
 
   it('can be destroyed twice', async function() {


### PR DESCRIPTION
Address sporadic failures in [this test](https://ci.appveyor.com/project/Atom/github/build/1117/job/c6u0cejtbq2mcqgc/tests) that occur when the filesystem observer is automatically started again during the `context.destroy()` call.

/cc @kuychaco 