### PR TITLE
Consistently use native filepath separators on Windows

### DIFF
--- a/lib/deferred-callback-queue.js
+++ b/lib/deferred-callback-queue.js
@@ -2,14 +2,6 @@ import {remote} from 'electron';
 import {CompositeDisposable, Disposable} from 'event-kit';
 import {autobind} from 'core-decorators';
 
-import fs from 'fs-extra';
-const file = '/tmp/disposable.log';
-
-let focusListeners = 0;
-let blurListeners = 0;
-const log = msg => {
-  fs.appendFileSync(file, msg + '\n', 'utf8');
-};
 export default class DeferredCallbackQueue {
   constructor(wait, callback, options = {}) {
     this.wait = wait;
@@ -17,13 +9,7 @@ export default class DeferredCallbackQueue {
 
     const onDidFocus = options.onDidFocus || function(cb) {
       currentWindow.on('focus', cb);
-      focusListeners += 1;
-      log('adding focus listeners, now at ' + focusListeners);
-      log('focus listener count is ' + currentWindow.listenerCount('focus'));
       return new Disposable(() => {
-        focusListeners -= 1;
-        log('removing focus listeners, now at ' + focusListeners);
-        log('focus listener count is ' + currentWindow.listenerCount('focus'));
         currentWindow.removeListener('focus', cb);
       });
     };
@@ -32,13 +18,7 @@ export default class DeferredCallbackQueue {
         return new Disposable();
       }
       currentWindow.on('blur', cb);
-      blurListeners += 1;
-      log('adding blur listeners, now at ' + blurListeners);
-      log('blur listener count is ' + currentWindow.listenerCount('blur'));
       return new Disposable(() => {
-        blurListeners -= 1;
-        log('removing blur listeners, now at ' + blurListeners);
-        log('blur listener count is ' + currentWindow.listenerCount('blur'));
         currentWindow.removeListener('blur', cb);
       });
     };

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -290,13 +290,13 @@ export default class GitShellOutStrategy {
    */
   stageFiles(paths) {
     if (paths.length === 0) { return Promise.resolve(null); }
-    const args = ['add'].concat(paths);
+    const args = ['add'].concat(paths.map(toGitPathSep));
     return this.exec(args, {writeOperation: true});
   }
 
   unstageFiles(paths, commit = 'HEAD') {
     if (paths.length === 0) { return Promise.resolve(null); }
-    const args = ['reset', commit, '--'].concat(paths);
+    const args = ['reset', commit, '--'].concat(paths.map(toGitPathSep));
     return this.exec(args, {writeOperation: true});
   }
 
@@ -339,7 +339,7 @@ export default class GitShellOutStrategy {
         const line = lines[i];
         if (line === '') { continue; }
         const [_, x, y, rawFilePath] = line.match(/(.)(.)\s(.*)/); // eslint-disable-line no-unused-vars
-        const filePath = normalizePathSeparators(rawFilePath);
+        const filePath = toNativePathSep(rawFilePath);
         if (x === 'U' || y === 'U' || (x === 'A' && y === 'A')) {
           // Skipping this check here because we only run a single `await`
           // and we only run it in the main, synchronous body of the for loop.
@@ -388,7 +388,8 @@ export default class GitShellOutStrategy {
 
     const fileStatuses = {};
     output && output.trim().split(LINE_ENDING_REGEX).forEach(line => {
-      const [status, filePath] = line.split('\t');
+      const [status, rawFilePath] = line.split('\t');
+      const filePath = toNativePathSep(rawFilePath);
       fileStatuses[filePath] = statusMap[status];
     });
     if (!options.staged) {
@@ -401,14 +402,14 @@ export default class GitShellOutStrategy {
   async getUntrackedFiles() {
     const output = await this.exec(['ls-files', '--others', '--exclude-standard']);
     if (output.trim() === '') { return []; }
-    return output.trim().split(LINE_ENDING_REGEX);
+    return output.trim().split(LINE_ENDING_REGEX).map(toNativePathSep);
   }
 
   async getDiffForFilePath(filePath, {staged, baseCommit} = {}) {
     let args = ['diff', '--no-prefix', '--no-renames', '--diff-filter=u'];
     if (staged) { args.push('--staged'); }
     if (baseCommit) { args.push(baseCommit); }
-    args = args.concat(['--', filePath]);
+    args = args.concat(['--', toGitPathSep(filePath)]);
     const output = await this.exec(args);
 
     let rawDiffs = [];
@@ -426,7 +427,7 @@ export default class GitShellOutStrategy {
   }
 
   async isPartiallyStaged(filePath) {
-    const args = ['status', '--short', '--', filePath];
+    const args = ['status', '--short', '--', toGitPathSep(filePath)];
     const output = await this.exec(args);
     const results = output.trim().split(LINE_ENDING_REGEX);
     if (results.length === 2) {
@@ -462,7 +463,7 @@ export default class GitShellOutStrategy {
   }
 
   readFileFromIndex(filePath) {
-    return this.exec(['show', `:${filePath}`]);
+    return this.exec(['show', `:${toGitPathSep(filePath)}`]);
   }
 
   /**
@@ -490,7 +491,7 @@ export default class GitShellOutStrategy {
       return Promise.resolve();
     }
 
-    return this.exec(['checkout', `--${side}`, ...paths]);
+    return this.exec(['checkout', `--${side}`, ...paths.map(toGitPathSep)]);
   }
 
   /**
@@ -585,7 +586,7 @@ export default class GitShellOutStrategy {
     if (paths.length === 0) { return null; }
     const args = ['checkout'];
     if (revision) { args.push(revision); }
-    return this.exec(args.concat('--', paths), {writeOperation: true});
+    return this.exec(args.concat('--', paths.map(toGitPathSep)), {writeOperation: true});
   }
 
   async getBranches() {
@@ -697,16 +698,17 @@ export default class GitShellOutStrategy {
   }
 
   async writeMergeConflictToIndex(filePath, commonBaseSha, oursSha, theirsSha) {
+    const gitFilePath = toGitPathSep(filePath);
     const fileMode = await this.getFileMode(filePath);
-    let indexInfo = `0 0000000000000000000000000000000000000000\t${filePath}\n`;
-    if (commonBaseSha) { indexInfo += `${fileMode} ${commonBaseSha} 1\t${filePath}\n`; }
-    if (oursSha) { indexInfo += `${fileMode} ${oursSha} 2\t${filePath}\n`; }
-    if (theirsSha) { indexInfo += `${fileMode} ${theirsSha} 3\t${filePath}\n`; }
+    let indexInfo = `0 0000000000000000000000000000000000000000\t${gitFilePath}\n`;
+    if (commonBaseSha) { indexInfo += `${fileMode} ${commonBaseSha} 1\t${gitFilePath}\n`; }
+    if (oursSha) { indexInfo += `${fileMode} ${oursSha} 2\t${gitFilePath}\n`; }
+    if (theirsSha) { indexInfo += `${fileMode} ${theirsSha} 3\t${gitFilePath}\n`; }
     return this.exec(['update-index', '--index-info'], {stdin: indexInfo, writeOperation: true});
   }
 
   async getFileMode(filePath) {
-    const output = await this.exec(['ls-files', '--stage', '--', filePath]);
+    const output = await this.exec(['ls-files', '--stage', '--', toGitPathSep(filePath)]);
     if (output) {
       return output.slice(0, 6);
     } else {
@@ -737,7 +739,7 @@ function buildAddedFilePatch(filePath, contents, executable) {
   }
   return {
     oldPath: null,
-    newPath: filePath,
+    newPath: toNativePathSep(filePath),
     oldMode: null,
     newMode: executable ? '100755' : '100644',
     status: 'added',
@@ -749,10 +751,18 @@ function buildAddedFilePatch(filePath, contents, executable) {
  * On Windows, git returns paths delimited with / as a path separator. Ensure that Atom uniformly sees
  * native path separators.
  */
-function normalizePathSeparators(rawPath) {
+function toNativePathSep(rawPath) {
   if (process.platform !== 'win32') {
     return rawPath;
   } else {
     return rawPath.split('/').join(path.sep);
+  }
+}
+
+function toGitPathSep(rawPath) {
+  if (process.platform !== 'win32') {
+    return rawPath;
+  } else {
+    return rawPath.split(path.sep).join('/');
   }
 }

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -338,7 +338,8 @@ export default class GitShellOutStrategy {
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         if (line === '') { continue; }
-        const [_, x, y, filePath] = line.match(/(.)(.)\s(.*)/); // eslint-disable-line no-unused-vars
+        const [_, x, y, rawFilePath] = line.match(/(.)(.)\s(.*)/); // eslint-disable-line no-unused-vars
+        const filePath = normalizePathSeparators(rawFilePath);
         if (x === 'U' || y === 'U' || (x === 'A' && y === 'A')) {
           // Skipping this check here because we only run a single `await`
           // and we only run it in the main, synchronous body of the for loop.
@@ -742,4 +743,16 @@ function buildAddedFilePatch(filePath, contents, executable) {
     status: 'added',
     hunks,
   };
+}
+
+/**
+ * On Windows, git returns paths delimited with / as a path separator. Ensure that Atom uniformly sees
+ * native path separators.
+ */
+function normalizePathSeparators(rawPath) {
+  if (process.platform !== 'win32') {
+    return rawPath;
+  } else {
+    return rawPath.split('/').join(path.sep);
+  }
 }

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -426,19 +426,6 @@ export default class GitShellOutStrategy {
     return rawDiffs[0];
   }
 
-  async isPartiallyStaged(filePath) {
-    const args = ['status', '--short', '--', toGitPathSep(filePath)];
-    const output = await this.exec(args);
-    const results = output.trim().split(LINE_ENDING_REGEX);
-    if (results.length === 2) {
-      return true;
-    } else if (results.length === 1) {
-      return ['MM', 'AM', 'MD'].includes(results[0].slice(0, 2));
-    } else {
-      throw new Error(`Unexpected output for ${args.join(' ')}: ${output}`);
-    }
-  }
-
   /**
    * Miscellaneous getters
    */

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -11,7 +11,7 @@ import AsyncQueue from './async-queue';
 import {
   getPackageRoot, getDugitePath,
   readFile, fileExists, fsStat, writeFile, isFileExecutable,
-  normalizeGitHelperPath,
+  normalizeGitHelperPath, toNativePathSep, toGitPathSep,
 } from './helpers';
 import GitTimingsView from './views/git-timings-view';
 import WorkerManager from './worker-manager';
@@ -745,24 +745,4 @@ function buildAddedFilePatch(filePath, contents, executable) {
     status: 'added',
     hunks,
   };
-}
-
-/**
- * On Windows, git returns paths delimited with / as a path separator. Ensure that Atom uniformly sees
- * native path separators.
- */
-function toNativePathSep(rawPath) {
-  if (process.platform !== 'win32') {
-    return rawPath;
-  } else {
-    return rawPath.split('/').join(path.sep);
-  }
-}
-
-function toGitPathSep(rawPath) {
-  if (process.platform !== 'win32') {
-    return rawPath;
-  } else {
-    return rawPath.split(path.sep).join('/');
-  }
 }

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -413,7 +413,20 @@ export default class GitShellOutStrategy {
     const output = await this.exec(args);
 
     let rawDiffs = [];
-    if (output) { rawDiffs = parseDiff(output).filter(rawDiff => rawDiff.status !== 'unmerged'); }
+    if (output) {
+      rawDiffs = parseDiff(output)
+        .filter(rawDiff => rawDiff.status !== 'unmerged');
+
+      for (let i = 0; i < rawDiffs.length; i++) {
+        const rawDiff = rawDiffs[i];
+        if (rawDiff.oldPath) {
+          rawDiff.oldPath = toNativePathSep(rawDiff.oldPath);
+        }
+        if (rawDiff.newPath) {
+          rawDiff.newPath = toNativePathSep(rawDiff.newPath);
+        }
+      }
+    }
 
     if (!staged && (await this.getUntrackedFiles()).includes(filePath)) {
       // add untracked file

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -208,3 +208,26 @@ export function normalizeGitHelperPath(inPath) {
     return inPath;
   }
 }
+
+/*
+ * On Windows, git commands report paths with / delimiters. Convert them to \-delimited paths
+ * so that Atom unifromly treats paths with native path separators.
+ */
+export function toNativePathSep(rawPath) {
+  if (process.platform !== 'win32') {
+    return rawPath;
+  } else {
+    return rawPath.split('/').join(path.sep);
+  }
+}
+
+/*
+ * Convert Windows paths back to /-delimited paths to be presented to git.
+ */
+export function toGitPathSep(rawPath) {
+  if (process.platform !== 'win32') {
+    return rawPath;
+  } else {
+    return rawPath.split(path.sep).join('/');
+  }
+}

--- a/lib/models/file-patch.js
+++ b/lib/models/file-patch.js
@@ -1,4 +1,5 @@
 import Hunk from './hunk';
+import {toGitPathSep} from '../helpers';
 
 export default class FilePatch {
   constructor(oldPath, newPath, status, hunks) {
@@ -156,9 +157,9 @@ export default class FilePatch {
   }
 
   getHeaderString() {
-    let header = this.getOldPath() ? `--- a/${this.getOldPath()}` : '--- /dev/null';
+    let header = this.getOldPath() ? `--- a/${toGitPathSep(this.getOldPath())}` : '--- /dev/null';
     header += '\n';
-    header += this.getNewPath() ? `+++ b/${this.getNewPath()}` : '+++ /dev/null';
+    header += this.getNewPath() ? `+++ b/${toGitPathSep(this.getNewPath())}` : '+++ /dev/null';
     header += '\n';
     return header;
   }

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -176,9 +176,9 @@ export default class Repository {
     const u = unstagedFiles[fileName];
     const s = stagedFiles[fileName];
     return (u === 'modified' && s === 'modified') ||
-      (u === 'added' && s === 'modified') ||
       (u === 'modified' && s === 'added') ||
-      (u === 'modified' && s === 'deleted');
+      (u === 'added' && s === 'deleted') ||
+      (u === 'deleted' && s === 'modified');
   }
 
   async getRemoteForBranch(branchName) {

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -177,6 +177,7 @@ export default class Repository {
     const s = stagedFiles[fileName];
     return (u === 'modified' && s === 'modified') ||
       (u === 'added' && s === 'modified') ||
+      (u === 'modified' && s === 'added') ||
       (u === 'modified' && s === 'deleted');
   }
 

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -239,8 +239,8 @@ import {fsStat, normalizeGitHelperPath, writeFile} from '../lib/helpers';
         fs.writeFileSync(path.join(folderPath, 'f.txt'), 'qux', 'utf8');
         assert.deepEqual(await git.getUntrackedFiles(), [
           'd.txt',
-          'folder/subfolder/e.txt',
-          'folder/subfolder/f.txt',
+          path.join('folder', 'subfolder', 'e.txt'),
+          path.join('folder', 'subfolder', 'f.txt'),
         ]);
       });
 

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -428,42 +428,6 @@ import {fsStat, normalizeGitHelperPath, writeFile} from '../lib/helpers';
       });
     });
 
-    describe('isPartiallyStaged(filePath)', function() {
-      it('returns true if specified file path is partially staged', async function() {
-        const workingDirPath = await cloneRepository('three-files');
-        const git = createTestStrategy(workingDirPath);
-        fs.writeFileSync(path.join(workingDirPath, 'a.txt'), 'modified file', 'utf8');
-        fs.writeFileSync(path.join(workingDirPath, 'new-file.txt'), 'foo\nbar\nbaz\n', 'utf8');
-        fs.writeFileSync(path.join(workingDirPath, 'b.txt'), 'blah blah blah', 'utf8');
-        fs.unlinkSync(path.join(workingDirPath, 'c.txt'));
-
-        assert.isFalse(await git.isPartiallyStaged('a.txt'));
-        assert.isFalse(await git.isPartiallyStaged('b.txt'));
-        assert.isFalse(await git.isPartiallyStaged('c.txt'));
-        assert.isFalse(await git.isPartiallyStaged('new-file.txt'));
-
-        await git.stageFiles(['a.txt', 'b.txt', 'c.txt', 'new-file.txt']);
-        assert.isFalse(await git.isPartiallyStaged('a.txt'));
-        assert.isFalse(await git.isPartiallyStaged('b.txt'));
-        assert.isFalse(await git.isPartiallyStaged('c.txt'));
-        assert.isFalse(await git.isPartiallyStaged('new-file.txt'));
-
-        // modified on both
-        fs.writeFileSync(path.join(workingDirPath, 'a.txt'), 'more mods', 'utf8');
-        // modified in working directory, added on index
-        fs.writeFileSync(path.join(workingDirPath, 'new-file.txt'), 'foo\nbar\nbaz\nqux\n', 'utf8');
-        // deleted in working directory, modified on index
-        fs.unlinkSync(path.join(workingDirPath, 'b.txt'));
-        // untracked in working directory, deleted on index
-        fs.writeFileSync(path.join(workingDirPath, 'c.txt'), 'back baby', 'utf8');
-
-        assert.isTrue(await git.isPartiallyStaged('a.txt'));
-        assert.isTrue(await git.isPartiallyStaged('b.txt'));
-        assert.isTrue(await git.isPartiallyStaged('c.txt'));
-        assert.isTrue(await git.isPartiallyStaged('new-file.txt'));
-      });
-    });
-
     describe('isMerging', function() {
       it('returns true if `.git/MERGE_HEAD` exists', async function() {
         const workingDirPath = await cloneRepository('merge-conflict');

--- a/test/models/file-patch.test.js
+++ b/test/models/file-patch.test.js
@@ -287,6 +287,7 @@ describe('FilePatch', function() {
         assert.equal(patch.getHeaderString(), dedent`
           --- a/foo/bar/old.js
           +++ b/baz/qux/new.js
+
         `);
       });
     });

--- a/test/models/file-patch.test.js
+++ b/test/models/file-patch.test.js
@@ -276,4 +276,19 @@ describe('FilePatch', function() {
       `);
     });
   });
+
+  if (process.platform === 'win32') {
+    describe('getHeaderString()', function() {
+      it('formats paths with git line endings', function() {
+        const oldPath = path.join('foo', 'bar', 'old.js');
+        const newPath = path.join('baz', 'qux', 'new.js');
+
+        const patch = new FilePatch(oldPath, newPath, 'modified', []);
+        assert.equal(patch.getHeaderString(), dedent`
+          --- a/foo/bar/old.js
+          +++ b/baz/qux/new.js
+        `);
+      });
+    });
+  }
 });

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -335,8 +335,8 @@ describe('Repository', function() {
 
       let unstagedChanges = (await repo.getUnstagedChanges()).map(c => c.filePath);
       let stagedChanges = (await repo.getStagedChanges()).map(c => c.filePath);
-      assert.deepEqual(unstagedChanges, ['subdir-1/a.txt']);
-      assert.deepEqual(stagedChanges, ['subdir-1/a.txt']);
+      assert.deepEqual(unstagedChanges, [path.join('subdir-1', 'a.txt')]);
+      assert.deepEqual(stagedChanges, [path.join('subdir-1', 'a.txt')]);
 
       await repo.applyPatchToIndex(unstagedPatch1.getUnstagePatch());
       repo.refresh();
@@ -344,7 +344,7 @@ describe('Repository', function() {
       assert.deepEqual(unstagedPatch3, unstagedPatch2);
       unstagedChanges = (await repo.getUnstagedChanges()).map(c => c.filePath);
       stagedChanges = (await repo.getStagedChanges()).map(c => c.filePath);
-      assert.deepEqual(unstagedChanges, ['subdir-1/a.txt']);
+      assert.deepEqual(unstagedChanges, [path.join('subdir-1', 'a.txt')]);
       assert.deepEqual(stagedChanges, []);
     });
   });


### PR DESCRIPTION
On Windows, our build of git reports and operates on paths with `/` separators, but the rest of Atom presents and consumes paths with native `\` separators. This was causing issues with cache invalidation because filesystem events were using `\`-separated paths and not invalidating the correct file patches.

I'm fixing this by uniformly presenting all repository-relative paths to git processes as `/`-separated paths via a `toGitPathSep` helper, and translating all returned paths from git status and diff output to `\`-separated paths via `toNativePathSep`.

Fixes #768 and #770.