### PR TITLE
Fix HunkView-stageButton border

### DIFF
--- a/styles/hunk-view.less
+++ b/styles/hunk-view.less
@@ -125,7 +125,7 @@
   .github-HunkView-line.is-selected .github-HunkView-lineNumber {
     border-color: mix(@button-border-color, @button-background-color-selected, 25%);
   }
-  .is-hunkMode .github-HunkView-stageButton {
+  .github-HunkView.is-selected.is-hunkMode .github-HunkView-stageButton {
     border-color: mix(@hunk-bg-color, @button-background-color-selected, 30%);
     &:hover  { background-color: mix(@hunk-bg-color, @button-background-color-selected, 10%); }
     &:active { background-color: @button-background-color-selected; }


### PR DESCRIPTION
### Description of the Change

This removes the colored border (mostly blue, but depends on the theme) of `HunkView-stageButton`s when they are **not** selected.

![screen shot 2017-05-15 at 10 10 18 am](https://cloud.githubusercontent.com/assets/378023/26039528/d2a96942-3956-11e7-9222-5907fe290640.png)

### Applicable Issues

Part of https://github.com/atom/github/pull/591
