### PR TITLE
Only restore focus if the tab was revealed

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -785,17 +785,21 @@ class TabTracker {
 
   @autobind
   async toggle() {
-    const originalFocus = document.activeElement;
+    const focusToRestore = document.activeElement;
+    let shouldRestoreFocus = false;
 
     if (!this.getState()) {
       await this.setStateKey(true);
+      shouldRestoreFocus = true;
     } else if (this.getDockItem()) {
-      await this.getWorkspace().toggle(this.getDockItem());
+      shouldRestoreFocus = await this.getWorkspace().toggle(this.getDockItem()) !== undefined;
     } else {
       await this.setStateKey(false);
     }
 
-    process.nextTick(() => originalFocus.focus());
+    if (shouldRestoreFocus) {
+      process.nextTick(() => focusToRestore.focus());
+    }
   }
 
   @autobind


### PR DESCRIPTION
Fixes #784 with `useLegacyPanels` set to true and false.

This is what I get for not taking the extra effort to stub `document.activeElement` somehow.