### PR TITLE
Handle legacy panels correctly in TabTracker

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -795,6 +795,7 @@ class TabTracker {
     } else if (this.getDockItem()) {
       shouldRestoreFocus = await this.getWorkspace().toggle(this.getDockItem()) !== undefined;
     } else {
+      // Legacy panels.
       await this.setStateKey(false);
     }
 
@@ -841,7 +842,8 @@ class TabTracker {
 
     const item = this.getDockItem();
     if (!item) {
-      return false;
+      // Legacy panels active. Use getState(), which is true.
+      return true;
     }
 
     const workspace = this.getWorkspace();


### PR DESCRIPTION
When Docks are disabled or unavailable, return `true` from TabTracker.isVisible() instead of `false` when `getState()` is true.

Fixes #795.