### PR TITLE
Create absentWorkdirContext lazily

### DIFF
--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -8,7 +8,7 @@ import {autobind} from 'core-decorators';
 
 import {mkdirs} from './helpers';
 import WorkdirCache from './models/workdir-cache';
-import WorkdirContext, {absentWorkdirContext} from './models/workdir-context';
+import WorkdirContext from './models/workdir-context';
 import WorkdirContextPool from './models/workdir-context-pool';
 import Repository from './models/repository';
 import StyleCalculator from './models/style-calculator';
@@ -67,7 +67,7 @@ export default class GithubPackage {
       }),
       this.contextPool.onDidDestroyRepository(context => {
         if (context === this.activeContext) {
-          this.setActiveContext(absentWorkdirContext);
+          this.setActiveContext(WorkdirContext.absent());
         }
       }),
     );
@@ -353,7 +353,7 @@ export default class GithubPackage {
 
     if (this.project.getPaths().length === 0 && !this.activeContext.getRepository().isUndetermined()) {
       // No projects. Revert to the absent context unless we've guessed that more projects are on the way.
-      return absentWorkdirContext;
+      return WorkdirContext.absent();
     }
 
     // Restore models from saved state. Will return a NullWorkdirContext if this path is not presently

--- a/lib/models/workdir-context-pool.js
+++ b/lib/models/workdir-context-pool.js
@@ -1,7 +1,7 @@
 import compareSets from 'compare-sets';
 
 import {Emitter, CompositeDisposable} from 'event-kit';
-import WorkdirContext, {absentWorkdirContext} from './workdir-context';
+import WorkdirContext from './workdir-context';
 
 /**
  * Manage a WorkdirContext for each open directory.
@@ -26,7 +26,7 @@ export default class WorkdirContextPool {
    * Access the context mapped to a known directory.
    */
   getContext(directory) {
-    return this.contexts.get(directory) || absentWorkdirContext;
+    return this.contexts.get(directory) || WorkdirContext.absent();
   }
 
   add(directory, options = {}) {

--- a/lib/models/workdir-context.js
+++ b/lib/models/workdir-context.js
@@ -8,6 +8,8 @@ import WorkspaceChangeObserver from './workspace-change-observer';
 
 const createRepoSym = Symbol('createRepo');
 
+let absentWorkdirContext;
+
 /*
  * Bundle of model objects associated with a git working directory.
  *
@@ -50,6 +52,13 @@ export default class WorkdirContext {
 
     // If a pre-loaded Repository was provided, broadcast an initial state change event.
     this.repositoryChangedState({from: null, to: this.repository.state});
+  }
+
+  static absent() {
+    if (!absentWorkdirContext) {
+      absentWorkdirContext = new AbsentWorkdirContext();
+    }
+    return absentWorkdirContext;
   }
 
   static guess(options) {
@@ -188,5 +197,3 @@ class AbsentWorkdirContext extends WorkdirContext {
     return false;
   }
 }
-
-export const absentWorkdirContext = new AbsentWorkdirContext();

--- a/test/models/workdir-context.test.js
+++ b/test/models/workdir-context.test.js
@@ -2,7 +2,7 @@ import {CompositeDisposable, Disposable} from 'event-kit';
 
 import {cloneRepository} from '../helpers';
 
-import WorkdirContext, {absentWorkdirContext} from '../../lib/models/workdir-context';
+import WorkdirContext from '../../lib/models/workdir-context';
 
 describe('WorkdirContext', function() {
   let context, workingDirectory, subs;
@@ -104,7 +104,7 @@ describe('WorkdirContext', function() {
   });
 
   it('exports a singleton containing a Repository in the absent state', function() {
-    assert.isTrue(absentWorkdirContext.getRepository().isAbsent());
+    assert.isTrue(WorkdirContext.absent().getRepository().isAbsent());
   });
 
   it('can be constructed containing an undetermined Repository that acts absent', function() {


### PR DESCRIPTION
Previously, the `absentWorkdirContext` singleton was being created eagerly during require time. This breaks bundling because that code path creates a `CompositeGitStrategy` which needs to require `os` (but `require` isn't available during the snapshotting phase).

@smashwilson I'm going to merge this so I can bump and continue the snapshotting work but feel free to suggest a different mechanism for handling this.