### PR TITLE
Support gitdir files

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -278,9 +278,9 @@ export default class GitShellOutStrategy {
       const output = await this.exec(['rev-parse', '--resolve-git-dir', path.join(this.workingDir, '.git')]);
       const dotGitDir = output.trim();
       if (path.isAbsolute(dotGitDir)) {
-        return dotGitDir;
+        return toNativePathSep(dotGitDir);
       } else {
-        return path.resolve(path.join(this.workingDir, dotGitDir));
+        return toNativePathSep(path.resolve(path.join(this.workingDir, dotGitDir)));
       }
     } catch (e) {
       return null;

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -272,13 +272,18 @@ export default class GitShellOutStrategy {
     });
   }
 
-  async isGitRepository() {
+  async resolveDotGitDir() {
     try {
       await fsStat(this.workingDir); // fails if folder doesn't exist
-      await this.exec(['rev-parse', '--resolve-git-dir', path.join(this.workingDir, '.git')]);
-      return true;
+      const output = await this.exec(['rev-parse', '--resolve-git-dir', path.join(this.workingDir, '.git')]);
+      const dotGitDir = output.trim();
+      if (path.isAbsolute(dotGitDir)) {
+        return dotGitDir;
+      } else {
+        return path.resolve(path.join(this.workingDir, dotGitDir));
+      }
     } catch (e) {
-      return false;
+      return null;
     }
   }
 
@@ -445,9 +450,9 @@ export default class GitShellOutStrategy {
     return this.gpgExec(['merge', branchName], {writeOperation: true});
   }
 
-  async isMerging() {
+  async isMerging(dotGitDir) {
     try {
-      await readFile(path.join(this.workingDir, '.git', 'MERGE_HEAD'));
+      await readFile(path.join(dotGitDir, 'MERGE_HEAD'));
       return true;
     } catch (e) {
       return false;
@@ -469,10 +474,10 @@ export default class GitShellOutStrategy {
   /**
    * Rebase
    */
-  async isRebasing() {
+  async isRebasing(dotGitDir) {
     const results = await Promise.all([
-      fileExists(path.join(this.workingDir, '.git', 'rebase-merge')),
-      fileExists(path.join(this.workingDir, '.git', 'rebase-apply')),
+      fileExists(path.join(dotGitDir, 'rebase-merge')),
+      fileExists(path.join(dotGitDir, 'rebase-apply')),
     ]);
     return results.some(r => r);
   }

--- a/lib/models/repository-states/loading.js
+++ b/lib/models/repository-states/loading.js
@@ -6,7 +6,9 @@ import State from './state';
  */
 export default class Loading extends State {
   async start() {
-    if (await this.isGitRepository()) {
+    const dotGitDir = await this.resolveDotGitDir();
+    if (dotGitDir) {
+      this.repository.setGitDirectoryPath(dotGitDir);
       const history = await this.loadHistoryPayload();
       return this.transitionTo('Present', history);
     } else {
@@ -32,8 +34,8 @@ export default class Loading extends State {
     return true;
   }
 
-  directIsGitRepository() {
-    return this.git().isGitRepository();
+  directResolveDotGitDir() {
+    return this.git().resolveDotGitDir();
   }
 
   directGetConfig(key, options) {

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -532,11 +532,11 @@ export default class Present extends State {
   // Merging and rebasing status
 
   isMerging() {
-    return this.git().isMerging();
+    return this.git().isMerging(this.repository.getGitDirectoryPath());
   }
 
   isRebasing() {
-    return this.git().isRebasing();
+    return this.git().isRebasing(this.repository.getGitDirectoryPath());
   }
 
   // Remotes

--- a/lib/models/repository-states/state.js
+++ b/lib/models/repository-states/state.js
@@ -463,8 +463,8 @@ export default class State {
   // Direct git access
   // Non-delegated git operations for internal use within states.
 
-  directIsGitRepository() {
-    return Promise.resolve(false);
+  directResolveDotGitDir() {
+    return Promise.resolve(null);
   }
 
   directGetConfig(key, options = {}) {
@@ -487,8 +487,8 @@ export default class State {
   // Direct raw git operations to the current state, even if the state has been changed. Use these methods within
   // start() methods.
 
-  isGitRepository() {
-    return this.current().directIsGitRepository();
+  resolveDotGitDir() {
+    return this.current().directResolveDotGitDir();
   }
 
   doInit(workdir) {

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -127,7 +127,7 @@ export default class Repository {
 
   async getMergeMessage() {
     try {
-      const contents = await readFile(path.join(this.getWorkingDirectoryPath(), '.git', 'MERGE_MSG'), 'utf8');
+      const contents = await readFile(path.join(this.getGitDirectoryPath(), 'MERGE_MSG'), 'utf8');
       return contents;
     } catch (e) {
       return null;
@@ -140,8 +140,16 @@ export default class Repository {
     return this.workingDirectoryPath;
   }
 
+  setGitDirectoryPath(gitDirectoryPath) {
+    this._gitDirectoryPath = gitDirectoryPath;
+  }
+
   getGitDirectoryPath() {
-    return path.join(this.getWorkingDirectoryPath(), '.git');
+    if (this._gitDirectoryPath) {
+      return this._gitDirectoryPath;
+    } else {
+      return path.join(this.getWorkingDirectoryPath(), '.git');
+    }
   }
 
   isInState(stateName) {

--- a/lib/models/workdir-cache.js
+++ b/lib/models/workdir-cache.js
@@ -70,7 +70,6 @@ export default class WorkdirCache {
           if (!stat.isDirectory()) {
             const contents = await readFile(dotGit, 'utf8');
             if (contents.startsWith('gitdir: ')) {
-              console.log('RETURNING', currentDir);
               return resolve(currentDir);
             } else {
               return walk();

--- a/lib/models/workdir-cache.js
+++ b/lib/models/workdir-cache.js
@@ -1,6 +1,8 @@
 import path from 'path';
 import fs from 'fs';
 
+import {readFile} from '../helpers';
+
 /**
  * Locate the nearest git working directory above a given starting point, caching results.
  */
@@ -55,7 +57,7 @@ export default class WorkdirCache {
 
       const check = () => {
         const dotGit = path.join(currentDir, '.git');
-        fs.stat(dotGit, (statError, stat) => {
+        fs.stat(dotGit, async (statError, stat) => {
           if (statError) {
             if (statError.code === 'ENOENT' || statError.code === 'ENOTDIR') {
               // File not found. This is not the directory we're looking for. Continue walking.
@@ -66,8 +68,13 @@ export default class WorkdirCache {
           }
 
           if (!stat.isDirectory()) {
-            // A file called ".git". Probably not a good idea, but still not a git working directory.
-            return walk();
+            const contents = await readFile(dotGit, 'utf8');
+            if (contents.startsWith('gitdir: ')) {
+              console.log('RETURNING', currentDir);
+              return resolve(currentDir);
+            } else {
+              return walk();
+            }
           }
 
           // .git directory found! Mission accomplished.

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -28,14 +28,15 @@ import {fsStat, normalizeGitHelperPath, writeFile} from '../lib/helpers';
   };
 
   describe(`Git commands for CompositeGitStrategy made of [${strategies.map(s => s.name).join(', ')}]`, function() {
-    describe('isGitRepository', function() {
-      it('returns true if the path passed is a valid repository, and false if not', async function() {
+    describe('resolveDotGitDir', function() {
+      it('returns the path to the .git dir for a working directory if it exists, and null otherwise', async function() {
         const workingDirPath = await cloneRepository('three-files');
         const git = createTestStrategy(workingDirPath);
-        assert.isTrue(await git.isGitRepository(workingDirPath));
+        const dotGitFolder = await git.resolveDotGitDir(workingDirPath);
+        assert.equal(dotGitFolder, path.join(workingDirPath, '.git'));
 
         fs.removeSync(path.join(workingDirPath, '.git'));
-        assert.isFalse(await git.isGitRepository(workingDirPath));
+        assert.isNull(await git.resolveDotGitDir(workingDirPath));
       });
     });
 
@@ -376,8 +377,9 @@ import {fsStat, normalizeGitHelperPath, writeFile} from '../lib/helpers';
     describe('isMerging', function() {
       it('returns true if `.git/MERGE_HEAD` exists', async function() {
         const workingDirPath = await cloneRepository('merge-conflict');
+        const dotGitDir = path.join(workingDirPath, '.git');
         const git = createTestStrategy(workingDirPath);
-        let isMerging = await git.isMerging();
+        let isMerging = await git.isMerging(dotGitDir);
         assert.isFalse(isMerging);
 
         try {
@@ -385,11 +387,11 @@ import {fsStat, normalizeGitHelperPath, writeFile} from '../lib/helpers';
         } catch (e) {
           // expect merge to have conflicts
         }
-        isMerging = await git.isMerging();
+        isMerging = await git.isMerging(dotGitDir);
         assert.isTrue(isMerging);
 
         fs.unlinkSync(path.join(workingDirPath, '.git', 'MERGE_HEAD'));
-        isMerging = await git.isMerging();
+        isMerging = await git.isMerging(dotGitDir);
         assert.isFalse(isMerging);
       });
     });

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -12,7 +12,7 @@ import GitShellOutStrategy from '../lib/git-shell-out-strategy';
 import WorkerManager from '../lib/worker-manager';
 
 import {cloneRepository, initRepository, assertDeepPropertyVals} from './helpers';
-import {fsStat, normalizeGitHelperPath, writeFile} from '../lib/helpers';
+import {fsStat, normalizeGitHelperPath, writeFile, getTempDir} from '../lib/helpers';
 
 /**
  * KU Thoughts: The GitShellOutStrategy methods are tested in Repository tests for the most part
@@ -37,6 +37,16 @@ import {fsStat, normalizeGitHelperPath, writeFile} from '../lib/helpers';
 
         fs.removeSync(path.join(workingDirPath, '.git'));
         assert.isNull(await git.resolveDotGitDir(workingDirPath));
+      });
+
+      it('supports gitdir files', async function() {
+        const workingDirPath = await cloneRepository('three-files');
+        const workingDirPathWithDotGitFile = await getTempDir();
+        await writeFile(path.join(workingDirPathWithDotGitFile, '.git'), `gitdir: ${path.join(workingDirPath, '.git')}`);
+
+        const git = createTestStrategy(workingDirPathWithDotGitFile);
+        const dotGitFolder = await git.resolveDotGitDir(workingDirPathWithDotGitFile);
+        assert.equal(dotGitFolder, path.join(workingDirPath, '.git'));
       });
     });
 

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -15,7 +15,7 @@ import {
   cloneRepository, setUpLocalAndRemoteRepositories, getHeadCommitOnRemote,
   assertDeepPropertyVals, assertEqualSortedArraysByKey,
 } from '../helpers';
-import {getPackageRoot, writeFile, copyFile, fsStat} from '../../lib/helpers';
+import {getPackageRoot, writeFile, copyFile, fsStat, getTempDir} from '../../lib/helpers';
 
 describe('Repository', function() {
   it('delegates all state methods', function() {
@@ -65,6 +65,20 @@ describe('Repository', function() {
       assert.isTrue(repository.isInState('LoadingGuess'));
       assert.isTrue(repository.showGitTabLoading());
       assert.isFalse(repository.showGitTabInit());
+    });
+  });
+
+  describe('getGitDirectoryPath', function() {
+    it('returns the correct git directory path', async function() {
+      const workingDirPath = await cloneRepository('three-files');
+      const workingDirPathWithGitFile = await getTempDir();
+      await writeFile(path.join(workingDirPathWithGitFile, '.git'), `gitdir: ${path.join(workingDirPath, '.git')}`);
+
+      const repository = new Repository(workingDirPath);
+      assert.equal(repository.getGitDirectoryPath(), path.join(workingDirPath, '.git'));
+
+      const repositoryWithGitFile = new Repository(workingDirPathWithGitFile);
+      await assert.async.equal(repositoryWithGitFile.getGitDirectoryPath(), path.join(workingDirPath, '.git'));
     });
   });
 

--- a/test/models/workdir-cache.test.js
+++ b/test/models/workdir-cache.test.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import temp from 'temp';
+import fs from 'fs';
 
 import {cloneRepository} from '../helpers';
 
@@ -22,6 +23,15 @@ describe('WorkdirCache', function() {
     const expectedDir = await cloneRepository('three-files');
     const givenDir = path.join(expectedDir, 'subdir-1');
     const actualDir = await cache.find(givenDir);
+
+    assert.equal(actualDir, expectedDir);
+  });
+
+  it('finds a workdir from a gitdir file', async function() {
+    const repoDir = await cloneRepository('three-files');
+    const expectedDir = fs.realpathSync(temp.mkdirSync());
+    fs.writeFileSync(path.join(expectedDir, '.git'), `gitdir: ${path.join(repoDir, '.git')}`, 'utf8');
+    const actualDir = await cache.find(expectedDir);
 
     assert.equal(actualDir, expectedDir);
   });


### PR DESCRIPTION
From the [Git docs](https://git-scm.com/docs/gitrepository-layout#_description):

> **Note:** Also you can have a plain text file `.git` at the root of your working tree, containing `gitdir: <path>` to point at the real directory that has the repository.

This PR adds support for this feature; most notably, this adds support for using submodules as root project folders in Atom and having everything work correctly (#839).

Fixes #839 
Ref #309 