### PR TITLE
Include a payload in WorkspaceChangeObserver.didUpdate() from focus events

### DIFF
--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -3,6 +3,7 @@ import path from 'path';
 import State from './state';
 
 import {deleteFileOrFolder} from '../../helpers';
+import {FOCUS} from '../workspace-change-observer';
 import FilePatch from '../file-patch';
 import Hunk from '../hunk';
 import HunkLine from '../hunk-line';
@@ -73,6 +74,14 @@ export default class Present extends State {
     const keys = new Set();
     for (let i = 0; i < paths.length; i++) {
       const fullPath = paths[i];
+
+      if (fullPath === FOCUS) {
+        keys.add(Keys.changedFiles);
+        for (const k of Keys.filePatch.eachWithOpts({staged: false})) {
+          keys.add(k);
+        }
+        continue;
+      }
 
       const endsWith = (...segments) => fullPath.endsWith(path.join(...segments));
       const includes = (...segments) => fullPath.includes(path.join(...segments));

--- a/lib/models/workdir-context.js
+++ b/lib/models/workdir-context.js
@@ -54,7 +54,7 @@ export default class WorkdirContext {
     // Wire up event forwarding among models
     this.subs.add(this.repository.onDidChangeState(this.repositoryChangedState));
     this.subs.add(this.observer.onDidChange(events => {
-      const paths = events.map(e => path.join(e.directory, e.file || e.newFile));
+      const paths = events.map(e => e.special || path.join(e.directory, e.file || e.newFile));
       this.deferredCallbackQueue.push(...paths);
     }));
     this.subs.add(this.observer.onDidChangeWorkdirOrHead(() => this.emitter.emit('did-change-workdir-or-head')));

--- a/lib/models/workdir-context.js
+++ b/lib/models/workdir-context.js
@@ -39,7 +39,7 @@ export default class WorkdirContext {
     this.emitter = new Emitter();
     this.subs = new CompositeDisposable();
 
-    this.observer = process.platform === 'linux'
+    this.observer = this.useWorkspaceChangeObserver()
       ? new WorkspaceChangeObserver(theWindow, workspace, this.repository)
       : new FileSystemChangeObserver(this.repository);
     this.resolutionProgress = new ResolutionProgress();
@@ -120,6 +120,10 @@ export default class WorkdirContext {
 
   isDestroyed() {
     return this.destroyed;
+  }
+
+  useWorkspaceChangeObserver() {
+    return !!process.env.ATOM_GITHUB_WORKSPACE_OBSERVER || process.platform === 'linux';
   }
 
   // Event subscriptions

--- a/lib/models/workspace-change-observer.js
+++ b/lib/models/workspace-change-observer.js
@@ -6,6 +6,8 @@ import {autobind} from 'core-decorators';
 
 import EventLogger from './event-logger';
 
+export const FOCUS = Symbol('focus');
+
 export default class WorkspaceChangeObserver {
   constructor(window, workspace, repository) {
     this.window = window;
@@ -22,7 +24,7 @@ export default class WorkspaceChangeObserver {
     const focusHandler = event => {
       if (this.repository) {
         this.logger.showFocusEvent();
-        this.didChange();
+        this.didChange([{special: FOCUS}]);
       }
     };
     this.window.addEventListener('focus', focusHandler);


### PR DESCRIPTION
Introduce a `{special: FOCUS}` event payload when a workspace change observer triggers a focus event (which doesn't have a path). The `special` key is propagated through the WorkdirContext event handler and handled by the `Present` state by invalidating status and all file patches.

I've also added an `ATOM_GITHUB_WORKSPACE_OBSERVER` env var to let us override the FilesystemChangeObserver on Mac or Windows to let us test the Linux code paths a little more easily.

Fixes #794.