### PR TITLE
Don't display large diffs by default

### DIFF
--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -10,6 +12,7 @@ import FilePatchView from '../views/file-patch-view';
 
 export default class FilePatchController extends React.Component {
   static propTypes = {
+    largeDiffLineThreshold: PropTypes.number,
     activeWorkingDirectory: PropTypes.string,
     repository: PropTypes.object.isRequired,
     commandRegistry: PropTypes.object.isRequired,
@@ -27,7 +30,14 @@ export default class FilePatchController extends React.Component {
   }
 
   static defaultProps = {
+    largeDiffLineThreshold: 1000,
     switchboard: new Switchboard(),
+  }
+
+  static confirmedLargeFilePatches = new Set()
+
+  static resetConfirmedLargeFilePatches() {
+    this.confirmedLargeFilePatches = new Set();
   }
 
   constructor(props, context) {
@@ -53,6 +63,13 @@ export default class FilePatchController extends React.Component {
       return (
         <div className="github-PaneView pane-item is-blank">
           <span className="icon icon-info">File has no contents</span>
+        </div>
+      );
+    } else if (!this.shouldDisplayLargeDiff(hunks)) {
+      return (
+        <div className="github-PaneView pane-item large-file-patch">
+          <p>This is a large diff. For performance reasons, it is not rendered by default.</p>
+          <button className="btn btn-primary" onClick={this.handleShowDiffClick}>Show Diff</button>
         </div>
       );
     } else {
@@ -83,12 +100,28 @@ export default class FilePatchController extends React.Component {
     }
   }
 
+  shouldDisplayLargeDiff(hunks) {
+    const lineCount = hunks.reduce((acc, hunk) => hunk.lines.length, 0);
+    const fullPath = path.join(this.props.repository.getWorkingDirectoryPath(), this.props.filePatch.getPath());
+    return lineCount < this.props.largeDiffLineThreshold ||
+      FilePatchController.confirmedLargeFilePatches.has(fullPath);
+  }
+
   onDidChangeTitle(callback) {
     return this.emitter.on('did-change-title', callback);
   }
 
   onDidDestroy(callback) {
     return this.emitter.on('did-destroy', callback);
+  }
+
+  @autobind
+  handleShowDiffClick() {
+    if (this.props.repository) {
+      const fullPath = path.join(this.props.repository.getWorkingDirectoryPath(), this.props.filePatch.getPath());
+      FilePatchController.confirmedLargeFilePatches.add(fullPath);
+      this.forceUpdate();
+    }
   }
 
   async stageHunk(hunk) {

--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -65,7 +65,7 @@ export default class FilePatchController extends React.Component {
           <span className="icon icon-info">File has no contents</span>
         </div>
       );
-    } else if (!this.shouldDisplayLargeDiff(hunks)) {
+    } else if (!this.shouldDisplayLargeDiff(this.props.filePatch)) {
       return (
         <div className="github-PaneView pane-item large-file-patch">
           <p>This is a large diff. For performance reasons, it is not rendered by default.</p>
@@ -100,11 +100,14 @@ export default class FilePatchController extends React.Component {
     }
   }
 
-  shouldDisplayLargeDiff(hunks) {
-    const lineCount = hunks.reduce((acc, hunk) => hunk.lines.length, 0);
+  shouldDisplayLargeDiff(filePatch) {
     const fullPath = path.join(this.props.repository.getWorkingDirectoryPath(), this.props.filePatch.getPath());
-    return lineCount < this.props.largeDiffLineThreshold ||
-      FilePatchController.confirmedLargeFilePatches.has(fullPath);
+    if (FilePatchController.confirmedLargeFilePatches.has(fullPath)) {
+      return true;
+    }
+
+    const lineCount = filePatch.getHunks().reduce((acc, hunk) => hunk.getLines().length, 0);
+    return lineCount < this.props.largeDiffLineThreshold;
   }
 
   onDidChangeTitle(callback) {

--- a/styles/pane-view.less
+++ b/styles/pane-view.less
@@ -5,11 +5,15 @@
   display: flex;
   height: 100%;
 
-  &.is-blank {
+  &.is-blank, &.large-file-patch {
     align-items: center;
     justify-content: center;
     text-align: center;
     font-size: 1.2em;
     padding: @component-padding;
+  }
+
+  &.large-file-patch {
+    flex-direction: column;
   }
 }

--- a/test/controllers/file-patch-controller.test.js
+++ b/test/controllers/file-patch-controller.test.js
@@ -33,7 +33,10 @@ describe('FilePatchController', function() {
 
     const filePatch = new FilePatch('a.txt', 'a.txt', 'modified', [new Hunk(1, 1, 1, 3, '', [])]);
     const repository = Repository.absent();
+    sinon.stub(repository, 'getWorkingDirectoryPath').returns('/absent');
     const resolutionProgress = new ResolutionProgress();
+
+    FilePatchController.resetConfirmedLargeFilePatches();
 
     component = (
       <FilePatchController
@@ -77,6 +80,76 @@ describe('FilePatchController', function() {
     const actualTitle = wrapper.instance().getTitle();
     assert.equal(actualTitle, 'Staged Changes: a.txt');
     assert.isTrue(changeHandler.calledWith(actualTitle));
+  });
+
+  describe('when the FilePatch has many lines', function() {
+    it('renders a confirmation widget', function() {
+      const hunk1 = new Hunk(0, 0, 1, 1, '', [
+        new HunkLine('line-1', 'added', 1, 1),
+        new HunkLine('line-2', 'added', 2, 2),
+        new HunkLine('line-3', 'added', 3, 3),
+        new HunkLine('line-4', 'added', 4, 4),
+        new HunkLine('line-5', 'added', 5, 5),
+        new HunkLine('line-6', 'added', 6, 6),
+      ]);
+      const filePatch = new FilePatch('a.txt', 'a.txt', 'modified', [hunk1]);
+
+      const wrapper = mount(React.cloneElement(component, {
+        filePatch, largeDiffLineThreshold: 5,
+      }));
+
+      assert.isFalse(wrapper.find('FilePatchView').exists());
+      assert.match(wrapper.text(), /large diff/);
+    });
+
+    it('renders the full diff when the confirmation is clicked', function() {
+      const hunk = new Hunk(0, 0, 1, 1, '', [
+        new HunkLine('line-1', 'added', 1, 1),
+        new HunkLine('line-2', 'added', 2, 2),
+        new HunkLine('line-3', 'added', 3, 3),
+        new HunkLine('line-4', 'added', 4, 4),
+        new HunkLine('line-5', 'added', 5, 5),
+        new HunkLine('line-6', 'added', 6, 6),
+      ]);
+      const filePatch = new FilePatch('a.txt', 'a.txt', 'modified', [hunk]);
+
+      const wrapper = mount(React.cloneElement(component, {
+        filePatch, largeDiffLineThreshold: 5,
+      }));
+
+      assert.isFalse(wrapper.find('FilePatchView').exists());
+
+      // wrapper.find('button').simulate('click');
+      // assert.isTrue(wrapper.find('FilePatchView').exists());
+    });
+
+    it('renders the full diff if the file has been confirmed before', async function() {
+      const hunk = new Hunk(0, 0, 1, 1, '', [
+        new HunkLine('line-1', 'added', 1, 1),
+        new HunkLine('line-2', 'added', 2, 2),
+        new HunkLine('line-3', 'added', 3, 3),
+        new HunkLine('line-4', 'added', 4, 4),
+        new HunkLine('line-5', 'added', 5, 5),
+        new HunkLine('line-6', 'added', 6, 6),
+      ]);
+      const filePatch1 = new FilePatch('a.txt', 'a.txt', 'modified', [hunk]);
+      const filePatch2 = new FilePatch('b.txt', 'b.txt', 'modified', [hunk]);
+
+      const wrapper = mount(React.cloneElement(component, {
+        filePatch: filePatch1, largeDiffLineThreshold: 5,
+      }));
+
+      assert.isFalse(wrapper.find('FilePatchView').exists());
+
+      wrapper.find('button').simulate('click');
+      assert.isTrue(wrapper.find('FilePatchView').exists());
+
+      wrapper.setProps({filePatch: filePatch2});
+      await assert.async.isFalse(wrapper.find('FilePatchView').exists());
+
+      wrapper.setProps({filePatch: filePatch1});
+      assert.isTrue(wrapper.find('FilePatchView').exists());
+    });
   });
 
   it('renders FilePatchView only if FilePatch has hunks', function() {

--- a/test/controllers/file-patch-controller.test.js
+++ b/test/controllers/file-patch-controller.test.js
@@ -119,8 +119,8 @@ describe('FilePatchController', function() {
 
       assert.isFalse(wrapper.find('FilePatchView').exists());
 
-      // wrapper.find('button').simulate('click');
-      // assert.isTrue(wrapper.find('FilePatchView').exists());
+      wrapper.find('button').simulate('click');
+      assert.isTrue(wrapper.find('FilePatchView').exists());
     });
 
     it('renders the full diff if the file has been confirmed before', async function() {


### PR DESCRIPTION
Large diffs can slow down rendering and make Atom feel slow. This is a stopgap solution that presents a GitHub.com-style warning about large diffs that the user can confirm to see the diff; I've set the default threshold to 1000 lines.

Once a user confirms a large diff, its path gets added to a Set that ensures any diff with the same path will always be shown. I debated on this functionality but in the end decided it would make the most sense. 💭 s?

Fixes https://github.com/atom/github/issues/786