### PR TITLE
Don't update Push button to say Force Push when cmd/ctrl held

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -168,6 +168,7 @@ export default class RootController extends React.Component {
           commandRegistry={this.props.commandRegistry}
           notificationManager={this.props.notificationManager}
           tooltips={this.props.tooltips}
+          confirm={this.props.confirm}
           toggleGitTab={this.gitTabTracker.toggle}
         />
       </StatusBar>

--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -234,8 +234,8 @@ export default class StatusBarTileController extends React.Component {
   async doPush(options) {
     if (options.force) {
       const choice = this.props.confirm({
-        message: 'Are you sure you wish to force push?',
-        detailedMessage: 'This operation could result it losing data on the remote.',
+        message: 'Are you sure you want to force push?',
+        detailedMessage: 'This operation could result in losing data on the remote.',
         buttons: ['Force Push', 'Cancel Push'],
       });
       if (choice !== 0) { return; }

--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -54,6 +54,7 @@ export default class StatusBarTileController extends React.Component {
     notificationManager: PropTypes.object.isRequired,
     commandRegistry: PropTypes.object.isRequired,
     tooltips: PropTypes.object.isRequired,
+    confirm: PropTypes.func.isRequired,
     repository: PropTypes.object.isRequired,
     currentBranch: BranchPropType.isRequired,
     branches: PropTypes.arrayOf(BranchPropType).isRequired,
@@ -231,6 +232,15 @@ export default class StatusBarTileController extends React.Component {
   }
 
   async doPush(options) {
+    if (options.force) {
+      const choice = this.props.confirm({
+        message: 'Are you sure you wish to force push?',
+        detailedMessage: 'This operation could result it losing data on the remote.',
+        buttons: ['Force Push', 'Cancel Push'],
+      });
+      if (choice !== 0) { return; }
+    }
+
     await this.setInProgressWhile(() => {
       return this.props.repository.push(this.props.currentBranch.getName(), options);
     }, {push: true});

--- a/lib/views/push-pull-menu-view.js
+++ b/lib/views/push-pull-menu-view.js
@@ -27,32 +27,8 @@ export default class PushPullMenuView extends React.Component {
     super(props, context);
 
     this.state = {
-      force: false,
       errorMessage: '',
     };
-  }
-
-  getKeyEventTarget() {
-    return document.querySelector('atom-workspace') || document;
-  }
-
-  componentDidMount() {
-    this.getKeyEventTarget().addEventListener('keydown', this.handleForceKeys);
-    this.getKeyEventTarget().addEventListener('keyup', this.handleForceKeys);
-  }
-
-  componentWillUnmount() {
-    this.getKeyEventTarget().removeEventListener('keydown', this.handleForceKeys);
-    this.getKeyEventTarget().removeEventListener('keyup', this.handleForceKeys);
-  }
-
-  @autobind
-  handleForceKeys(e) {
-    if (!this.state.force && (e.metaKey || e.ctrlKey)) {
-      this.setState({force: true});
-    } else if (this.state.force) {
-      this.setState({force: false});
-    }
   }
 
   render() {
@@ -84,7 +60,7 @@ export default class PushPullMenuView extends React.Component {
             <button className="btn github-PushPullMenuView-push" onClick={this.push} disabled={pushDisabled}>
               <span className="icon icon-arrow-up" />
               <span>
-                {this.state.force ? 'Force' : ''} Push {this.props.aheadCount ? `(${this.props.aheadCount})` : ''}
+                Push {this.props.aheadCount ? `(${this.props.aheadCount})` : ''}
               </span>
             </button>
           </div>
@@ -136,7 +112,7 @@ export default class PushPullMenuView extends React.Component {
   }
 
   @autobind
-  push() {
-    return this.props.push({force: this.state.force, setUpstream: !this.props.currentRemote.isPresent()});
+  push(e) {
+    return this.props.push({force: e.metaKey || e.ctrlKey, setUpstream: !this.props.currentRemote.isPresent()});
   }
 }

--- a/test/controllers/status-bar-tile-controller.test.js
+++ b/test/controllers/status-bar-tile-controller.test.js
@@ -362,7 +362,7 @@ describe('StatusBarTileController', function() {
         });
       });
 
-      it('displays an error message if push fails and allows force pushing if meta/ctrl key is pressed', async function() {
+      it('displays an error message if push fails', async function() {
         const {localRepoPath} = await setUpLocalAndRemoteRepositories();
         const repository = await buildRepository(localRepoPath);
         await repository.git.exec(['reset', '--hard', 'HEAD~2']);
@@ -390,16 +390,8 @@ describe('StatusBarTileController', function() {
         assert.match(notificationArgs[1].description, /Try pulling before pushing again/);
 
         await wrapper.instance().refreshModelData();
-        // This rigmarole is to get around a bug where dispatching a `KeyboardEvent` does not work.
-        // Note that this causes an error from down in Atom's internals; fixing the error
-        // makes the event dispatch fail. -_-
-        const event = new Event('keydown', {bubbles: true});
-        event.key = 'a';
-        event.keyCode = 65;
-        event.ctrlKey = true;
-        document.dispatchEvent(event);
 
-        await assert.async.equal(pushButton.textContent.trim(), 'Force Push (1)');
+        await assert.async.equal(pushButton.textContent.trim(), 'Push (1)');
         await assert.async.equal(pullButton.textContent.trim(), 'Pull (2)');
         wrapper.unmount();
       });

--- a/test/controllers/status-bar-tile-controller.test.js
+++ b/test/controllers/status-bar-tile-controller.test.js
@@ -15,7 +15,7 @@ import ChangedFilesCountView from '../../lib/views/changed-files-count-view';
 
 describe('StatusBarTileController', function() {
   let atomEnvironment;
-  let workspace, workspaceElement, commandRegistry, notificationManager, tooltips;
+  let workspace, workspaceElement, commandRegistry, notificationManager, tooltips, confirm;
   let component;
 
   beforeEach(function() {
@@ -24,6 +24,7 @@ describe('StatusBarTileController', function() {
     commandRegistry = atomEnvironment.commands;
     notificationManager = atomEnvironment.notifications;
     tooltips = atomEnvironment.tooltips;
+    confirm = atomEnvironment.confirm;
 
     workspaceElement = atomEnvironment.views.getView(workspace);
 
@@ -33,6 +34,7 @@ describe('StatusBarTileController', function() {
         commandRegistry={commandRegistry}
         notificationManager={notificationManager}
         tooltips={tooltips}
+        confirm={confirm}
       />
     );
   });
@@ -477,13 +479,15 @@ describe('StatusBarTileController', function() {
         const {localRepoPath} = await setUpLocalAndRemoteRepositories();
         const repository = await buildRepository(localRepoPath);
 
-        const wrapper = mount(React.cloneElement(component, {repository}));
+        const fakeConfirm = sinon.stub().returns(0);
+        const wrapper = mount(React.cloneElement(component, {repository, confirm: fakeConfirm}));
         await wrapper.instance().refreshModelData();
 
         sinon.spy(repository, 'push');
 
         commandRegistry.dispatch(workspaceElement, 'github:force-push');
 
+        assert.equal(fakeConfirm.callCount, 1);
         assert.isTrue(repository.push.calledWith('master', sinon.match({force: true, setUpstream: false})));
       });
     });


### PR DESCRIPTION
It seems that, on certain systems, this doesn't work as expected. Sometimes it flashes very quickly between the two states, and using `ctrl` as a modifier for mouse clicks can also put it into a weird state. I've seen both of these states on my own computer, but have been unable to reproduce consistently.

The last thing we want to do is accidentally cause a user to force push. So, instead, we use the `metaKey` and `ctrlKey` properties of the click event to determine if we should force push. Since the feature is, unfortunately, less discoverable, I added a confirmation that makes sure the user meant to force push.

Fixes #766 