### PR TITLE
File diff view button polish

### DIFF
--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -81,6 +81,7 @@ export default class FilePatchController extends React.Component {
           <FilePatchView
             ref={c => { this.filePatchView = c; }}
             commandRegistry={this.props.commandRegistry}
+            tooltips={this.props.tooltips}
             hunks={hunks}
             filePath={filePath}
             stagingStatus={this.props.stagingStatus}

--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -16,6 +16,7 @@ export default class FilePatchController extends React.Component {
     activeWorkingDirectory: PropTypes.string,
     repository: PropTypes.object.isRequired,
     commandRegistry: PropTypes.object.isRequired,
+    tooltips: PropTypes.object.isRequired,
     filePatch: PropTypes.object.isRequired,
     stagingStatus: PropTypes.oneOf(['unstaged', 'staged']).isRequired,
     isPartiallyStaged: PropTypes.bool.isRequired,

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -293,6 +293,7 @@ export default class RootController extends React.Component {
             activeWorkingDirectory={this.props.activeWorkingDirectory}
             repository={this.props.repository}
             commandRegistry={this.props.commandRegistry}
+            tooltips={this.props.tooltips}
             filePatch={this.state.filePatch}
             stagingStatus={this.state.stagingStatus}
             isAmending={this.state.amending}

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -6,6 +6,7 @@ import cx from 'classnames';
 import {autobind} from 'core-decorators';
 
 import HunkView from './hunk-view';
+import SimpleTooltip from './simple-tooltip';
 import Commands, {Command} from './commands';
 import FilePatchSelection from './file-patch-selection';
 import Switchboard from '../switchboard';
@@ -46,19 +47,7 @@ export default class FilePatchView extends React.Component {
 
   componentDidMount() {
     window.addEventListener('mouseup', this.mouseup);
-    const correspondingStagingStatus = this.props.stagingStatus === 'unstaged' ? 'staged' : 'unstaged';
-    this.disposables.add(
-      new Disposable(() => window.removeEventListener('mouseup', this.mouseup)),
-      this.props.tooltips.add(this.openFileButton, {title: 'Open file'}),
-    );
-
-    if (this.props.isPartiallyStaged) {
-      this.disposables.add(
-        this.props.tooltips.add(this.diveIntoCorrespondingButton, {
-          title: `View ${correspondingStagingStatus} changes`,
-        },
-      ));
-    }
+    this.disposables.add(new Disposable(() => window.removeEventListener('mouseup', this.mouseup)));
   }
 
   componentWillReceiveProps(nextProps) {
@@ -181,17 +170,23 @@ export default class FilePatchView extends React.Component {
           </button>
         ) : null}
         {this.props.isPartiallyStaged ? (
-          <button
-            className={cx('btn', 'icon', {'icon-tasklist': unstaged, 'icon-list-unordered': !unstaged})}
-            onClick={this.props.didDiveIntoCorrespondingFilePatch}
-            ref={e => { this.diveIntoCorrespondingButton = e; }}
-          />
+          <SimpleTooltip
+            tooltips={this.props.tooltips}
+            title={`View ${unstaged ? 'staged' : 'unstaged'} changes`}>
+            <button
+              className={cx('btn', 'icon', {'icon-tasklist': unstaged, 'icon-list-unordered': !unstaged})}
+              onClick={this.props.didDiveIntoCorrespondingFilePatch}
+            />
+          </SimpleTooltip>
         ) : null}
-        <button
-          className="btn icon icon-code"
-          onClick={this.openFile}
-          ref={e => { this.openFileButton = e; }}
-        />
+        <SimpleTooltip
+          tooltips={this.props.tooltips}
+          title="Open File">
+          <button
+            className="btn icon icon-code"
+            onClick={this.openFile}
+          />
+        </SimpleTooltip>
         <button
           className={cx('btn', 'icon', {'icon-move-down': unstaged, 'icon-move-up': !unstaged})}
           onClick={this.stageOrUnstageAll}>

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -180,7 +180,7 @@ export default class FilePatchView extends React.Component {
         <button
           className={cx('btn', 'icon', {'icon-move-down': unstaged, 'icon-move-up': !unstaged})}
           onClick={this.stageOrUnstageAll}>
-          {unstaged ? 'Stage All' : 'Unstage All'}
+          {unstaged ? 'Stage File' : 'Unstage File'}
         </button>
       </span>
     );

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -53,7 +53,11 @@ export default class FilePatchView extends React.Component {
     );
 
     if (this.props.isPartiallyStaged) {
-      this.disposables.add(this.props.tooltips.add(this.diveIntoCorrespondingButton, {title: `View ${correspondingStagingStatus} changes`}));
+      this.disposables.add(
+        this.props.tooltips.add(this.diveIntoCorrespondingButton, {
+          title: `View ${correspondingStagingStatus} changes`,
+        },
+      ));
     }
   }
 

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -13,6 +13,7 @@ import Switchboard from '../switchboard';
 export default class FilePatchView extends React.Component {
   static propTypes = {
     commandRegistry: PropTypes.object.isRequired,
+    tooltips: PropTypes.object.isRequired,
     filePath: PropTypes.string.isRequired,
     hunks: PropTypes.arrayOf(PropTypes.object).isRequired,
     stagingStatus: PropTypes.oneOf(['unstaged', 'staged']).isRequired,
@@ -45,7 +46,15 @@ export default class FilePatchView extends React.Component {
 
   componentDidMount() {
     window.addEventListener('mouseup', this.mouseup);
-    this.disposables.add(new Disposable(() => window.removeEventListener('mouseup', this.mouseup)));
+    const correspondingStagingStatus = this.props.stagingStatus === 'unstaged' ? 'staged' : 'unstaged';
+    this.disposables.add(
+      new Disposable(() => window.removeEventListener('mouseup', this.mouseup)),
+      this.props.tooltips.add(this.openFileButton, {title: 'Open file'}),
+    );
+
+    if (this.props.isPartiallyStaged) {
+      this.disposables.add(this.props.tooltips.add(this.diveIntoCorrespondingButton, {title: `View ${correspondingStagingStatus} changes`}));
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -171,11 +180,13 @@ export default class FilePatchView extends React.Component {
           <button
             className={cx('btn', 'icon', {'icon-tasklist': unstaged, 'icon-list-unordered': !unstaged})}
             onClick={this.props.didDiveIntoCorrespondingFilePatch}
+            ref={e => { this.diveIntoCorrespondingButton = e; }}
           />
         ) : null}
         <button
           className="btn icon icon-code"
           onClick={this.openFile}
+          ref={e => { this.openFileButton = e; }}
         />
         <button
           className={cx('btn', 'icon', {'icon-move-down': unstaged, 'icon-move-up': !unstaged})}

--- a/lib/views/simple-tooltip.js
+++ b/lib/views/simple-tooltip.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+
+export default class SimpleTooltip extends React.Component {
+  propTypes = {
+    tooltips: PropTypes.object.isRequired,
+    children: PropTypes.node.isRequired,
+    title: PropTypes.string.isRequired,
+  }
+
+  componentDidMount() {
+    this.disposable = this.props.tooltips.add(ReactDOM.findDOMNode(this.child), {title: () => this.props.title});
+  }
+
+  componentWillUnmount() {
+    this.disposable.dispose();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.title !== this.props.title) {
+      this.disposable.dispose();
+      this.disposable = this.props.tooltips.add(ReactDOM.findDOMNode(this.child), {title: () => this.props.title});
+    }
+  }
+
+  render() {
+    const child = React.Children.only(this.props.children);
+    return React.cloneElement(child, {ref: e => { this.child = e; }});
+  }
+}

--- a/test/controllers/file-patch-controller.test.js
+++ b/test/controllers/file-patch-controller.test.js
@@ -14,13 +14,14 @@ import ResolutionProgress from '../../lib/models/conflicts/resolution-progress';
 import Switchboard from '../../lib/switchboard';
 
 describe('FilePatchController', function() {
-  let atomEnv, commandRegistry;
+  let atomEnv, commandRegistry, tooltips;
   let component, switchboard;
   let discardLines, didSurfaceFile, didDiveIntoFilePath, quietlySelectItem, undoLastDiscard, openFiles;
 
   beforeEach(function() {
     atomEnv = global.buildAtomEnvironment();
     commandRegistry = atomEnv.commands;
+    tooltips = atomEnv.tooltips;
 
     switchboard = new Switchboard();
 
@@ -41,6 +42,7 @@ describe('FilePatchController', function() {
     component = (
       <FilePatchController
         commandRegistry={commandRegistry}
+        tooltips={tooltips}
         repository={repository}
         resolutionProgress={resolutionProgress}
         filePatch={filePatch}

--- a/test/views/file-patch-view.test.js
+++ b/test/views/file-patch-view.test.js
@@ -8,13 +8,14 @@ import HunkLine from '../../lib/models/hunk-line';
 import {assertEqualSets} from '../helpers';
 
 describe('FilePatchView', function() {
-  let atomEnv, commandRegistry, component;
+  let atomEnv, commandRegistry, tooltips, component;
   let attemptLineStageOperation, attemptHunkStageOperation, discardLines, undoLastDiscard, openCurrentFile;
   let didSurfaceFile, didDiveIntoCorrespondingFilePatch;
 
   beforeEach(function() {
     atomEnv = global.buildAtomEnvironment();
     commandRegistry = atomEnv.commands;
+    tooltips = atomEnv.tooltips;
 
     attemptLineStageOperation = sinon.spy();
     attemptHunkStageOperation = sinon.spy();
@@ -27,6 +28,7 @@ describe('FilePatchView', function() {
     component = (
       <FilePatchView
         commandRegistry={commandRegistry}
+        tooltips={tooltips}
         filePath="filename.js"
         hunks={[]}
         stagingStatus="unstaged"


### PR DESCRIPTION
Change "Stage/Unstage All" to "Stage/Unstage File" to differentiate from the "Stage/Unstage All buttons in the file list view. Additionally, add tooltips for icon-only buttons to improve discoverability.

<img width="708" alt="fullscreen_5_24_17__10_15_pm" src="https://cloud.githubusercontent.com/assets/7910250/26423770/2a9f646a-40cf-11e7-91d1-41f8e1b25592.png">

