### PR TITLE
Diagnostic cache viewer

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -25,6 +25,7 @@ import FilePatchController from './file-patch-controller';
 import GitTabController from './git-tab-controller';
 import StatusBarTileController from './status-bar-tile-controller';
 import RepositoryConflictController from './repository-conflict-controller';
+import GitCacheView from '../views/git-cache-view';
 import ModelObserver from '../models/model-observer';
 import ModelStateRegistry from '../models/model-state-registry';
 import Conflict from '../models/conflicts/conflict';
@@ -88,6 +89,7 @@ export default class RootController extends React.Component {
       cloneDialogInProgress: false,
       initDialogActive: false,
       credentialDialogQuery: null,
+      cacheViewActive: false,
     };
 
     this.repositoryStateRegistry = new ModelStateRegistry(RootController, {
@@ -140,6 +142,7 @@ export default class RootController extends React.Component {
       <div>
         <Commands registry={this.props.commandRegistry} target="atom-workspace">
           <Command command="github:show-waterfall-diagnostics" callback={this.showWaterfallDiagnostics} />
+          <Command command="github:show-cache-diagnostics" callback={this.showCacheDiagnostics} />
           <Command command="github:open-issue-or-pull-request" callback={this.showOpenIssueishDialog} />
           <Command command="github:toggle-git-tab" callback={this.gitTabTracker.toggle} />
           <Command command="github:toggle-git-tab-focus" callback={this.gitTabTracker.toggleFocus} />
@@ -154,6 +157,7 @@ export default class RootController extends React.Component {
         {this.renderCloneDialog()}
         {this.renderCredentialDialog()}
         {this.renderOpenIssueishDialog()}
+        {this.renderGitCacheView()}
         {this.renderRepositoryConflictController()}
       </div>
     );
@@ -389,6 +393,20 @@ export default class RootController extends React.Component {
     );
   }
 
+  renderGitCacheView() {
+    if (!this.state.cacheViewActive) {
+      return null;
+    }
+
+    return (
+      <PaneItem
+        workspace={this.props.workspace}
+        onDidCloseItem={() => { this.setState({cacheViewActive: false}); }}>
+        <GitCacheView repository={this.props.repository} />
+      </PaneItem>
+    );
+  }
+
   componentWillUnmount() {
     this.repositoryStateRegistry.save();
     this.subscriptions.dispose();
@@ -418,6 +436,11 @@ export default class RootController extends React.Component {
   @autobind
   showWaterfallDiagnostics() {
     this.props.workspace.open('atom-github://debug/timings');
+  }
+
+  @autobind
+  showCacheDiagnostics() {
+    this.setState({cacheViewActive: true});
   }
 
   @autobind

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -496,6 +496,11 @@ export default class Present extends State {
   getLastHistorySnapshots(partialDiscardFilePath = null) {
     return this.discardHistory.getLastSnapshots(partialDiscardFilePath);
   }
+
+  // Cache
+  getCache() {
+    return this.cache;
+  }
 }
 
 State.register(Present);

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -597,12 +597,17 @@ class Cache {
     const primary = key.getPrimary();
     const existing = this.storage.get(primary);
     if (existing !== undefined) {
-      return existing;
+      existing.hits++;
+      return existing.promise;
     }
 
     const created = operation();
 
-    this.storage.set(primary, created);
+    this.storage.set(primary, {
+      createdAt: performance.now(),
+      hits: 0,
+      promise: created,
+    });
 
     const groups = key.getGroups();
     for (let i = 0; i < groups.length; i++) {
@@ -643,6 +648,10 @@ class Cache {
     const groupSet = this.byGroup.get(group);
     groupSet && groupSet.delete(key);
     this.didUpdate();
+  }
+
+  [Symbol.iterator]() {
+    return this.storage[Symbol.iterator]();
   }
 
   clear() {

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import {Emitter} from 'event-kit';
 
 import State from './state';
 
@@ -57,6 +58,11 @@ export default class Present extends State {
 
   isPresent() {
     return true;
+  }
+
+  destroy() {
+    this.cache.dispose();
+    super.destroy();
   }
 
   showStatusBarTiles() {
@@ -583,6 +589,8 @@ class Cache {
   constructor() {
     this.storage = new Map();
     this.byGroup = new Map();
+
+    this.emitter = new Emitter();
   }
 
   getOrSet(key, operation) {
@@ -607,12 +615,18 @@ class Cache {
       groupSet.add(key);
     }
 
+    this.didUpdate();
+
     return created;
   }
 
   invalidate(keys) {
     for (let i = 0; i < keys.length; i++) {
       keys[i].removeFromCache(this);
+    }
+
+    if (keys.length > 0) {
+      this.didUpdate();
     }
   }
 
@@ -622,16 +636,31 @@ class Cache {
 
   removePrimary(primary) {
     this.storage.delete(primary);
+    this.didUpdate();
   }
 
   removeFromGroup(group, key) {
     const groupSet = this.byGroup.get(group);
     groupSet && groupSet.delete(key);
+    this.didUpdate();
   }
 
   clear() {
     this.storage.clear();
     this.byGroup.clear();
+    this.didUpdate();
+  }
+
+  didUpdate() {
+    this.emitter.emit('did-update');
+  }
+
+  onDidUpdate(callback) {
+    return this.emitter.on('did-update', callback);
+  }
+
+  destroy() {
+    this.emitter.dispose();
   }
 }
 

--- a/lib/models/repository-states/state.js
+++ b/lib/models/repository-states/state.js
@@ -396,6 +396,13 @@ export default class State {
     return null;
   }
 
+  // Cache
+
+  @shouldDelegate
+  getCache() {
+    return null;
+  }
+
   // Internal //////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Non-delegated methods that provide subclasses with convenient access to Repository properties.
 

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -292,6 +292,8 @@ const delegates = [
   'hasDiscardHistory',
   'getDiscardHistory',
   'getLastHistorySnapshots',
+
+  'getCache',
 ];
 
 for (let i = 0; i < delegates.length; i++) {

--- a/lib/views/git-cache-view.js
+++ b/lib/views/git-cache-view.js
@@ -1,0 +1,139 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {autobind} from 'core-decorators';
+import {inspect} from 'util';
+
+import ObserveModel from '../views/observe-model';
+
+export default class GitCacheView extends React.Component {
+  static propTypes = {
+    repository: PropTypes.object.isRequired,
+  }
+
+  getURI() {
+    return 'atom-github://debug/cache';
+  }
+
+  getTitle() {
+    return 'GitHub Package Cache View';
+  }
+
+  serialize() {
+    return null;
+  }
+
+  @autobind
+  fetchRepositoryData(repository) {
+    return repository.getCache();
+  }
+
+  @autobind
+  fetchCacheData(cache) {
+    const cached = {};
+    const promises = [];
+    const now = performance.now();
+
+    for (const [key, value] of cache) {
+      cached[key] = {
+        hits: value.hits,
+        age: now - value.createdAt,
+      };
+
+      promises.push(
+        value.promise
+          .then(
+            payload => inspect(payload, {breakLength: 50}),
+            err => `${err.message}\n${err.stack}`,
+          )
+          .then(resolved => { cached[key].value = resolved; }),
+      );
+    }
+
+    return Promise.all(promises).then(() => cached);
+  }
+
+  render() {
+    return (
+      <ObserveModel model={this.props.repository} fetchData={this.fetchRepositoryData}>
+        {cache => (
+          <ObserveModel model={cache} fetchData={this.fetchCacheData}>
+            {this.renderCache}
+          </ObserveModel>
+        )}
+      </ObserveModel>
+    );
+  }
+
+  @autobind
+  renderCache(contents) {
+    const keys = Object.keys(contents || []);
+
+    return (
+      <div className="github-CacheView">
+        <header>
+          <h1>Cache contents</h1>
+          <p>
+            <span className="badge">{keys.length}</span> cached items
+          </p>
+        </header>
+        <main>
+          <table>
+            <thead>
+              <tr>
+                <td className="github-CacheView-Key">key</td>
+                <td className="github-CacheView-Age">age</td>
+                <td className="github-CacheView-Hits">hits</td>
+                <td className="github-CacheView-Content">content</td>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map(key => (
+                <tr key={key} className="github-CacheView-Row">
+                  <td className="github-CacheView-Key">
+                    <code>{key}</code>
+                  </td>
+                  <td className="github-CacheView-Age">
+                    {this.formatAge(contents[key].age)}
+                  </td>
+                  <td className="github-CacheView-Hits">
+                    {contents[key].hits}
+                  </td>
+                  <td className="github-CacheView-Content">
+                    {contents[key].value}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </main>
+      </div>
+    );
+  }
+
+  formatAge(ageMs) {
+    let remaining = ageMs;
+    const parts = [];
+
+    if (remaining > 3600000) {
+      const hours = Math.floor(remaining / 3600000);
+      parts.push(`${hours}h`);
+      remaining -= (3600000 * hours);
+    }
+
+    if (remaining > 60000) {
+      const minutes = Math.floor(remaining / 60000);
+      parts.push(`${minutes}m`);
+      remaining -= (60000 * minutes);
+    }
+
+    if (remaining > 1000) {
+      const seconds = Math.floor(remaining / 1000);
+      parts.push(`${seconds}s`);
+      remaining -= (1000 * seconds);
+    }
+
+    parts.push(`${Math.floor(remaining)}ms`);
+
+    return parts.slice(parts.length - 2).join(' ');
+  }
+}

--- a/styles/cache-view.less
+++ b/styles/cache-view.less
@@ -1,0 +1,45 @@
+@import "variables";
+
+.github-CacheView {
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+
+  header {
+    text-align: center;
+    border-bottom: 1px solid @base-border-color;
+    padding: @component-padding;
+  }
+
+  table {
+    margin: 10px 20px;
+    width: 90%;
+  }
+
+  thead {
+    color: @text-color-highlight;
+    background-color: @background-color-highlight;
+    font-weight: bold;
+  }
+
+  td {
+    padding: @component-padding / 2;
+    vertical-align: top;
+  }
+
+  &-Key {
+    text-align: right;
+  }
+
+  &-Age {
+    min-width: 100px;
+  }
+
+  &-Hits {
+    min-width: 50px;
+  }
+
+  &-Content {
+    white-space: pre-wrap;
+  }
+}


### PR DESCRIPTION
Track the usage of cache data. Add a pane item that displays the current cache contents, live, and allows selective or bulk cache flushing. Totally low-priority tinkering from me.

Here's what I've got so far, pardon the Developer Art :art::

<img width="1077" alt="screen shot 2017-05-13 at 10 01 57 pm" src="https://cloud.githubusercontent.com/assets/17565/26030691/e0877f48-3827-11e7-97fe-fae0d11ff7dd.png">

- [x] Give the Cache an event emitter and an `onDidUpdate` event.
- [x] Store extra cache entry metadata: age and hit count.
- [x] Display the cache data in a PaneItem triggered with `github:show-cache-diagnostics`.
- [ ] Sort cache entries within the table: alphabetic by name, oldest first, newest first, most hits, fewest hits.
- [ ] Convert the cache key column to buttons that evict that cache entry on click.
- [ ] Add a button to flush the entire cache at once.
- [ ] Truncate cache entry values at some reasonable maximum size.
- [ ] Periodically re-render the component to bring the age column up to date _(maybe)_.
- [ ] Broadcast invalidation events with a reason: "cache key X was evicted at time Y because of this filesystem event or `Present` method".
- [ ] Display recent invalidation events, either somewhere within the GitCacheView, a new DockItem, or just in the console.