### PR TITLE
Add button for discarding hunk/selection in HunkView

### DIFF
--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -137,6 +137,7 @@ export default class FilePatchView extends React.Component {
             return (
               <HunkView
                 key={hunk.getHeader()}
+                tooltips={this.props.tooltips}
                 hunk={hunk}
                 isSelected={selectedHunks.has(hunk)}
                 hunkSelectionMode={hunkSelectionMode}

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -130,6 +130,7 @@ export default class FilePatchView extends React.Component {
               stageButtonSuffix += 's';
             }
             const stageButtonLabel = stageButtonLabelPrefix + stageButtonSuffix;
+            const discardButtonLabel = 'Discard' + stageButtonSuffix;
 
             return (
               <HunkView
@@ -137,7 +138,9 @@ export default class FilePatchView extends React.Component {
                 hunk={hunk}
                 isSelected={selectedHunks.has(hunk)}
                 hunkSelectionMode={hunkSelectionMode}
+                unstaged={unstaged}
                 stageButtonLabel={stageButtonLabel}
+                discardButtonLabel={discardButtonLabel}
                 selectedLines={selectedLines}
                 headLine={headLine}
                 headHunk={headHunk}
@@ -146,6 +149,7 @@ export default class FilePatchView extends React.Component {
                 mousemoveOnLine={this.mousemoveOnLine}
                 contextMenuOnItem={this.contextMenuOnItem}
                 didClickStageButton={() => this.didClickStageButtonForHunk(hunk)}
+                didClickDiscardButton={() => this.didClickDiscardButtonForHunk(hunk)}
               />
             );
           })}
@@ -399,6 +403,16 @@ export default class FilePatchView extends React.Component {
     } else {
       this.setState(prevState => ({selection: prevState.selection.selectHunk(hunk)}), () => {
         this.props.attemptHunkStageOperation(hunk);
+      });
+    }
+  }
+
+  didClickDiscardButtonForHunk(hunk) {
+    if (this.state.selection.getSelectedHunks().has(hunk)) {
+      this.discardSelection();
+    } else {
+      this.setState(prevState => ({selection: prevState.selection.selectHunk(hunk)}), () => {
+        this.discardSelection();
       });
     }
   }

