### PR TITLE
Don't search parent directories for `.babelrc` when transpiling

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "sourceMaps": "inline",
+  "babelrc": false,
   "plugins": [
     "./graphql/relay-babel-plugin.js",
     "./assert-async-plugin.js",


### PR DESCRIPTION
I was actually made aware of this via https://github.com/AtomLinter/linter-eslint/issues/920. By default, if a `.babelrc` file doesn't exist in the same directory as the file being transpiled, Babel searches up the directory hierarchy to find a `.babelrc` file to use during its transpilation. Adding this here means that if we ever decide to put this in `package.json` we won't get bitten by someone's `~/.babelrc` or something.