### PR TITLE
Start-up behavior

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -56,14 +56,14 @@ export default class RootController extends React.Component {
     switchboard: PropTypes.instanceOf(Switchboard),
     savedState: PropTypes.object,
     useLegacyPanels: PropTypes.bool,
-    firstRun: React.PropTypes.bool,
+    startOpen: React.PropTypes.bool,
   }
 
   static defaultProps = {
     switchboard: new Switchboard(),
     savedState: {},
     useLegacyPanels: false,
-    firstRun: true,
+    startOpen: true,
   }
 
   serialize() {
@@ -80,8 +80,8 @@ export default class RootController extends React.Component {
     this.state = {
       ...nullFilePatchState,
       amending: false,
-      gitTabActive: props.firstRun || props.savedState.gitTabActive,
-      githubTabActive: props.firstRun || props.savedState.githubTabActive || props.savedState.githubPanelActive,
+      gitTabActive: props.startOpen || props.savedState.gitTabActive,
+      githubTabActive: props.startOpen || props.savedState.githubTabActive || props.savedState.githubPanelActive,
       panelSize: props.savedState.panelSize || 400,
       activeTab: props.savedState.activeTab || 0,
       cloneDialogActive: false,
@@ -184,7 +184,7 @@ export default class RootController extends React.Component {
           getItem={({subtree}) => subtree.getWrappedComponent()}
           onDidCloseItem={() => this.setState({gitTabActive: false})}
           stubItemSelector="git-tab-controller"
-          activate={this.props.firstRun}>
+          activate={this.props.startOpen}>
           <EtchWrapper
             ref={c => { this.gitTabController = c; }}
             className="github-PanelEtchWrapper"

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -6,7 +6,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import {autobind} from 'core-decorators';
 
-import {mkdirs} from './helpers';
+import {mkdirs, fileExists, writeFile} from './helpers';
 import WorkdirCache from './models/workdir-cache';
 import WorkdirContext from './models/workdir-context';
 import WorkdirContextPool from './models/workdir-context-pool';
@@ -29,7 +29,7 @@ const defaultState = {
 
 export default class GithubPackage {
   constructor(workspace, project, commandRegistry, notificationManager, tooltips, styles, config,
-      confirm, getLoadSettings) {
+      confirm, configDirPath, getLoadSettings) {
     this.workspace = workspace;
     this.project = project;
     this.commandRegistry = commandRegistry;
@@ -37,6 +37,7 @@ export default class GithubPackage {
     this.tooltips = tooltips;
     this.config = config;
     this.styles = styles;
+    this.configPath = path.join(configDirPath, 'github.cson');
 
     this.styleCalculator = new StyleCalculator(this.styles, this.config);
     this.confirm = confirm;
@@ -120,10 +121,14 @@ export default class GithubPackage {
     );
   }
 
-  activate(state = {}) {
+  async activate(state = {}) {
     this.savedState = {...defaultState, ...state};
-    this.startOpen = this.config.get('github.firstRun') && !this.config.get('welcome.showOnStartup');
-    this.config.set('github.firstRun', false);
+
+    const firstRun = !await fileExists(this.configPath);
+    this.startOpen = firstRun && !this.config.get('welcome.showOnStartup');
+    if (firstRun) {
+      await writeFile(this.configPath, '# Store non-visible GitHub package state.');
+    }
 
     if (!this.workspace.getLeftDock || this.config.get('github.useLegacyPanels')) {
       this.useLegacyPanels = true;

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -214,7 +214,7 @@ export default class GithubPackage {
         cloneRepositoryForProjectPath={this.cloneRepositoryForProjectPath}
         switchboard={this.switchboard}
         useLegacyPanels={this.useLegacyPanels}
-        firstRun={this.savedState.firstRun}
+        startOpen={this.startOpen}
       />, this.element, callback,
     );
   }

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -41,6 +41,7 @@ export default class GithubPackage {
     this.styleCalculator = new StyleCalculator(this.styles, this.config);
     this.confirm = confirm;
     this.useLegacyPanels = false;
+    this.startOpen = false;
 
     const criteria = {
       projectPathCount: this.project.getPaths().length,
@@ -121,6 +122,8 @@ export default class GithubPackage {
 
   activate(state = {}) {
     this.savedState = {...defaultState, ...state};
+    this.startOpen = this.config.get('github.firstRun') && !this.config.get('welcome.showOnStartup');
+    this.config.set('github.firstRun', false);
 
     if (!this.workspace.getLeftDock || this.config.get('github.useLegacyPanels')) {
       this.useLegacyPanels = true;

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,8 @@ const entry = {
   initialize() {
     pack = new GithubPackage(
       atom.workspace, atom.project, atom.commands, atom.notifications, atom.tooltips,
-      atom.styles, atom.config, atom.confirm.bind(atom), atom.getLoadSettings.bind(atom),
+      atom.styles, atom.config, atom.confirm.bind(atom), atom.getConfigDirPath(),
+      atom.getLoadSettings.bind(atom),
     );
   },
 };

--- a/package.json
+++ b/package.json
@@ -145,6 +145,12 @@
       "type": "boolean",
       "default": false,
       "description": "Capture CPU profiles"
+    },
+    "firstRun": {
+      "type": "boolean",
+      "default": true,
+      "description": "Display the Git and GitHub tabs on Atom launch. Reverts to false on each launch.",
+      "hidden": true
     }
   },
   "deserializers": {

--- a/package.json
+++ b/package.json
@@ -145,12 +145,6 @@
       "type": "boolean",
       "default": false,
       "description": "Capture CPU profiles"
-    },
-    "firstRun": {
-      "type": "boolean",
-      "default": true,
-      "description": "Display the Git and GitHub tabs on Atom launch. Reverts to false on each launch.",
-      "hidden": true
     }
   },
   "deserializers": {

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -48,7 +48,7 @@ import RootController from '../../lib/controllers/root-controller';
           repository={absentRepository}
           resolutionProgress={emptyResolutionProgress}
           useLegacyPanels={useLegacyPanels || !workspace.getLeftDock}
-          firstRun={false}
+          startOpen={false}
         />
       );
     });
@@ -78,11 +78,11 @@ import RootController from '../../lib/controllers/root-controller';
         assert.isTrue(isGitPaneDisplayed(wrapper));
       });
 
-      it('is always visible when the firstRun prop is true', async function() {
+      it('is always visible when the startOpen prop is true', async function() {
         const workdirPath = await cloneRepository('multiple-commits');
         const repository = await buildRepository(workdirPath);
 
-        app = React.cloneElement(app, {repository, firstRun: true});
+        app = React.cloneElement(app, {repository, startOpen: true});
         const wrapper = shallow(app);
 
         assert.isTrue(isGitPaneDisplayed(wrapper));

--- a/test/fixtures/atomenv-config/.gitignore
+++ b/test/fixtures/atomenv-config/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -66,7 +66,8 @@ describe('GithubPackage', function() {
       const getLoadSettings1 = () => ({initialPaths});
 
       githubPackage1 = new GithubPackage(
-        workspace, project, commandRegistry, notificationManager, tooltips, styles, config, confirm, getLoadSettings1,
+        workspace, project, commandRegistry, notificationManager, tooltips, styles, config, confirm,
+        configDirPath, getLoadSettings1,
       );
     }
 

--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -42,9 +42,9 @@ describe('GithubPackage', function() {
     atomEnv.destroy();
   });
 
-  function contextUpdateAfter(chunk) {
+  async function contextUpdateAfter(chunk) {
     const updatePromise = githubPackage.getSwitchboard().getFinishActiveContextUpdatePromise();
-    chunk();
+    await chunk();
     return updatePromise;
   }
 

--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -183,7 +183,6 @@ describe('GithubPackage', function() {
 
       await contextUpdateAfter(() => githubPackage.activate({
         activeRepositoryPath: workdirPath2,
-        firstRun: false,
       }));
 
       const context = contextPool.getContext(workdirPath2);

--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -272,6 +272,33 @@ describe('GithubPackage', function() {
       assert.isFalse(githubPackage.getActiveResolutionProgress().isEmpty());
       assert.equal(githubPackage.getActiveResolutionProgress().getRemaining('modified-on-both-ours.txt'), 3);
     });
+
+    describe('startOpen', function() {
+      it('renders with startOpen on the first run', function() {
+        config.set('github.firstRun', true);
+        config.set('welcome.showOnStartup', false);
+        githubPackage.activate();
+
+        assert.isTrue(githubPackage.startOpen);
+        assert.isFalse(config.get('github.firstRun'));
+      });
+
+      it('renders without startOpen on non-first runs', function() {
+        config.set('github.firstRun', false);
+        githubPackage.activate();
+
+        assert.isFalse(githubPackage.startOpen);
+      });
+
+      it('renders without startOpen on the first run if the welcome pane is shown', function() {
+        config.set('github.firstRun', true);
+        config.set('welcome.showOnStartup', true);
+        githubPackage.activate();
+
+        assert.isFalse(githubPackage.startOpen);
+        assert.isFalse(config.get('github.firstRun'));
+      });
+    });
   });
 
   describe('when the project paths change', function() {

--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -4,12 +4,12 @@ import temp from 'temp';
 import until from 'test-until';
 
 import {cloneRepository} from './helpers';
-import {writeFile, getTempDir} from '../lib/helpers';
+import {writeFile, deleteFileOrFolder, fileExists, getTempDir} from '../lib/helpers';
 import GithubPackage from '../lib/github-package';
 
 describe('GithubPackage', function() {
   let atomEnv, workspace, project, commandRegistry, notificationManager, config, confirm, tooltips, styles;
-  let getLoadSettings;
+  let getLoadSettings, configDirPath;
   let githubPackage, contextPool;
 
   beforeEach(function() {
@@ -23,9 +23,11 @@ describe('GithubPackage', function() {
     confirm = atomEnv.confirm.bind(atomEnv);
     styles = atomEnv.styles;
     getLoadSettings = atomEnv.getLoadSettings.bind(atomEnv);
+    configDirPath = path.join(__dirname, 'fixtures', 'atomenv-config');
 
     githubPackage = new GithubPackage(
-      workspace, project, commandRegistry, notificationManager, tooltips, styles, config, confirm, getLoadSettings,
+      workspace, project, commandRegistry, notificationManager, tooltips, styles, config, confirm,
+      configDirPath, getLoadSettings,
     );
 
     sinon.stub(githubPackage, 'rerender').callsFake(callback => {
@@ -273,29 +275,35 @@ describe('GithubPackage', function() {
     });
 
     describe('startOpen', function() {
-      it('renders with startOpen on the first run', function() {
-        config.set('github.firstRun', true);
+      let confFile;
+
+      beforeEach(async function() {
+        confFile = path.join(configDirPath, 'github.cson');
+        await deleteFileOrFolder(confFile);
+      });
+
+      it('renders with startOpen on the first run', async function() {
         config.set('welcome.showOnStartup', false);
-        githubPackage.activate();
+        await githubPackage.activate();
 
         assert.isTrue(githubPackage.startOpen);
-        assert.isFalse(config.get('github.firstRun'));
+        assert.isTrue(await fileExists(confFile));
       });
 
-      it('renders without startOpen on non-first runs', function() {
-        config.set('github.firstRun', false);
-        githubPackage.activate();
+      it('renders without startOpen on non-first runs', async function() {
+        await writeFile(confFile, '');
+        await githubPackage.activate();
 
         assert.isFalse(githubPackage.startOpen);
+        assert.isTrue(await fileExists(confFile));
       });
 
-      it('renders without startOpen on the first run if the welcome pane is shown', function() {
-        config.set('github.firstRun', true);
+      it('renders without startOpen on the first run if the welcome pane is shown', async function() {
         config.set('welcome.showOnStartup', true);
-        githubPackage.activate();
+        await githubPackage.activate();
 
         assert.isFalse(githubPackage.startOpen);
-        assert.isFalse(config.get('github.firstRun'));
+        assert.isTrue(await fileExists(confFile));
       });
     });
   });


### PR DESCRIPTION
This implements the proposed startup behavior described in #872.

* If this is the first Atom launch with the github package installed, but the Welcome pane will be shown, start _closed_. atom/welcome#62 will make it redundant in any case.
* If this is the first Atom launch and the Welcome pane is not shown, start _open_.
* If this is not the first Atom launch, start _closed_.

Uses an (empty except for a comment, right now) flag file called `~/.atom/github.cson` to detect prior runs.