### PR TITLE
Enable git tracing during authentication tests

### DIFF
--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -999,6 +999,7 @@ import {fsStat, normalizeGitHelperPath, writeFile} from '../lib/helpers';
         useEnvironment({
           SSH_ASKPASS: '',
           GIT_ASKPASS: '',
+          ATOM_GITHUB_GIT_DIAGNOSTICS: 'true',
         });
       });
 
@@ -1162,6 +1163,7 @@ import {fsStat, normalizeGitHelperPath, writeFile} from '../lib/helpers';
           SSH_AUTH_SOCK: undefined,
           SSH_ASKPASS: '',
           GIT_ASKPASS: '',
+          ATOM_GITHUB_GIT_DIAGNOSTICS: 'true',
         });
       });
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -177,8 +177,19 @@ export function isProcessAlive(pid) {
   return alive;
 }
 
+let originalEnvVars = {};
+export function useEnvironment(envVars) {
+  const varNames = Object.keys(envVars);
+  for (let i = 0; i < varNames.length; i++) {
+    const varName = varNames[i];
+    originalEnvVars[varName] = process.env[varName];
+    process.env[varName] = envVars[varName];
+  }
+}
+
 // eslint-disable-next-line jasmine/no-global-setup
 beforeEach(function() {
+  originalEnvVars = {};
   global.sinon = sinon.sandbox.create();
 });
 
@@ -187,6 +198,13 @@ afterEach(function() {
   activeRenderers.forEach(r => r.unmount());
   activeRenderers = [];
   global.sinon.restore();
+
+  const varNames = Object.keys(originalEnvVars);
+  for (let i = 0; i < varNames.length; i++) {
+    const varName = varNames[i];
+    process.env[varName] = originalEnvVars[varName];
+  }
+  originalEnvVars = {};
 });
 
 // eslint-disable-next-line jasmine/no-global-setup

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -350,16 +350,6 @@ describe('Repository', function() {
   });
 
   describe('commit', function() {
-    let realPath = '';
-
-    beforeEach(function() {
-      realPath = process.env.PATH;
-    });
-
-    afterEach(function() {
-      process.env.PATH = realPath;
-    });
-
     it('creates a commit that contains the staged changes', async function() {
       const workingDirPath = await cloneRepository('three-files');
       const repo = new Repository(workingDirPath);
@@ -479,7 +469,9 @@ describe('Repository', function() {
       const repo = new Repository(workingDirPath);
       await repo.getLoadPromise();
 
-      process.env.PATH = `${scriptDirPath}:${process.env.PATH}`;
+      useEnvironment({
+        PATH: `${scriptDirPath}:${process.env.PATH}`,
+      });
 
       await assert.isRejected(repo.commit('hmm'), /didirun\.sh did run/);
     });


### PR DESCRIPTION
Git diagnostic output would be helpful for tracking down flakes like #731 and #761, but is way too noisy in other parts of the test suite. Use the env var to temporarily enable git diagnostics for certain tests.

Along the way I'm introducing a `useEnvironment` helper for tests to temporarily override environment variables and restore them automatically after the test completes:

```javascript
useEnvironment({
  PATH: '/some/value',
  EDITOR: '/bin/echo',
});
```