### PR TITLE
Handle renamed buffers and unnamed buffers in WorkspaceChangeObserver

### DIFF
--- a/lib/models/workspace-change-observer.js
+++ b/lib/models/workspace-change-observer.js
@@ -126,30 +126,31 @@ export default class WorkspaceChangeObserver {
   observeTextEditor(editor) {
     const buffer = editor.getBuffer();
     if (!this.observedBuffers.has(buffer)) {
-      const fullPath = buffer.getPath();
-      const events = [{
-        directory: path.dirname(fullPath),
-        file: path.basename(fullPath),
-      }];
+      const didChange = () => {
+        const fullPath = buffer.getPath();
+        const events = [{
+          directory: path.dirname(fullPath),
+          file: path.basename(fullPath),
+        }];
+        this.logger.showEvents(events);
+        this.didChange(events);
+      };
 
       this.observedBuffers.add(buffer);
       const disposables = new CompositeDisposable(
         buffer.onDidSave(() => {
           if (this.activeRepositoryContainsPath(buffer.getPath())) {
-            this.logger.showEvents(events);
-            this.didChange(events);
+            didChange();
           }
         }),
         buffer.onDidReload(() => {
           if (this.activeRepositoryContainsPath(buffer.getPath())) {
-            this.logger.showEvents(events);
-            this.didChange(events);
+            didChange();
           }
         }),
         buffer.onDidDestroy(() => {
           if (this.activeRepositoryContainsPath(buffer.getPath())) {
-            this.logger.showEvents(events);
-            this.didChange(events);
+            didChange();
           }
           disposables.dispose();
         }),

--- a/lib/models/workspace-change-observer.js
+++ b/lib/models/workspace-change-observer.js
@@ -115,7 +115,7 @@ export default class WorkspaceChangeObserver {
 
   activeRepositoryContainsPath(filePath) {
     const repository = this.getRepository();
-    if (repository) {
+    if (filePath && repository) {
       return filePath.indexOf(repository.getWorkingDirectoryPath()) !== -1;
     } else {
       return false;

--- a/test/models/workspace-change-observer.test.js
+++ b/test/models/workspace-change-observer.test.js
@@ -71,4 +71,26 @@ describe('WorkspaceChangeObserver', function() {
     editor.destroy();
     await until(() => changeSpy.calledOnce);
   });
+
+  describe('when a buffer is renamed', function() {
+    it('emits a change event with the new path', async function() {
+      const workdirPath = await cloneRepository('three-files');
+      const repository = await buildRepository(workdirPath);
+      const editor = await workspace.open(path.join(workdirPath, 'a.txt'));
+
+      const changeSpy = sinon.spy();
+      const changeObserver = new WorkspaceChangeObserver(window, workspace, repository);
+      changeObserver.onDidChange(changeSpy);
+      await changeObserver.start();
+
+      editor.getBuffer().setPath(path.join(workdirPath, 'renamed-path.txt'));
+
+      editor.setText('change');
+      editor.save();
+      await assert.async.isTrue(changeSpy.calledWith([{
+        directory: workdirPath,
+        file: 'renamed-path.txt',
+      }]));
+    });
+  });
 });

--- a/test/models/workspace-change-observer.test.js
+++ b/test/models/workspace-change-observer.test.js
@@ -92,5 +92,16 @@ describe('WorkspaceChangeObserver', function() {
         file: 'renamed-path.txt',
       }]));
     });
+
+    it('doesn\'t emit events for unsaved files', async function() {
+      const workdirPath = await cloneRepository('three-files');
+      const repository = await buildRepository(workdirPath);
+      const editor = await workspace.open();
+
+      const changeObserver = new WorkspaceChangeObserver(window, workspace, repository);
+      await changeObserver.start();
+
+      assert.doesNotThrow(() => editor.destroy());
+    });
   });
 });

--- a/test/models/workspace-change-observer.test.js
+++ b/test/models/workspace-change-observer.test.js
@@ -92,16 +92,16 @@ describe('WorkspaceChangeObserver', function() {
         file: 'renamed-path.txt',
       }]));
     });
+  });
 
-    it('doesn\'t emit events for unsaved files', async function() {
-      const workdirPath = await cloneRepository('three-files');
-      const repository = await buildRepository(workdirPath);
-      const editor = await workspace.open();
+  it('doesn\'t emit events for unsaved files', async function() {
+    const workdirPath = await cloneRepository('three-files');
+    const repository = await buildRepository(workdirPath);
+    const editor = await workspace.open();
 
-      const changeObserver = new WorkspaceChangeObserver(window, workspace, repository);
-      await changeObserver.start();
+    const changeObserver = new WorkspaceChangeObserver(window, workspace, repository);
+    await changeObserver.start();
 
-      assert.doesNotThrow(() => editor.destroy());
-    });
+    assert.doesNotThrow(() => editor.destroy());
   });
 });


### PR DESCRIPTION
Fixes #827

Previously opening a new file and closing it would result in an uncaught exception because we were assuming the existence of a file path and looking up a string method on it.

Additionally, we were precomputing the path to specify in the change events and not adjusting them when the file's path changed due to renaming.