### PR TITLE
Temporarily disable the schemacheck job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ env:
   - ATOM_CHANNEL=stable
   matrix:
   - TRAVIS_BUILD_JOB=runtests
-  - TRAVIS_BUILD_JOB=schemacheck
 
 notifications:
   email:


### PR DESCRIPTION
The schemacheck job on Travis isn't giving us much value these days. Let's turn it off until we can either eliminate it entirely or revisit it and make it more useful.

/xref #577