### PR TITLE
Implement quick fixes for submodules

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -317,7 +317,7 @@ export default class GitShellOutStrategy {
    * File Status and Diffs
    */
   async getStatusesForChangedFiles() {
-    const output = await this.exec(['status', '--untracked-files=all', '-z']);
+    const output = await this.exec(['status', '--untracked-files=all', '--ignore-submodules=dirty', '-z']);
 
     const statusMap = {
       'A': 'added',

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -120,7 +120,8 @@ export default class Repository {
       const contents = await readFile(path.join(this.getWorkingDirectoryPath(), relativePath), 'utf8');
       return MERGE_MARKER_REGEX.test(contents);
     } catch (e) {
-      if (e.code === 'ENOENT') { return false; } else { throw e; }
+      // EISDIR implies this is a submodule
+      if (e.code === 'ENOENT' || e.code === 'EISDIR') { return false; } else { throw e; }
     }
   }
 


### PR DESCRIPTION
Fixes #828.

Here we implement a couple of quick fixes until we can implement more comprehensive submodule support #309 

In the meantime, we now ignore dirty submodules and do not display them in the changed file list. This avoids the uncaught error in #828. We also assume submodules don't have merge markers, which will avoid the ENOENT error when staging a submodule in the Unstaged Changes list.