### PR TITLE
Fix exception caused in `atom.inSpecMode()` returns undefined

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -97,7 +97,7 @@ export default class GitShellOutStrategy {
         env.ATOM_GITHUB_ORIGINAL_GIT_ASKPASS = process.env.GIT_ASKPASS || '';
         env.ATOM_GITHUB_ORIGINAL_SSH_ASKPASS = process.env.SSH_ASKPASS || '';
         env.ATOM_GITHUB_ORIGINAL_GIT_SSH_COMMAND = process.env.GIT_SSH_COMMAND || '';
-        env.ATOM_GITHUB_SPEC_MODE = atom.inSpecMode().toString();
+        env.ATOM_GITHUB_SPEC_MODE = atom.inSpecMode() ? 'true' : 'false';
 
         env.SSH_ASKPASS = normalizeGitHelperPath(askPass.launcher);
         env.GIT_ASKPASS = normalizeGitHelperPath(askPass.launcher);


### PR DESCRIPTION
Manifesting for @kuychaco and myself when we try to push:

```
/Users/mtilley/src/dotfiles/atom/packages/github/lib/git-shell-out-strategy.js:144 Uncaught (in promise) TypeError: Cannot read property 'toString' of undefined
```

/cc @smashwilson 