### PR TITLE
File patch selection and context menu interaction

### DIFF
--- a/lib/context-menu-interceptor.js
+++ b/lib/context-menu-interceptor.js
@@ -32,7 +32,7 @@ export default class ContextMenuInterceptor extends React.Component {
   }
 
   componentWillUnmount() {
-    ContextMenuInterceptor.registration.remove(this.element);
+    ContextMenuInterceptor.registration.delete(this.element);
   }
 }
 

--- a/lib/context-menu-interceptor.js
+++ b/lib/context-menu-interceptor.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class ContextMenuInterceptor extends React.Component {
+  static propTypes = {
+    onWillShowContextMenu: PropTypes.func.isRequired,
+    children: PropTypes.element.isRequired,
+  }
+
+  static registration = new Map()
+
+  static handle(event) {
+    for (const [element, callback] of ContextMenuInterceptor.registration) {
+      if (element.contains(event.target)) {
+        callback(event);
+      }
+    }
+  }
+
+  static dispose() {
+    document.removeEventListener('contextmenu', contextMenuHandler, {capture: true});
+  }
+
+  componentDidMount() {
+    // Helpfully, addEventListener dedupes listeners for us.
+    document.addEventListener('contextmenu', contextMenuHandler, {capture: true});
+    ContextMenuInterceptor.registration.set(this.element, this.props.onWillShowContextMenu);
+  }
+
+  render() {
+    return <div ref={e => { this.element = e; }}>{this.props.children}</div>;
+  }
+
+  componentWillUnmount() {
+    ContextMenuInterceptor.registration.remove(this.element);
+  }
+}
+
+function contextMenuHandler(event) {
+  ContextMenuInterceptor.handle(event);
+}

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -18,6 +18,7 @@ import StubItem from './atom-items/stub-item';
 import Switchboard from './switchboard';
 import yardstick from './yardstick';
 import GitTimingsView from './views/git-timings-view';
+import ContextMenuInterceptor from './context-menu-interceptor';
 import AsyncQueue from './async-queue';
 import WorkerManager from './worker-manager';
 
@@ -71,6 +72,7 @@ export default class GithubPackage {
           this.setActiveContext(WorkdirContext.absent());
         }
       }),
