### PR TITLE
Style diff selections

### DIFF
--- a/styles/hunk-view.less
+++ b/styles/hunk-view.less
@@ -77,6 +77,16 @@
 // States
 // -------------------------------
 
+.github-HunkView.is-selected.is-hunkMode .github-HunkView-header {
+  background-color: @background-color-selected;
+  .github-HunkView-title {
+    color: @text-color;
+  }
+  .github-HunkView-stageButton {
+    border-color: mix(@text-color, @background-color-selected, 25%);
+  }
+}
+
 .github-HunkView-title:hover {
   color: @text-color-highlight;
 }
@@ -87,6 +97,10 @@
   .hunk-line-mixin(@fg; @bg) {
     &:hover {
       background-color: @background-color-highlight;
+    }
+    &.is-selected {
+      color: @text-color;
+      background-color: @background-color-selected;
     }
     .github-HunkView-lineContent {
       color: saturate( mix(@fg, @text-color-highlight, 20%), 20%);


### PR DESCRIPTION
### Description of the Change

Adds a background color to selections in the diff-view.

![selection](https://cloud.githubusercontent.com/assets/378023/26441456/6c72fa2c-416b-11e7-8640-c8e2e8bc57c9.gif)

### Benefits

Let's you see what is selected even when the stage button eats the focus. Makes it consistent with the list selection/focus.

### Applicable Issues

Closes #649
