### PR TITLE
Adjust diff colors

### DIFF
--- a/styles/hunk-view.less
+++ b/styles/hunk-view.less
@@ -59,7 +59,7 @@
 
   &-plusMinus {
     margin-right: 1ch;
-    color: fade(@text-color, 33%);
+    color: fade(@text-color, 50%);
   }
 
   &-lineContent {
@@ -89,13 +89,13 @@
       background-color: @background-color-highlight;
     }
     .github-HunkView-lineContent {
-      color: mix(@fg, @text-color-highlight, 50%);
-      background-color: mix(@bg, @hunk-bg-color, 12%);
+      color: saturate( mix(@fg, @text-color-highlight, 20%), 20%);
+      background-color: saturate( mix(@bg, @hunk-bg-color, 15%), 20%);
     }
     // hightlight when focused + selected
     .github-FilePatchView:focus &.is-selected .github-HunkView-lineContent  {
-      color: mix(@fg, @text-color-highlight, 30%);
-      background-color: mix(@bg, @hunk-bg-color, 24%);
+      color: saturate( mix(@fg, @text-color-highlight, 10%), 10%);
+      background-color: saturate( mix(@bg, @hunk-bg-color, 25%), 10%);
     }
   }
 
@@ -106,6 +106,12 @@
   &.is-added {
     .hunk-line-mixin(@text-color-success, @background-color-success);
   }
+
+  // divider line between added and deleted lines
+  &.is-deleted + .is-added .github-HunkView-lineContent {
+    box-shadow: 0 -1px 0 hsla(0,0%,50%,.1);
+  }
+
 }
 
 // focus colors


### PR DESCRIPTION
### Description of the Change

This makes the diff background a bit more saturated and the text has more contrast.

Before | After
--- | ---
![screen shot 2017-05-04 at 2 00 41 pm](https://cloud.githubusercontent.com/assets/378023/25691036/1c758aa2-30d2-11e7-8510-83e93ef7b371.png) | ![screen shot 2017-05-04 at 2 00 10 pm](https://cloud.githubusercontent.com/assets/378023/25691037/1c762a20-30d2-11e7-9119-a8617f5d0c5a.png)

### Alternate Designs

Was also considering not to differentiate between selected and un-selected lines. But since you can drag on the code (and not just the line numbers), it's good to keep the two different states.

![diff-selection](https://cloud.githubusercontent.com/assets/378023/25691132/120d9964-30d3-11e7-9939-939995a9d925.gif)


### Benefits

Easier to tell additions/deletions apart.

### Possible Drawbacks

Doesn't work the same in every theme. Solarized dark still has a weak red.

### Applicable Issues

None
