### PR TITLE
Fix not matching branches with '/' in name

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -591,7 +591,7 @@ export default class GitShellOutStrategy {
   }
 
   async getBranches() {
-    const output = await this.exec(['for-each-ref', '--format=%(refname:short)', 'refs/heads/*']);
+    const output = await this.exec(['for-each-ref', '--format=%(refname:short)', 'refs/heads/**']);
     return output.trim().split(LINE_ENDING_REGEX);
   }
 


### PR DESCRIPTION
### Requirements

- [X] Template filled out
- [X] I don't believe this change requires a test

### Description of the Change

This commit fixes issues where branches will not display if they contain a '/' character.

For example: 'hello/world'

### Alternate Designs

This came about because I am required to name certain branches with my initials such as:
ct/hello-world
ct/fix-bug-x

### Benefits

Branches that otherwise will not display in the dropdown menu will be included.

### Possible Drawbacks

Without this pull request, I cannot change to these kinds of branches from the dropdown menu.

### Applicable Issues

N/A

Thanks for your time!
