### PR TITLE
Defer updates based on filesystem events when Atom is in the background

### DIFF
--- a/lib/deferred-callback-queue.js
+++ b/lib/deferred-callback-queue.js
@@ -4,7 +4,6 @@ import {autobind} from 'core-decorators';
 
 export default class DeferredCallbackQueue {
   constructor(wait, callback, options = {}) {
-    console.log('create DeferredCallbackQueue');
     this.wait = wait;
     const currentWindow = remote.getCurrentWindow();
 
@@ -32,13 +31,13 @@ export default class DeferredCallbackQueue {
   @autobind
   pause() {
     if (this.paused) { return; }
-    console.log('paused');
     this.paused = true;
   }
 
   @autobind
   resume() {
     if (!this.paused) { return; }
+    console.log('resume');
     this.paused = false;
     if (this.timer) {
       clearTimeout(this.timer);

--- a/lib/deferred-callback-queue.js
+++ b/lib/deferred-callback-queue.js
@@ -4,6 +4,7 @@ import {autobind} from 'core-decorators';
 
 export default class DeferredCallbackQueue {
   constructor(wait, callback, options = {}) {
+    console.log('create DeferredCallbackQueue');
     this.wait = wait;
     const currentWindow = remote.getCurrentWindow();
 
@@ -12,6 +13,9 @@ export default class DeferredCallbackQueue {
       return new Disposable(() => currentWindow.removeListener('focus', cb));
     };
     const onDidBlur = options.onDidBlur || function(cb) {
+      if (atom.inSpecMode()) {
+        return new Disposable();
+      }
       currentWindow.on('blur', cb);
       return new Disposable(() => currentWindow.removeListener('blur', cb));
     };
@@ -20,7 +24,7 @@ export default class DeferredCallbackQueue {
     this.subscriptions = new CompositeDisposable();
     this.items = new Set();
 
-    this.paused = !currentWindow.isFocused();
+    this.paused = !currentWindow.isFocused() || !atom.inSpecMode();
     this.subscriptions.add(onDidFocus(this.resume));
     this.subscriptions.add(onDidBlur(this.pause));
   }
@@ -28,6 +32,7 @@ export default class DeferredCallbackQueue {
   @autobind
   pause() {
     if (this.paused) { return; }
+    console.log('paused');
     this.paused = true;
   }
 
@@ -50,6 +55,7 @@ export default class DeferredCallbackQueue {
 
   @autobind
   flush() {
+    console.warn('FLUSH');
     delete this.timer;
     if (this.items.size) {
       this.callback([...this.items]);

--- a/lib/deferred-callback-queue.js
+++ b/lib/deferred-callback-queue.js
@@ -37,7 +37,6 @@ export default class DeferredCallbackQueue {
   @autobind
   resume() {
     if (!this.paused) { return; }
-    console.log('resume');
     this.paused = false;
     if (this.timer) {
       clearTimeout(this.timer);
@@ -54,7 +53,6 @@ export default class DeferredCallbackQueue {
 
   @autobind
   flush() {
-    console.warn('FLUSH');
     delete this.timer;
     if (this.items.size) {
       this.callback([...this.items]);

--- a/lib/deferred-callback-queue.js
+++ b/lib/deferred-callback-queue.js
@@ -23,7 +23,7 @@ export default class DeferredCallbackQueue {
     this.subscriptions = new CompositeDisposable();
     this.items = new Set();
 
-    this.paused = !currentWindow.isFocused() || !atom.inSpecMode();
+    this.paused = !currentWindow.isFocused() && !atom.inSpecMode();
     this.subscriptions.add(onDidFocus(this.resume));
     this.subscriptions.add(onDidBlur(this.pause));
   }

--- a/lib/deferred-callback-queue.js
+++ b/lib/deferred-callback-queue.js
@@ -1,0 +1,72 @@
+import {remote} from 'electron';
+import {CompositeDisposable, Disposable} from 'event-kit';
+import {autobind} from 'core-decorators';
+
+export default class DeferredCallbackQueue {
+  constructor(wait, callback, options = {}) {
+    this.wait = wait;
+    const currentWindow = remote.getCurrentWindow();
+
+    const onDidFocus = options.onDidFocus || function(cb) {
+      currentWindow.on('focus', cb);
+      return new Disposable(() => currentWindow.removeListener('focus', cb));
+    };
+    const onDidBlur = options.onDidBlur || function(cb) {
+      currentWindow.on('blur', cb);
+      return new Disposable(() => currentWindow.removeListener('blur', cb));
+    };
+
+    this.callback = callback;
+    this.subscriptions = new CompositeDisposable();
+    this.items = new Set();
+
+    this.paused = !currentWindow.isFocused();
+    this.subscriptions.add(onDidFocus(this.resume));
+    this.subscriptions.add(onDidBlur(this.pause));
+  }
+
+  @autobind
+  pause() {
+    if (this.paused) { return; }
+    this.paused = true;
+  }
+
+  @autobind
+  resume() {
+    if (!this.paused) { return; }
+    this.paused = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    this.flush();
+  }
+
+  resetTimer() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    this.timer = setTimeout(this.flush, this.wait);
+  }
+
+  @autobind
+  flush() {
+    delete this.timer;
+    if (this.items.size) {
+      this.callback([...this.items]);
+      this.items.clear();
+    }
+  }
+
+  push(...items) {
+    if (this.paused) {
+      items.forEach(item => this.items.add(item));
+      this.resetTimer();
+    } else {
+      this.callback(items);
+    }
+  }
+
+  destroy() {
+    this.subscriptions.dispose();
+  }
+}

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -523,7 +523,7 @@ export default class GitShellOutStrategy {
 
       // Detached HEAD
       return {
-        name: (await this.exec(['describe', '--contains', '--all', 'HEAD'])).trim(),
+        name: (await this.exec(['describe', '--contains', '--all', '--always', 'HEAD'])).trim(),
         isDetached: true,
       };
     }

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -69,12 +69,10 @@ export default class Present extends State {
     this.didUpdate();
   }
 
-  observeFilesystemChange(events) {
+  observeFilesystemChange(paths) {
     const keys = new Set();
-    for (let i = 0; i < events.length; i++) {
-      const event = events[i];
-
-      const fullPath = path.join(event.directory, event.file || event.newFile);
+    for (let i = 0; i < paths.length; i++) {
+      const fullPath = paths[i];
 
       const endsWith = (...segments) => fullPath.endsWith(path.join(...segments));
       const includes = (...segments) => fullPath.includes(path.join(...segments));

--- a/lib/models/workdir-context.js
+++ b/lib/models/workdir-context.js
@@ -1,8 +1,9 @@
 import path from 'path';
 
-import {Emitter, CompositeDisposable} from 'event-kit';
+import {Emitter, CompositeDisposable, Disposable} from 'event-kit';
 import {autobind} from 'core-decorators';
 
+import DeferredCallbackQueue from '../deferred-callback-queue';
 import Repository from './repository';
 import ResolutionProgress from './conflicts/resolution-progress';
 import FileSystemChangeObserver from './file-system-change-observer';
@@ -40,6 +41,9 @@ export default class WorkdirContext {
       ? new WorkspaceChangeObserver(theWindow, workspace, this.repository)
       : new FileSystemChangeObserver(this.repository);
     this.resolutionProgress = new ResolutionProgress();
+    this.deferredCallbackQueue = new DeferredCallbackQueue(3000, collection => {
+      this.repository.observeFilesystemChange(collection);
+    });
 
     if (promptCallback) {
       this.repository.setPromptCallback(promptCallback);
@@ -49,9 +53,10 @@ export default class WorkdirContext {
     this.subs.add(this.repository.onDidChangeState(this.repositoryChangedState));
     this.subs.add(this.observer.onDidChange(events => {
       const paths = events.map(e => path.join(e.directory, e.file || e.newFile));
-      this.repository.observeFilesystemChange(paths);
+      this.deferredCallbackQueue.push(...paths);
     }));
     this.subs.add(this.observer.onDidChangeWorkdirOrHead(() => this.emitter.emit('did-change-workdir-or-head')));
+    this.subs.add(new Disposable(() => this.deferredCallbackQueue.destroy()));
 
     // If a pre-loaded Repository was provided, broadcast an initial state change event.
     this.repositoryChangedState({from: null, to: this.repository.state});

--- a/lib/models/workdir-context.js
+++ b/lib/models/workdir-context.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import {Emitter, CompositeDisposable} from 'event-kit';
 import {autobind} from 'core-decorators';
 
@@ -45,7 +47,10 @@ export default class WorkdirContext {
 
     // Wire up event forwarding among models
     this.subs.add(this.repository.onDidChangeState(this.repositoryChangedState));
-    this.subs.add(this.observer.onDidChange(payload => this.repository.observeFilesystemChange(payload)));
+    this.subs.add(this.observer.onDidChange(events => {
+      const paths = events.map(e => path.join(e.directory, e.file || e.newFile));
+      this.repository.observeFilesystemChange(paths);
+    }));
     this.subs.add(this.observer.onDidChangeWorkdirOrHead(() => this.emitter.emit('did-change-workdir-or-head')));
 
     // If a pre-loaded Repository was provided, broadcast an initial state change event.

--- a/test/deferred-callback-queue.test.js
+++ b/test/deferred-callback-queue.test.js
@@ -1,0 +1,54 @@
+import DeferredCallbackQueue from '../lib/deferred-callback-queue';
+import {Emitter} from 'event-kit';
+
+describe('DeferredCallbackQueue', function() {
+  let callbackSpy, emitter, queue;
+  beforeEach(() => {
+    callbackSpy = sinon.spy();
+    emitter = new Emitter();
+    queue = new DeferredCallbackQueue(20, callbackSpy, {
+      onDidFocus: cb => {
+        return emitter.on('focus', cb);
+      },
+      onDidBlur: cb => {
+        return emitter.on('blur', cb);
+      },
+    });
+  });
+
+  describe('when focused', function() {
+    it('calls the specified callback immediately', function() {
+      emitter.emit('focus');
+      queue.push('a', 'b', 'c');
+      assert.deepEqual(callbackSpy.args[0][0], ['a', 'b', 'c']);
+    });
+  });
+
+  describe('when blurred', function() {
+    it('calls the specified callback after a specified quiet time', async function() {
+      emitter.emit('blur');
+      queue.push(1);
+      await new Promise(res => setTimeout(res, 10));
+      queue.push(2);
+      await new Promise(res => setTimeout(res, 10));
+      queue.push(3);
+      await new Promise(res => setTimeout(res, 10));
+      assert.isFalse(callbackSpy.called);
+      await new Promise(res => setTimeout(res, 20));
+      assert.deepEqual(callbackSpy.args[0][0], [1, 2, 3]);
+    });
+
+    it('calls the specified callback immediately when focus is regained', async function() {
+      emitter.emit('blur');
+      queue.push(4);
+      await new Promise(res => setTimeout(res, 10));
+      queue.push(5);
+      await new Promise(res => setTimeout(res, 10));
+      queue.push(6);
+      await new Promise(res => setTimeout(res, 10));
+      assert.isFalse(callbackSpy.called);
+      emitter.emit('focus');
+      assert.deepEqual(callbackSpy.args[0][0], [4, 5, 6]);
+    });
+  });
+});

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1263,7 +1263,8 @@ describe('Repository', function() {
         );
 
         sub.add(observer.onDidChange(events => {
-          repository.observeFilesystemChange(events);
+          const paths = events.map(e => path.join(e.directory, e.file || e.newFile));
+          repository.observeFilesystemChange(paths);
           observedEvents.push(...events);
           eventCallback();
         }));

--- a/test/models/workdir-context.test.js
+++ b/test/models/workdir-context.test.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import {CompositeDisposable, Disposable} from 'event-kit';
 
 import {cloneRepository} from '../helpers';
@@ -62,10 +64,9 @@ describe('WorkdirContext', function() {
 
     sinon.spy(repo, 'observeFilesystemChange');
 
-    const payload = {};
-    context.getChangeObserver().didChange(payload);
+    context.getChangeObserver().didChange([{directory: '/a/b', file: 'c'}]);
 
-    assert.isTrue(repo.observeFilesystemChange.calledWith(payload));
+    assert.isTrue(repo.observeFilesystemChange.calledWith([path.join('/a/b', 'c')]));
   });
 
   it('re-emits an event on workdir or head change', async function() {


### PR DESCRIPTION
Fixes #569.
Fixes #348.

We were seeing issues with lock contention when interacting with git on the command line for a repo that was open in Atom. This is because when Atom detects changes to the repo, it updates all of its git data by shelling out and running `git status`. `status` locks the index while performing caching, thus preventing command line git commands from running successfully and resulting in errors such as `Another git process seems to be running in this repository`.

This PR implements DeferredCallbackQueue which tracks whether the window is focused or blurred and pauses updates accordingly. When blurred, update events are stored off in a queue and processed after a specified quiet time (currently set to 3 seconds) to reduce contention. The idea is that Atom will wait until the users activity has died down before it tries to perform its update. If the application is focused before the wait period ends, the update is triggered immediately upon focus. 

