### PR TITLE
Warn when running package in normal mode

### DIFF
--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -117,6 +117,21 @@ export default class GithubPackage {
   }
 
   activate(state = {}) {
+    setTimeout(() => {
+      if (!(atom.inDevMode() || atom.inSpecMode()) && !atom.packages.getActivePackage('github').bundledPackage) {
+        atom.notifications.addWarning(
+          'The GitHub package will be bundled soon!',
+          {
+            description: 'Starting in Atom 1.18-beta, the GitHub package will be bundled with Atom. ' +
+              'However, you have the GitHub package installed separately, so your installed version ' +
+              'will supercede the built-in package. You should uninstall your local copy of the GitHub package ' +
+              'once Atom 1.18 is released.',
+            dismissable: true,
+          },
+        );
+      }
+    }, 1000);
+
     this.savedState = {...defaultState, ...state};
 
     if (!this.workspace.getLeftDock || this.config.get('github.useLegacyPanels')) {


### PR DESCRIPTION
@kuychaco @smashwilson Curious what you think of this — just an additional warning that we can remove just before ship so people running the GitHub package in normal mode will get a little warning letting them know that they should uninstall it soon.

<img width="514" alt="cursor_and_package_coffee_ ___github_atom" src="https://cloud.githubusercontent.com/assets/189606/25778887/9a511460-330b-11e7-930e-a2e088b6fcc1.png">

Just before we release, we can remove this and rely on the less-obtrusive warning from `dalek` to warn users if they are shadowing the bundled package.