### PR TITLE
Show committer avatar as well as author in the PR commit view

### DIFF
--- a/lib/containers/timeline-items/commit-container.js
+++ b/lib/containers/timeline-items/commit-container.js
@@ -9,16 +9,33 @@ export class Commit extends React.Component {
     item: PropTypes.object.isRequired,
   }
 
+  authoredByCommitter(commit) {
+    if (commit.authoredByCommitter) {
+      return true;
+    }
+    // If you commit on GitHub online the committer details would be:
+    //
+    //    name: "GitHub"
+    //    email: "noreply@github.com"
+    //
+    // Do we need to compare the name too ?
+    if (commit.committer.email === 'noreply@github.com') {
+      return true;
+    }
+    return false;
+  }
+
   renderCommitter(commit) {
-    if (!commit.authoredByCommitter) {
+    if (!this.authoredByCommitter(commit)) {
       return (
         <img
           className="author-avatar" src={commit.committer.avatarUrl}
           title={commit.committer.user ? commit.committer.user.login : commit.committer.name}
         />
       );
+    } else {
+      return null;
     }
-    return null;
   }
   render() {
     const commit = this.props.item;

--- a/lib/containers/timeline-items/commit-container.js
+++ b/lib/containers/timeline-items/commit-container.js
@@ -42,11 +42,13 @@ export class Commit extends React.Component {
     return (
       <div className="commit">
         <Octicon className="pre-timeline-item-icon" icon="git-commit" />
-        <img
-          className="author-avatar" src={commit.author.avatarUrl}
-          title={commit.author.user ? commit.author.user.login : commit.author.name}
-        />
-        {this.renderCommitter(commit)}
+        <span className="commit-author">
+          <img
+            className="author-avatar" src={commit.author.avatarUrl}
+            title={commit.author.user ? commit.author.user.login : commit.author.name}
+          />
+          {this.renderCommitter(commit)}
+        </span>
         <span
           className="commit-message-headline"
           title={commit.messageHeadline}

--- a/lib/containers/timeline-items/commit-container.js
+++ b/lib/containers/timeline-items/commit-container.js
@@ -17,11 +17,15 @@ export class Commit extends React.Component {
     //
     //    name: "GitHub"
     //    email: "noreply@github.com"
+    //    user: null
     //
-    // Do we need to compare the name too ?
     if (commit.committer.email === 'noreply@github.com') {
       return true;
     }
+    if (commit.committer.name === 'GitHub' && commit.committer.user === null) {
+      return true;
+    }
+
     return false;
   }
 

--- a/lib/containers/timeline-items/commit-container.js
+++ b/lib/containers/timeline-items/commit-container.js
@@ -9,6 +9,17 @@ export class Commit extends React.Component {
     item: PropTypes.object.isRequired,
   }
 
+  renderCommitter(commit) {
+    if (!commit.authoredByCommitter) {
+      return (
+        <img
+          className="author-avatar" src={commit.committer.avatarUrl}
+          title={commit.committer.user ? commit.committer.user.login : commit.committer.name}
+        />
+      );
+    }
+    return null;
+  }
   render() {
     const commit = this.props.item;
     return (
@@ -18,6 +29,7 @@ export class Commit extends React.Component {
           className="author-avatar" src={commit.author.avatarUrl}
           title={commit.author.user ? commit.author.user.login : commit.author.name}
         />
+        {this.renderCommitter(commit)}
         <span
           className="commit-message-headline"
           title={commit.messageHeadline}
@@ -39,6 +51,13 @@ export default Relay.createContainer(Commit, {
             login
           }
         }
+        committer {
+          name avatarUrl
+          user {
+            login
+          }
+        }
+        authoredByCommitter
         oid messageHeadline messageHeadlineHTML
       }
     `,

--- a/styles/pr-timeline.less
+++ b/styles/pr-timeline.less
@@ -33,7 +33,7 @@
   }
 
   .commit {
-    display: flex;
+    display: table-row;
     align-items: center;
     padding: 0 @component-padding;
     margin-left: @component-padding * 2;
@@ -53,13 +53,19 @@
       margin-top: @component-padding/2;
     }
 
+    .commit-author {
+      display: table-cell;
+      white-space: nowrap;
+      text-align: right;
+    }
+
     .author-avatar {
       flex-basis: @avatar-size;
     }
 
     .commit-message-headline {
+      display: table-cell;
       font-size: .9em;
-      flex: 1;
       max-height: @avatar-size;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -67,9 +73,10 @@
     }
 
     .commit-sha {
+      display: table-cell;
       text-align: right;
       font-family: monospace;
-      margin-left: 5px;
+      padding-left: 5px;
       font-size: .85em;
       color: @text-color-subtle;
     }

--- a/styles/pr-timeline.less
+++ b/styles/pr-timeline.less
@@ -68,6 +68,7 @@
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
+      max-width: 0; // this makes sure the ellipsis work in table-cell
       width: 100%;
     }
 

--- a/styles/pr-timeline.less
+++ b/styles/pr-timeline.less
@@ -35,9 +35,7 @@
   .commit {
     display: table-row;
     align-items: center;
-    padding: 0 @component-padding;
     margin-left: @component-padding * 2;
-    padding-bottom: @component-padding * 0.66;
 
     &:first-child {
       padding-top: @component-padding;

--- a/styles/pr-timeline.less
+++ b/styles/pr-timeline.less
@@ -13,6 +13,12 @@
     border-bottom: 1px solid mix(@text-color, @base-background-color, 15%);
   }
 
+  .emoji,
+  g-emoji {
+    margin-right: .25em;
+  }
+
+
   .author-avatar {
     width: @avatar-size;
     height: @avatar-size;

--- a/styles/pr-timeline.less
+++ b/styles/pr-timeline.less
@@ -64,6 +64,7 @@
     .commit-message-headline {
       display: table-cell;
       font-size: .9em;
+      padding: 0 @component-padding/3;
       max-height: @avatar-size;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/styles/pr-timeline.less
+++ b/styles/pr-timeline.less
@@ -68,6 +68,7 @@
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
+      width: 100%;
     }
 
     .commit-sha {

--- a/test/containers/commit-container.test.js
+++ b/test/containers/commit-container.test.js
@@ -9,26 +9,26 @@ describe('CommitContainer', function() {
       author: {
         name: 'author_name', avatarUrl: '',
         user: {
-          login: 'author_login'
-        }
+          login: 'author_login',
+        },
       },
       committer: {
         name: 'committer_name', avatarUrl: '',
         user: {
-          login: 'committer_login'
-        }
+          login: 'committer_login',
+        },
       },
-      oid: 'ff22',
+      oid: 'e6c80aa37dc6f7a5e5491e0ed6e00ec2c812b1a5',
       message: 'commit message',
       messageHeadlineHTML: '<h1>html</h1>',
     };
     const app = <Commit item={item} />;
     const instance = shallow(app);
     assert.isTrue(
-      instance.containsMatchingElement(<img title='author_login' />)
+      instance.containsMatchingElement(<img title="author_login" />),
     );
     assert.isTrue(
-      instance.containsMatchingElement(<img title='committer_login' />)
+      instance.containsMatchingElement(<img title="committer_login" />),
     );
   });
 
@@ -42,7 +42,7 @@ describe('CommitContainer', function() {
         name: 'committer_name', avatarUrl: '',
         user: null,
       },
-      oid: 'ff22',
+      oid: 'e6c80aa37dc6f7a5e5491e0ed6e00ec2c812b1a5',
       authoredByCommitter: false,
       message: 'commit message',
       messageHeadlineHTML: '<h1>html</h1>',
@@ -50,14 +50,14 @@ describe('CommitContainer', function() {
     const app = <Commit item={item} />;
     const instance = shallow(app);
     assert.isTrue(
-      instance.containsMatchingElement(<img title='author_name' />)
+      instance.containsMatchingElement(<img title="author_name" />),
     );
     assert.isTrue(
-      instance.containsMatchingElement(<img title='committer_name' />)
+      instance.containsMatchingElement(<img title="committer_name" />),
     );
   });
 
-  it('ignores committer when it authored by the same person', function(){
+  it('ignores committer when it authored by the same person', function() {
     const item = {
       author: {
         name: 'author_name', avatarUrl: '',
@@ -69,7 +69,7 @@ describe('CommitContainer', function() {
         name: 'author_name', avatarUrl: '',
         user: null,
       },
-      oid: 'ff22',
+      oid: 'e6c80aa37dc6f7a5e5491e0ed6e00ec2c812b1a5',
       authoredByCommitter: true,
       message: 'commit message',
       messageHeadlineHTML: '<h1>html</h1>',
@@ -77,14 +77,14 @@ describe('CommitContainer', function() {
     const app = <Commit item={item} />;
     const instance = shallow(app);
     assert.isTrue(
-      instance.containsMatchingElement(<img title='author_login' />)
+      instance.containsMatchingElement(<img title="author_login" />),
     );
     assert.isFalse(
-      instance.containsMatchingElement(<img title='committer_name' />)
+      instance.containsMatchingElement(<img title="committer_name" />),
     );
   });
 
-  it('ignores committer when it authored by GitHub', function(){
+  it('ignores committer when it authored by GitHub', function() {
     const item = {
       author: {
         name: 'author_name', avatarUrl: '',
@@ -96,7 +96,7 @@ describe('CommitContainer', function() {
         name: 'GitHub', avatarUrl: '',
         user: null,
       },
-      oid: 'ff22',
+      oid: 'e6c80aa37dc6f7a5e5491e0ed6e00ec2c812b1a5',
       authoredByCommitter: false,
       message: 'commit message',
       messageHeadlineHTML: '<h1>html</h1>',
@@ -104,14 +104,43 @@ describe('CommitContainer', function() {
     const app = <Commit item={item} />;
     const instance = shallow(app);
     assert.isTrue(
-      instance.containsMatchingElement(<img title='author_login' />)
+      instance.containsMatchingElement(<img title="author_login" />),
     );
     assert.isFalse(
-      instance.containsMatchingElement(<img title='GitHub' />)
+      instance.containsMatchingElement(<img title="GitHub" />),
     );
   });
 
-  it('shows the full commit message as tooltip', function(){
+  it('renders avatar URLs', function() {
+    const item = {
+      author: {
+        name: 'author_name', avatarUrl: 'URL1',
+        user: {
+          login: 'author_login',
+        },
+      },
+      committer: {
+        name: 'GitHub', avatarUrl: 'URL2',
+        user: {
+          login: 'committer_login',
+        },
+      },
+      oid: 'e6c80aa37dc6f7a5e5491e0ed6e00ec2c812b1a5',
+      authoredByCommitter: false,
+      message: 'commit message',
+      messageHeadlineHTML: '<h1>html</h1>',
+    };
+    const app = <Commit item={item} />;
+    const instance = shallow(app);
+    assert.isTrue(
+      instance.containsMatchingElement(<img src="URL1" />),
+    );
+    assert.isTrue(
+      instance.containsMatchingElement(<img src="URL2" />),
+    );
+  });
+
+  it('shows the full commit message as tooltip', function() {
     const item = {
       author: {
         name: 'author_name', avatarUrl: '',
@@ -123,7 +152,7 @@ describe('CommitContainer', function() {
         name: 'author_name', avatarUrl: '',
         user: null,
       },
-      oid: 'ff22',
+      oid: 'e6c80aa37dc6f7a5e5491e0ed6e00ec2c812b1a5',
       authoredByCommitter: true,
       message: 'full message',
       messageHeadlineHTML: '<h1>html</h1>',
@@ -131,11 +160,11 @@ describe('CommitContainer', function() {
     const app = <Commit item={item} />;
     const instance = shallow(app);
     assert.isTrue(
-      instance.containsMatchingElement(<span title='full message' />)
+      instance.containsMatchingElement(<span title="full message" />),
     );
   });
 
-  it('renders commit message headline', function(){
+  it('renders commit message headline', function() {
     const item = {
       author: {
         name: 'author_name', avatarUrl: '',
@@ -147,7 +176,7 @@ describe('CommitContainer', function() {
         name: 'author_name', avatarUrl: '',
         user: null,
       },
-      oid: 'ff22',
+      oid: 'e6c80aa37dc6f7a5e5491e0ed6e00ec2c812b1a5',
       authoredByCommitter: true,
       message: 'full message',
       messageHeadlineHTML: '<h1>inner HTML</h1>',
@@ -157,4 +186,25 @@ describe('CommitContainer', function() {
     assert.match(instance.html(), /<h1>inner HTML<\/h1>/);
   });
 
+  it('renders commit sha', function() {
+    const item = {
+      author: {
+        name: 'author_name', avatarUrl: '',
+        user: {
+          login: 'author_login',
+        },
+      },
+      committer: {
+        name: 'author_name', avatarUrl: '',
+        user: null,
+      },
+      oid: 'e6c80aa37dc6f7a5e5491e0ed6e00ec2c812b1a5',
+      authoredByCommitter: true,
+      message: 'full message',
+      messageHeadlineHTML: '<h1>inner HTML</h1>',
+    };
+    const app = <Commit item={item} />;
+    const instance = shallow(app);
+    assert.match(instance.text(), /e6c80aa3/);
+  });
 });

--- a/test/containers/commit-container.test.js
+++ b/test/containers/commit-container.test.js
@@ -1,0 +1,160 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {Commit} from '../../lib/containers/timeline-items/commit-container';
+
+describe('CommitContainer', function() {
+  it('prefers displaying usernames from `user.login`', function() {
+    const item = {
+      author: {
+        name: 'author_name', avatarUrl: '',
+        user: {
+          login: 'author_login'
+        }
+      },
+      committer: {
+        name: 'committer_name', avatarUrl: '',
+        user: {
+          login: 'committer_login'
+        }
+      },
+      oid: 'ff22',
+      message: 'commit message',
+      messageHeadlineHTML: '<h1>html</h1>',
+    };
+    const app = <Commit item={item} />;
+    const instance = shallow(app);
+    assert.isTrue(
+      instance.containsMatchingElement(<img title='author_login' />)
+    );
+    assert.isTrue(
+      instance.containsMatchingElement(<img title='committer_login' />)
+    );
+  });
+
+  it('displays the names if the are no usernames ', function() {
+    const item = {
+      author: {
+        name: 'author_name', avatarUrl: '',
+        user: null,
+      },
+      committer: {
+        name: 'committer_name', avatarUrl: '',
+        user: null,
+      },
+      oid: 'ff22',
+      authoredByCommitter: false,
+      message: 'commit message',
+      messageHeadlineHTML: '<h1>html</h1>',
+    };
+    const app = <Commit item={item} />;
+    const instance = shallow(app);
+    assert.isTrue(
+      instance.containsMatchingElement(<img title='author_name' />)
+    );
+    assert.isTrue(
+      instance.containsMatchingElement(<img title='committer_name' />)
+    );
+  });
+
+  it('ignores committer when it authored by the same person', function(){
+    const item = {
+      author: {
+        name: 'author_name', avatarUrl: '',
+        user: {
+          login: 'author_login',
+        },
+      },
+      committer: {
+        name: 'author_name', avatarUrl: '',
+        user: null,
+      },
+      oid: 'ff22',
+      authoredByCommitter: true,
+      message: 'commit message',
+      messageHeadlineHTML: '<h1>html</h1>',
+    };
+    const app = <Commit item={item} />;
+    const instance = shallow(app);
+    assert.isTrue(
+      instance.containsMatchingElement(<img title='author_login' />)
+    );
+    assert.isFalse(
+      instance.containsMatchingElement(<img title='committer_name' />)
+    );
+  });
+
+  it('ignores committer when it authored by GitHub', function(){
+    const item = {
+      author: {
+        name: 'author_name', avatarUrl: '',
+        user: {
+          login: 'author_login',
+        },
+      },
+      committer: {
+        name: 'GitHub', avatarUrl: '',
+        user: null,
+      },
+      oid: 'ff22',
+      authoredByCommitter: false,
+      message: 'commit message',
+      messageHeadlineHTML: '<h1>html</h1>',
+    };
+    const app = <Commit item={item} />;
+    const instance = shallow(app);
+    assert.isTrue(
+      instance.containsMatchingElement(<img title='author_login' />)
+    );
+    assert.isFalse(
+      instance.containsMatchingElement(<img title='GitHub' />)
+    );
+  });
+
+  it('shows the full commit message as tooltip', function(){
+    const item = {
+      author: {
+        name: 'author_name', avatarUrl: '',
+        user: {
+          login: 'author_login',
+        },
+      },
+      committer: {
+        name: 'author_name', avatarUrl: '',
+        user: null,
+      },
+      oid: 'ff22',
+      authoredByCommitter: true,
+      message: 'full message',
+      messageHeadlineHTML: '<h1>html</h1>',
+    };
+    const app = <Commit item={item} />;
+    const instance = shallow(app);
+    assert.isTrue(
+      instance.containsMatchingElement(<span title='full message' />)
+    );
+  });
+
+  it('renders commit message headline', function(){
+    const item = {
+      author: {
+        name: 'author_name', avatarUrl: '',
+        user: {
+          login: 'author_login',
+        },
+      },
+      committer: {
+        name: 'author_name', avatarUrl: '',
+        user: null,
+      },
+      oid: 'ff22',
+      authoredByCommitter: true,
+      message: 'full message',
+      messageHeadlineHTML: '<h1>inner HTML</h1>',
+    };
+    const app = <Commit item={item} />;
+    const instance = shallow(app);
+    assert.match(instance.html(), /<h1>inner HTML<\/h1>/);
+  });
+
+});

--- a/test/containers/commits-container.test.js
+++ b/test/containers/commits-container.test.js
@@ -35,7 +35,7 @@ describe('CommitsContainer', function() {
     assert.match(instance.text(), /FirstLogin, SecondLogin, and others added/);
   });
 
-  it('perefers displaying usernames from user.login', function() {
+  it('prefers displaying usernames from user.login', function() {
     const nodes = [
       {id: 1, author: {name: 'FirstName', user: {login: 'FirstLogin'}}},
       {id: 2, author: {name: 'SecondName', user: null}},


### PR DESCRIPTION
Fixes #774 

**Todo list**

- [x] Retrieve committer info 
- [x] Show committer's avatar in the commit view
- [x] Fix design (e.g. pull avatars to the right as [GitHub](https://cloud.githubusercontent.com/assets/189606/25895776/a5eb61cc-3581-11e7-9007-ae6c4530ea5f.png) does)
- [x] Add tests

