### PR TITLE
Fix incorrect title when changing diff to another file

### DIFF
--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -41,9 +41,9 @@ export default class FilePatchController extends React.Component {
     return null;
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.getTitle(nextProps) !== this.getTitle()) {
-      this.emitter.emit('did-change-title', this.getTitle(nextProps));
+  componentDidUpdate(prevProps) {
+    if (this.getTitle(prevProps) !== this.getTitle()) {
+      this.emitter.emit('did-change-title');
     }
   }
 

--- a/test/controllers/file-patch-controller.test.js
+++ b/test/controllers/file-patch-controller.test.js
@@ -62,7 +62,7 @@ describe('FilePatchController', function() {
   it('bases its tab title on the staging status', function() {
     const filePatch1 = new FilePatch('a.txt', 'a.txt', 'modified', [new Hunk(1, 1, 1, 3, '', [])]);
 
-    const wrapper = shallow(React.cloneElement(component, {
+    const wrapper = mount(React.cloneElement(component, {
       filePatch: filePatch1,
       stagingStatus: 'unstaged',
     }));
@@ -76,7 +76,7 @@ describe('FilePatchController', function() {
 
     const actualTitle = wrapper.instance().getTitle();
     assert.equal(actualTitle, 'Staged Changes: a.txt');
-    assert.isTrue(changeHandler.calledWith(actualTitle));
+    assert.isTrue(changeHandler.called);
   });
 
   it('renders FilePatchView only if FilePatch has hunks', function() {


### PR DESCRIPTION
Previously, we emitted a `did-change-title` event and passed in the new title as an argument. However, Atom doesn't use this argument, and directly calls `getTitle` on the pane item. Since we were emitting in `componentWillReceiveProps`, which happens *before* the next render, the
title was one item behind.

Fixes #667 