+      ContextMenuInterceptor,
     );
 
     this.setupYardstick();

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -193,8 +193,6 @@ export default class FilePatchView extends React.Component {
   @autobind
   contextMenuOnItem(event, hunk, line) {
     const resend = () => {
-      event.stopPropagation();
-
       const newEvent = new MouseEvent(event.type, event);
       requestAnimationFrame(() => {
         event.target.parentNode.dispatchEvent(newEvent);
@@ -203,10 +201,14 @@ export default class FilePatchView extends React.Component {
 
     const mode = this.state.selection.getMode();
     if (mode === 'hunk' && !this.state.selection.getSelectedHunks().has(hunk)) {
+      event.stopPropagation();
+
       this.setState(prevState => {
         return {selection: prevState.selection.selectHunk(hunk, event.shiftKey)};
       }, resend);
     } else if (mode === 'line' && !this.state.selection.getSelectedLines().has(line)) {
+      event.stopPropagation();
+
       this.setState(prevState => {
         return {selection: prevState.selection.selectLine(line, event.shiftKey)};
       }, resend);

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -194,9 +194,7 @@ export default class FilePatchView extends React.Component {
   contextMenuOnItem(event, hunk, line) {
     const resend = () => {
       const newEvent = new MouseEvent(event.type, event);
-      requestAnimationFrame(() => {
-        event.target.parentNode.dispatchEvent(newEvent);
-      });
+      setImmediate(() => event.target.parentNode.dispatchEvent(newEvent));
     };
 
     const mode = this.state.selection.getMode();

--- a/lib/views/hunk-view.js
+++ b/lib/views/hunk-view.js
@@ -109,7 +109,6 @@ class LineView extends React.Component {
           className={`github-HunkView-line ${lineSelectedClass} is-${line.getStatus()}`}
           onMouseDown={event => this.props.mousedown(event, line)}
           onMouseMove={event => this.props.mousemove(event, line)}
-          onContextMenu={event => this.props.contextMenuOnItem(event, line)}
           ref={e => this.props.registerLineElement(line, e)}>
           <div className="github-HunkView-lineNumber is-old">{oldLineNumber}</div>
           <div className="github-HunkView-lineNumber is-new">{newLineNumber}</div>

--- a/lib/views/hunk-view.js
+++ b/lib/views/hunk-view.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {autobind} from 'core-decorators';
 
+import ContextMenuInterceptor from '../context-menu-interceptor';
+
 export default class HunkView extends React.Component {
   static propTypes = {
     hunk: PropTypes.object.isRequired,
@@ -102,19 +104,21 @@ class LineView extends React.Component {
     const lineSelectedClass = this.props.isSelected ? 'is-selected' : '';
 
     return (
-      <div
-        className={`github-HunkView-line ${lineSelectedClass} is-${line.getStatus()}`}
-        onMouseDown={event => this.props.mousedown(event, line)}
-        onMouseMove={event => this.props.mousemove(event, line)}
-        onContextMenu={event => this.props.contextMenuOnItem(event, line)}
-        ref={e => this.props.registerLineElement(line, e)}>
-        <div className="github-HunkView-lineNumber is-old">{oldLineNumber}</div>
-        <div className="github-HunkView-lineNumber is-new">{newLineNumber}</div>
-        <div className="github-HunkView-lineContent">
-          <span className="github-HunkView-plusMinus">{line.getOrigin()}</span>
-          <span>{line.getText()}</span>
+      <ContextMenuInterceptor onWillShowContextMenu={event => this.props.contextMenuOnItem(event, line)}>
+        <div
+          className={`github-HunkView-line ${lineSelectedClass} is-${line.getStatus()}`}
+          onMouseDown={event => this.props.mousedown(event, line)}
+          onMouseMove={event => this.props.mousemove(event, line)}
+          onContextMenu={event => this.props.contextMenuOnItem(event, line)}
+          ref={e => this.props.registerLineElement(line, e)}>
+          <div className="github-HunkView-lineNumber is-old">{oldLineNumber}</div>
+          <div className="github-HunkView-lineNumber is-new">{newLineNumber}</div>
+          <div className="github-HunkView-lineContent">
+            <span className="github-HunkView-plusMinus">{line.getOrigin()}</span>
+            <span>{line.getText()}</span>
+          </div>
         </div>
-      </div>
+      </ContextMenuInterceptor>
     );
   }
 }

--- a/test/context-menu-interceptor.test.js
+++ b/test/context-menu-interceptor.test.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import ContextMenuInterceptor from '../lib/context-menu-interceptor';
+
+class SampleComponent extends React.Component {
+  render() {
+    return (
+      <div className="parent">
+        <div className="child">
+          This element has content.
+        </div>
+      </div>
+    );
+  }
+}
+
+describe('ContextMenuInterceptor', function() {
+  let rootElement, rootHandler, rootHandlerCalled;
+
+  beforeEach(function() {
+    rootHandlerCalled = false;
+    rootHandler = event => {
+      rootHandlerCalled = true;
+      event.preventDefault();
+      return false;
+    };
+    document.addEventListener('contextmenu', rootHandler);
+
+    rootElement = document.createElement('div');
+    document.body.appendChild(rootElement);
+  });
+
+  afterEach(function() {
+    document.removeEventListener('contextmenu', rootHandler);
+    ContextMenuInterceptor.dispose();
+    rootElement.remove();
+  });
+
+  it('responds to native contextmenu events before they reach the document root', function() {
+    let interceptorHandlerCalled = false;
+    let rootHandlerCalledFirst = false;
+    const handler = () => {
+      interceptorHandlerCalled = true;
+      rootHandlerCalledFirst = rootHandlerCalled;
+    };
+
+    const wrapper = mount(
+      <ContextMenuInterceptor onWillShowContextMenu={handler}>
+        <SampleComponent />
+      </ContextMenuInterceptor>,
+      {attachTo: rootElement},
+    );
+
+    const targetDOMNode = wrapper.find('.child').getDOMNode();
+    const event = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+    });
+    targetDOMNode.dispatchEvent(event);
+
+    assert.isTrue(interceptorHandlerCalled);
+    assert.isFalse(rootHandlerCalledFirst);
+    assert.isTrue(rootHandlerCalled);
+  });
+
+  it('can prevent event propagation', function() {
+    let interceptorHandlerCalled = false;
+    const handler = () => {
+      interceptorHandlerCalled = true;
+      event.stopPropagation();
+    };
+
+    const wrapper = mount(
+      <ContextMenuInterceptor onWillShowContextMenu={handler}>
+        <SampleComponent />
+      </ContextMenuInterceptor>,
+      {attachTo: rootElement},
+    );
+
+    const targetDOMNode = wrapper.find('.child').getDOMNode();
+    const event = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+    });
+    targetDOMNode.dispatchEvent(event);
+
+    assert.isTrue(interceptorHandlerCalled);
+    assert.isFalse(rootHandlerCalled);
+  });
+
+  it('ignores contextmenu events from other children', function() {
+    let interceptorHandlerCalled = false;
+    const handler = () => {
+      interceptorHandlerCalled = true;
+    };
+
+    const wrapper = mount(
+      <div>
+        <ContextMenuInterceptor onWillShowContextMenu={handler}>
+          <SampleComponent />
+        </ContextMenuInterceptor>
+        <div className="unrelated">
+          <div className="otherNode">
+            This is another div.
+          </div>
+        </div>
+      </div>,
+      {attachTo: rootElement},
+    );
+
+    const targetDOMNode = wrapper.find('.otherNode').getDOMNode();
+    const event = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+    });
+    targetDOMNode.dispatchEvent(event);
+
+    assert.isFalse(interceptorHandlerCalled);
+    assert.isTrue(rootHandlerCalled);
+  });
+
+  it('cleans itself up on .dispose()', function() {
+    let interceptorHandlerCalled = false;
+    const handler = () => {
+      interceptorHandlerCalled = true;
+    };
+
+    const wrapper = mount(
+      <ContextMenuInterceptor onWillShowContextMenu={handler}>
+        <SampleComponent />
+      </ContextMenuInterceptor>,
+      {attachTo: rootElement},
+    );
+
+    ContextMenuInterceptor.dispose();
+
+    const targetDOMNode = wrapper.find('.child').getDOMNode();
+    const event = new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+    });
+    targetDOMNode.dispatchEvent(event);
+
+    assert.isFalse(interceptorHandlerCalled);
+    assert.isTrue(rootHandlerCalled);
+  });
+});

--- a/test/controllers/file-patch-controller.test.js
+++ b/test/controllers/file-patch-controller.test.js
@@ -286,8 +286,8 @@ describe('FilePatchController', function() {
 
       const opPromise0 = switchboard.getFinishStageOperationPromise();
       const hunkView0 = wrapper.find('HunkView').at(0);
-      hunkView0.find('LineView').at(1).simulate('mousedown', {button: 0, detail: 1});
-      hunkView0.find('LineView').at(3).simulate('mousemove', {});
+      hunkView0.find('LineView').at(1).find('.github-HunkView-line').simulate('mousedown', {button: 0, detail: 1});
+      hunkView0.find('LineView').at(3).find('.github-HunkView-line').simulate('mousemove', {});
       window.dispatchEvent(new MouseEvent('mouseup'));
       hunkView0.find('button.github-HunkView-stageButton').simulate('click');
       await opPromise0;
@@ -329,9 +329,11 @@ describe('FilePatchController', function() {
       await updatePromise2;
 
       const hunkView2 = wrapper.find('HunkView').at(0);
-      hunkView2.find('LineView').at(1).simulate('mousedown', {button: 0, detail: 1});
+      hunkView2.find('LineView').at(1).find('.github-HunkView-line')
+        .simulate('mousedown', {button: 0, detail: 1});
       window.dispatchEvent(new MouseEvent('mouseup'));
-      hunkView2.find('LineView').at(2).simulate('mousedown', {button: 0, detail: 1, metaKey: true});
+      hunkView2.find('LineView').at(2).find('.github-HunkView-line')
+        .simulate('mousedown', {button: 0, detail: 1, metaKey: true});
       window.dispatchEvent(new MouseEvent('mouseup'));
 
       const opPromise2 = switchboard.getFinishStageOperationPromise();
@@ -442,7 +444,8 @@ describe('FilePatchController', function() {
         }));
 
         const hunkView0 = wrapper.find('HunkView').at(0);
-        hunkView0.find('LineView').at(1).simulate('mousedown', {button: 0, detail: 1});
+        hunkView0.find('LineView').at(1).find('.github-HunkView-line')
+          .simulate('mousedown', {button: 0, detail: 1});
         window.dispatchEvent(new MouseEvent('mouseup'));
 
         // stage lines in rapid succession
@@ -467,7 +470,8 @@ describe('FilePatchController', function() {
         await line1PatchPromise;
 
         const hunkView1 = wrapper.find('HunkView').at(0);
-        hunkView1.find('LineView').at(2).simulate('mousedown', {button: 0, detail: 1});
+        hunkView1.find('LineView').at(2).find('.github-HunkView-line')
+          .simulate('mousedown', {button: 0, detail: 1});
         window.dispatchEvent(new MouseEvent('mouseup'));
 
         const line2StagingPromise = switchboard.getFinishStageOperationPromise();

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,6 +9,7 @@ import sinon from 'sinon';
 import Repository from '../lib/models/repository';
 import GitShellOutStrategy from '../lib/git-shell-out-strategy';
 import WorkerManager from '../lib/worker-manager';
+import ContextMenuInterceptor from '../lib/context-menu-interceptor';
 
 assert.autocrlfEqual = (actual, expected, ...args) => {
   const newActual = actual.replace(/\r\n/g, '\n');
@@ -186,6 +187,9 @@ beforeEach(function() {
 afterEach(function() {
   activeRenderers.forEach(r => r.unmount());
   activeRenderers = [];
+
+  ContextMenuInterceptor.dispose();
+
   global.sinon.restore();
 });
 


### PR DESCRIPTION
Strictly speaking, the "actual fix" for #822 is a missing `event.persist()` call. In `FilePatchView.contextMenuOnItem()`, the MouseEvent is used in the `resend` callback, which is passed to `setState()` and may or may not be invoked asynchronously depending on React's scheduling mechanism. If you reproduce in dev mode you'll see a bunch of warnings to that effect in the console.

However... while I was reproducing this, I discovered that the right-click behavior no longer matched what the code was intended to do. We were _intending_ to add the right-clicked line or hunk to the selection if it was not already selected, but what was actually happening was that the context menu was appearing before the selection was modified.

This likely regressed in #617, because React's synthetic event system relies on event handlers added to the `document`, but Atom implements context menus internally by [adding an event handler to `document` _first_](https://github.com/atom/atom/blob/master/src/window-event-handler.coffee#L36). React's synthetic event callback fires too late to cancel the event.

To fix this, I've introduced a ContextMenuInterceptor component that installs a single native handler on the document with `{capture: true}` so that it'll trigger before Atom's handler.

I also had to change the event re-fire from a `requestAnimationFrame` to a `setImmediate` to actually allow the repaint with the updated selection to occur before the context menu is shown. I'm not entirely sure why that happens, but I suspect it has to do with [this bit from the documentation](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame):

> The window.requestAnimationFrame() method tells the browser that you wish to perform an animation and requests that the browser call a specified function to update an animation **before the next repaint.** The method takes as an argument a callback to be invoked before the repaint.

If I'm reading that right I bet two nested requestAnimationFrame() calls would do the trick as well... but setImmediate() works reliably for me and is somewhat cleaner.