### PR TITLE
Stale branch picker

### DIFF
--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -85,6 +85,7 @@ export default class StatusBarTileController extends React.Component {
 
   render() {
     const repoProps = {
+      repository: this.props.repository,
       currentBranch: this.props.currentBranch,
       branches: this.props.branches,
       currentRemote: this.props.currentRemote,

--- a/lib/views/branch-menu-view.js
+++ b/lib/views/branch-menu-view.js
@@ -11,6 +11,7 @@ export default class BranchMenuView extends React.Component {
     workspace: PropTypes.object.isRequired,
     commandRegistry: PropTypes.object.isRequired,
     notificationManager: PropTypes.object.isRequired,
+    repository: PropTypes.object,
     branches: PropTypes.arrayOf(BranchPropType).isRequired,
     currentBranch: BranchPropType.isRequired,
     checkout: PropTypes.func,
@@ -27,6 +28,12 @@ export default class BranchMenuView extends React.Component {
       createNew: false,
       checkingOutBranch: null,
     };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.repository !== nextProps.repository) {
+      this.setState({checkingOutBranch: null});
+    }
   }
 
   render() {


### PR DESCRIPTION
If a branch is created or checked out with the branch picker, and then the active Repository is changed, the BranchMenuView was still showing the old `checkingOutBranch`. Clear out the component state on Repository change to read the right branch from the new active Repository instead.

Fixes #836.