### PR TITLE
wrap file names in list

### DIFF
--- a/styles/file-patch-list-view.less
+++ b/styles/file-patch-list-view.less
@@ -30,7 +30,7 @@
 
   &-path {
     flex: 1;
-    word-break: break-all;
+    word-break: break-word;
   }
 
   &-resolutionItem {

--- a/styles/file-patch-list-view.less
+++ b/styles/file-patch-list-view.less
@@ -30,6 +30,7 @@
 
   &-path {
     flex: 1;
+    word-break: break-all;
   }
 
   &-resolutionItem {


### PR DESCRIPTION
### Description of the Change

Currently long filenames (and / or when the Git dock is narrow) the file names fall off the side. This will break the word onto multiple lines.

### Alternate Designs

Ideally, I believe the folder name should be shown above the filename for greater customisation but this is a quick fix.

### Benefits

Prevents filenames being hidden in the list, particularly useful for when there are multiple similar filenames: `/blah/blah/blah/blahblah.js` and `/blah/blah/blah/blahblah.scss`

### Possible Drawbacks

The list will be taller.