--- a/lib/views/hunk-view.js
+++ b/lib/views/hunk-view.js
@@ -13,11 +13,14 @@ export default class HunkView extends React.Component {
     selectedLines: PropTypes.instanceOf(Set).isRequired,
     hunkSelectionMode: PropTypes.bool.isRequired,
     stageButtonLabel: PropTypes.string.isRequired,
+    discardButtonLabel: PropTypes.string.isRequired,
+    unstaged: PropTypes.bool.isRequired,
     mousedownOnHeader: PropTypes.func.isRequired,
     mousedownOnLine: PropTypes.func.isRequired,
     mousemoveOnLine: PropTypes.func.isRequired,
     contextMenuOnItem: PropTypes.func.isRequired,
     didClickStageButton: PropTypes.func.isRequired,
+    didClickDiscardButton: PropTypes.func.isRequired,
   }
 
   constructor(props, context) {
@@ -38,6 +41,14 @@ export default class HunkView extends React.Component {
           <span className="github-HunkView-title">
             {this.props.hunk.getHeader().trim()} {this.props.hunk.getSectionHeading().trim()}
           </span>
+          {this.props.unstaged &&
+            <button
+              className="github-HunkView-discardButton"
+              onClick={this.props.didClickDiscardButton}
+              onMouseDown={event => event.stopPropagation()}>
+              {this.props.discardButtonLabel}
+            </button>
+          }
           <button
             className="github-HunkView-stageButton"
             onClick={this.props.didClickStageButton}

--- a/lib/views/hunk-view.js
+++ b/lib/views/hunk-view.js
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {autobind} from 'core-decorators';
 
+import SimpleTooltip from './simple-tooltip';
 import ContextMenuInterceptor from '../context-menu-interceptor';
 
 export default class HunkView extends React.Component {
   static propTypes = {
+    tooltips: PropTypes.object.isRequired,
     hunk: PropTypes.object.isRequired,
     headHunk: PropTypes.object,
     headLine: PropTypes.object,
@@ -41,20 +43,23 @@ export default class HunkView extends React.Component {
           <span className="github-HunkView-title">
             {this.props.hunk.getHeader().trim()} {this.props.hunk.getSectionHeading().trim()}
           </span>
-          {this.props.unstaged &&
-            <button
-              className="github-HunkView-discardButton"
-              onClick={this.props.didClickDiscardButton}
-              onMouseDown={event => event.stopPropagation()}>
-              {this.props.discardButtonLabel}
-            </button>
-          }
           <button
             className="github-HunkView-stageButton"
             onClick={this.props.didClickStageButton}
             onMouseDown={event => event.stopPropagation()}>
             {this.props.stageButtonLabel}
           </button>
+          {this.props.unstaged &&
+            <SimpleTooltip
+              tooltips={this.props.tooltips}
+              title={this.props.discardButtonLabel}>
+              <button
+                className="icon-flame github-HunkView-discardButton"
+                onClick={this.props.didClickDiscardButton}
+                onMouseDown={event => event.stopPropagation()}
+              />
+            </SimpleTooltip>
+          }
         </div>
         {this.props.hunk.getLines().map((line, idx) =>
           <LineView

--- a/lib/views/simple-tooltip.js
+++ b/lib/views/simple-tooltip.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 
 export default class SimpleTooltip extends React.Component {
-  propTypes = {
+  static propTypes = {
     tooltips: PropTypes.object.isRequired,
     children: PropTypes.node.isRequired,
     title: PropTypes.string.isRequired,

--- a/styles/hunk-view.less
+++ b/styles/hunk-view.less
@@ -83,7 +83,7 @@
   .github-HunkView-title {
     color: @text-color;
   }
-  .github-HunkView-stageButton {
+  .github-HunkView-stageButton, .github-HunkView-discardButton {
     border-color: mix(@text-color, @background-color-selected, 25%);
   }
 }

--- a/styles/hunk-view.less
+++ b/styles/hunk-view.less
@@ -27,7 +27,7 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  &-stageButton {
+  &-stageButton, &-discardButton {
     line-height: 1;
     font-family: @font-family;
     border: none;

--- a/styles/hunk-view.less
+++ b/styles/hunk-view.less
@@ -27,7 +27,8 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  &-stageButton, &-discardButton {
+  &-stageButton,
+  &-discardButton {
     line-height: 1;
     font-family: @font-family;
     border: none;
@@ -125,9 +126,12 @@
   .github-HunkView-line.is-selected .github-HunkView-lineNumber {
     border-color: mix(@button-border-color, @button-background-color-selected, 25%);
   }
-  .github-HunkView.is-selected.is-hunkMode .github-HunkView-stageButton {
-    border-color: mix(@hunk-bg-color, @button-background-color-selected, 30%);
-    &:hover  { background-color: mix(@hunk-bg-color, @button-background-color-selected, 10%); }
-    &:active { background-color: @button-background-color-selected; }
+  .github-HunkView.is-selected.is-hunkMode .github-HunkView {
+    &-stageButton,
+    &-discardButton {
+      border-color: mix(@hunk-bg-color, @button-background-color-selected, 30%);
+      &:hover  { background-color: mix(@hunk-bg-color, @button-background-color-selected, 10%); }
+      &:active { background-color: @button-background-color-selected; }
+    }
   }
 }


### PR DESCRIPTION
Fixes #604 

/cc @simurai for styling 💭 

I'm a bit concerned that the button is so close to the "Stage/Unstage" button and therefore might accidentally get pressed. Maybe we can move it elsewhere in the hunk header? But even if it does accidentally get pressed then the user can always undo the discard.

![discard-hunk](https://cloud.githubusercontent.com/assets/7910250/26405949/16ed69fe-4097-11e7-8fce-9b5debd28d88.gif)
