### PR TITLE
Ensure that activating a DockItem shows the corresponding Dock

### DIFF
--- a/lib/views/dock-item.js
+++ b/lib/views/dock-item.js
@@ -109,6 +109,11 @@ export default class DockItem extends React.Component {
       const pane = this.props.workspace.paneForItem(this.dockItem);
       if (pane) {
         pane.activateItem(this.dockItem);
+        const dock = this.props.workspace.getPaneContainers()
+          .find(container => container.getPanes().find(p => p.getItems().includes(this.dockItem)));
+        if (dock && dock.constructor.name === 'Dock') {
+          dock.show();
+        }
       } else {
         throw new Error('Cannot find pane for item in `DockItem#activate`');
       }

--- a/lib/views/dock-item.js
+++ b/lib/views/dock-item.js
@@ -111,7 +111,7 @@ export default class DockItem extends React.Component {
         pane.activateItem(this.dockItem);
         const dock = this.props.workspace.getPaneContainers()
           .find(container => container.getPanes().find(p => p.getItems().includes(this.dockItem)));
-        if (dock && dock.constructor.name === 'Dock') {
+        if (dock && dock.show) {
           dock.show();
         }
       } else {


### PR DESCRIPTION
#673 made it show the Dock items are shown on first launch; however, the right Dock defaults to closed. This changes it so when we `activate` the item, it also shows the Dock.