### PR TITLE
Choose the active context by the active item in the workspace center

### DIFF
--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -118,6 +118,10 @@ export default class GitTabController {
     return 'atom-github://stub-uri/git-tab-controller';
   }
 
+  getWorkingDirectory() {
+    return this.props.repository.getWorkingDirectoryPath();
+  }
+
   getLastModelDataRefreshPromise() {
     return this.repositoryObserver.getLastModelDataRefreshPromise();
   }

--- a/lib/controllers/github-tab-controller.js
+++ b/lib/controllers/github-tab-controller.js
@@ -150,6 +150,10 @@ export default class GithubTabController extends React.Component {
     return 'atom-github://stub-uri/github-tab-controller';
   }
 
+  getWorkingDirectory() {
+    return this.props.repository.getWorkingDirectoryPath();
+  }
+
   renderNoRemotes() {
     return (
       <div className="github-GithubTabController-no-remotes">

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -313,7 +313,8 @@ export default class GithubPackage {
    * Derive the git working directory context that should be used for the package's git operations based on the current
    * state of the Atom workspace. In priority, this prefers:
    *
-   * - A git working directory that contains the active pane item.
+   * - A git working directory that contains the workspace's active pane item.
+   * - A git working directory that contains the pane item in the workspace's center.
    * - A git working directory corresponding to a single Project.
    * - When initially activating the package, the working directory that was active when the package was last
    *   serialized.
@@ -332,21 +333,38 @@ export default class GithubPackage {
       ),
     );
 
-    const activeItemPath = pathForPaneItem(this.workspace.getActivePaneItem());
-    let activeItemWorkdir = null;
-    if (activeItemPath) {
-      activeItemWorkdir = await this.workdirCache.find(activeItemPath);
-    }
+    const fromPaneItem = async maybeItem => {
+      const itemPath = pathForPaneItem(maybeItem);
 
-    if (activeItemWorkdir && !this.project.contains(activeItemPath)) {
-      workdirs.add(activeItemWorkdir);
-    }
+      if (!itemPath) {
+        return {};
+      }
+
+      const itemWorkdir = await this.workdirCache.find(itemPath);
+
+      if (itemWorkdir && !this.project.contains(itemPath)) {
+        workdirs.add(itemWorkdir);
+      }
+
+      return {itemPath, itemWorkdir};
+    };
+
+    const items = [
+      this.workspace.getActivePaneItem(),
+      this.workspace.getCenter && this.workspace.getCenter().getActivePaneItem(),
+    ];
+    const [active, center = {}] = await Promise.all(items.map(fromPaneItem));
 
     this.contextPool.set(workdirs, savedState);
 
-    if (activeItemPath) {
+    if (active.itemPath) {
       // Prefer an active item
-      return this.contextPool.getContext(activeItemWorkdir || activeItemPath);
+      return this.contextPool.getContext(active.itemWorkdir || active.itemPath);
+    }
+
+    if (center.itemPath) {
+      // Try the item active in the Workspace's center
+      return this.contextPool.getContext(center.itemWorkdir || center.itemPath);
     }
 
     if (this.project.getPaths().length === 1) {

--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -431,6 +431,26 @@ describe('GithubPackage', function() {
       assert.isTrue(githubPackage.getActiveRepository().isAbsent());
     });
 
+    it('uses the context of the PaneItem active in the workspace center', async function() {
+      if (!workspace.getLeftDock) {
+        this.skip();
+      }
+
+      const [workdir0, workdir1] = await Promise.all([
+        cloneRepository('three-files'),
+        cloneRepository('three-files'),
+      ]);
+      project.setPaths([workdir1]);
+
+      await workspace.open(path.join(workdir0, 'a.txt'));
+      commandRegistry.dispatch(atomEnv.views.getView(workspace), 'tree-view:toggle-focus');
+      workspace.getLeftDock().activate();
+
+      await githubPackage.scheduleActiveContextUpdate();
+
+      assert.equal(githubPackage.getActiveWorkdir(), workdir0);
+    });
+
     it('uses the context of a single open project', async function() {
       const [workdirPath1, workdirPath2] = await Promise.all([
         cloneRepository('three-files'),


### PR DESCRIPTION
Now that the Docks API is shipped, the Workspace's active item can be either a pane item in the Workspace center _or_ an item in one of the three Docks. This includes items which were previously Panels, like the tree view or our own Git- and GithubTabControllers. As none of these implement the "active context" pane API, moving focus to any of these causes the context resolution algorithm to fall back on the added projects, which doesn't always work as expected if there are zero or many projects in the workspace.

This will fixes #825 and issues like it in several layers by:

- [x] Inferring the active context from an active item in the Workspace center if the active pane item doesn't implement the context API
- [x] Implementing the context API for the Git and GithubTabControllers so that clicking on one of our own dock items never causes an active context switch