### PR TITLE
Remove PrInfoController#shouldComponentUpdate

### DIFF
--- a/lib/controllers/pr-info-controller.js
+++ b/lib/controllers/pr-info-controller.js
@@ -27,16 +27,6 @@ export default class PrInfoController extends React.Component {
     onUnpinPr: PropTypes.func.isRequired,
   }
 
-  shouldComponentUpdate(nextProps) {
-    return (
-      nextProps.token !== this.props.token ||
-      nextProps.host !== this.props.host ||
-      nextProps.currentBranchName !== this.props.currentBranchName ||
-      nextProps.onLogin !== this.props.onLogin ||
-      nextProps.remote !== this.props.remote
-    );
-  }
-
   render() {
     if (this.props.token === UNAUTHENTICATED) {
       return null;


### PR DESCRIPTION
Since resizing the dock no longer causes the entire component tree to re-render, this is no longer necessary.

Fixes #743 