### PR TITLE
Report failed commits as Atom notifications

### DIFF
--- a/lib/controllers/commit-view-controller.js
+++ b/lib/controllers/commit-view-controller.js
@@ -61,10 +61,17 @@ export default class CommitViewController {
 
   @autobind
   async commit(message) {
-    await this.props.commit(message);
-    this.regularCommitMessage = '';
-    this.amendingCommitMessage = '';
-    etch.update(this);
+    try {
+      await this.props.commit(message);
+      this.regularCommitMessage = '';
+      this.amendingCommitMessage = '';
+      etch.update(this);
+    } catch (e) {
+      this.props.notificationManager.addError('Unable to commit', {
+        dismissable: true,
+        description: `<pre>${e.stdErr}</pre>`,
+      });
+    }
   }
 
   getCommitMessage() {

--- a/lib/controllers/commit-view-controller.js
+++ b/lib/controllers/commit-view-controller.js
@@ -69,7 +69,7 @@ export default class CommitViewController {
     } catch (e) {
       this.props.notificationManager.addError('Unable to commit', {
         dismissable: true,
-        description: `<pre>${e.stdErr}</pre>`,
+        description: `<pre>${e.stdErr || e.stack}</pre>`,
       });
     }
   }

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -266,7 +266,7 @@ export default class GitTabController {
           {dismissable: true},
         );
       } else {
-        console.error(e); // eslint-disable-line no-console
+        throw e;
       }
     }
   }

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -95,6 +95,7 @@ export default class GitTabView {
             abortMerge={this.props.abortMerge}
             branchName={this.props.branchName}
             commandRegistry={this.props.commandRegistry}
+            notificationManager={this.props.notificationManager}
             mergeMessage={this.props.mergeMessage}
             isMerging={this.props.isMerging}
             isAmending={this.props.isAmending}

--- a/test/controllers/commit-view-controller.test.js
+++ b/test/controllers/commit-view-controller.test.js
@@ -5,10 +5,12 @@ import {cloneRepository, buildRepository} from '../helpers';
 
 describe('CommitViewController', function() {
   let atomEnvironment, commandRegistry, lastCommit;
+  let atomEnvironment, commandRegistry, notificationManager, lastCommit;
 
   beforeEach(function() {
     atomEnvironment = global.buildAtomEnvironment();
     commandRegistry = atomEnvironment.commands;
+    notificationManager = atomEnvironment.notifications;
 
     lastCommit = new Commit('a1e23fd45', 'last commit message');
   });
@@ -22,7 +24,9 @@ describe('CommitViewController', function() {
     const repository1 = await buildRepository(workdirPath1);
     const workdirPath2 = await cloneRepository('three-files');
     const repository2 = await buildRepository(workdirPath2);
-    const controller = new CommitViewController({commandRegistry, lastCommit, repository: repository1});
+    const controller = new CommitViewController({
+      commandRegistry, notificationManager, lastCommit, repository: repository1,
+    });
 
     assert.equal(controller.regularCommitMessage, '');
     assert.equal(controller.amendingCommitMessage, '');
@@ -44,7 +48,7 @@ describe('CommitViewController', function() {
     beforeEach(async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
-      controller = new CommitViewController({commandRegistry, lastCommit, repository});
+      controller = new CommitViewController({commandRegistry, notificationManager, lastCommit, repository});
       commitView = controller.refs.commitView;
     });
 
@@ -80,6 +84,51 @@ describe('CommitViewController', function() {
         await controller.update({mergeMessage: 'merge conflict!'});
         assert.equal(commitView.props.message, 'regular commit message');
       });
+    });
+  });
+
+  describe('committing', function() {
+    let controller, resolve, reject;
+
+    beforeEach(async function() {
+      const workdirPath = await cloneRepository('three-files');
+      const repository = await buildRepository(workdirPath);
+      const commit = () => new Promise((resolver, rejecter) => {
+        resolve = resolver;
+        reject = rejecter;
+      });
+
+      controller = new CommitViewController({commandRegistry, notificationManager, lastCommit, repository, commit});
+    });
+
+    it('clears the regular and amending commit messages', async function() {
+      controller.regularCommitMessage = 'regular';
+      controller.amendingCommitMessage = 'amending';
+
+      const promise = controller.commit('message');
+      resolve();
+      await promise;
+
+      assert.equal(controller.regularCommitMessage, '');
+      assert.equal(controller.amendingCommitMessage, '');
+    });
+
+    it('issues a notification on failure', async function() {
+      controller.regularCommitMessage = 'regular';
+      controller.amendingCommitMessage = 'amending';
+
+      sinon.spy(notificationManager, 'addError');
+
+      const promise = controller.commit('message');
+      const e = new Error('message');
+      e.stdErr = 'stderr';
+      reject(e);
+      await promise;
+
+      assert.isTrue(notificationManager.addError.called);
+
+      assert.equal(controller.regularCommitMessage, 'regular');
+      assert.equal(controller.amendingCommitMessage, 'amending');
     });
   });
 });

--- a/test/controllers/commit-view-controller.test.js
+++ b/test/controllers/commit-view-controller.test.js
@@ -4,7 +4,6 @@ import CommitViewController from '../../lib/controllers/commit-view-controller';
 import {cloneRepository, buildRepository} from '../helpers';
 
 describe('CommitViewController', function() {
-  let atomEnvironment, commandRegistry, lastCommit;
   let atomEnvironment, commandRegistry, notificationManager, lastCommit;
 
   beforeEach(function() {


### PR DESCRIPTION
Create an Atom notification for failed commits, including the contents of the git process' stderr. Preserve the commit message as well.

<img width="524" alt="screen shot 2017-05-08 at 2 46 18 pm" src="https://cloud.githubusercontent.com/assets/17565/25819992/ba6712ac-33fd-11e7-9041-41e481d6427d.png">

Fixes #737 and #495.