### PR TITLE
Allow user to discard all changes and fix context menus

### DIFF
--- a/lib/views/hunk-view.js
+++ b/lib/views/hunk-view.js
@@ -54,7 +54,7 @@ export default class HunkView extends React.Component {
               tooltips={this.props.tooltips}
               title={this.props.discardButtonLabel}>
               <button
-                className="icon-flame github-HunkView-discardButton"
+                className="icon-trashcan github-HunkView-discardButton"
                 onClick={this.props.didClickDiscardButton}
                 onMouseDown={event => event.stopPropagation()}
               />

--- a/lib/views/merge-conflict-list-item-view.js
+++ b/lib/views/merge-conflict-list-item-view.js
@@ -25,7 +25,7 @@ export default class FilePatchListItemView {
     const className = selected ? 'is-selected' : '';
 
     return (
-      <div {...others} className={`is-${fileStatus} ${className}`}>
+      <div {...others} className={`github-MergeConflictListView-item is-${fileStatus} ${className}`}>
         <div className="github-FilePatchListView-item github-FilePatchListView-pathItem">
           <span className={`github-FilePatchListView-icon icon icon-diff-${fileStatus} status-${fileStatus}`} />
           <span className="github-FilePatchListView-path">{mergeConflict.filePath}</span>

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -91,9 +91,9 @@ export default class StagingView {
       'core:undo': () => this.props.hasUndoHistory && this.undoLastDiscard(),
     }));
     this.subscriptions.add(this.props.commandRegistry.add('atom-workspace', {
-      'github:stage-all': () => this.stageAll(),
-      'github:unstage-all': () => this.unstageAll(),
-      'github:discard-all': () => this.discardAll(),
+      'github:stage-all-changes': () => this.stageAll(),
+      'github:unstage-all-changes': () => this.unstageAll(),
+      'github:discard-all-changes': () => this.discardAll(),
       'github:undo-last-discard-in-git-tab': () => this.props.hasUndoHistory && this.undoLastDiscard(),
     }));
     this.subscriptions.add(this.props.commandRegistry.add(this.refs.unstagedChanges, {

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -418,7 +418,7 @@ export default class StagingView {
           <header className="github-StagingView-header">
             <span className="icon icon-list-unordered" />
             <span className="github-StagingView-title">Unstaged Changes</span>
-            {this.props.unstagedChanges.length ? this.renderStageAllAndDiscardButtons() : null}
+            {this.props.unstagedChanges.length ? this.renderStageAllButton() : null}
           </header>
           {this.props.hasUndoHistory ? this.renderUndoButton() : null}
 
@@ -536,20 +536,11 @@ export default class StagingView {
   }
 
   @autobind
-  renderStageAllAndDiscardButtons() {
+  renderStageAllButton() {
     return (
-      <div>
-        <button
-          className="github-StagingView-headerButton icon icon-flame"
-          onClick={this.discardAll}>
-          Discard All
-        </button>
-        <button
-          className="github-StagingView-headerButton icon icon-move-down"
-          onclick={this.stageAll}>
-          Stage All
-        </button>
-      </div>
+      <button
+        className="github-StagingView-headerButton icon icon-move-down"
+        onclick={this.stageAll}>Stage All</button>
     );
   }
 

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -93,6 +93,7 @@ export default class StagingView {
     this.subscriptions.add(this.props.commandRegistry.add('atom-workspace', {
       'github:stage-all': () => this.stageAll(),
       'github:unstage-all': () => this.unstageAll(),
+      'github:discard-all': () => this.discardAll(),
       'github:undo-last-discard-in-git-tab': () => this.props.hasUndoHistory && this.undoLastDiscard(),
     }));
     this.subscriptions.add(this.props.commandRegistry.add(this.refs.unstagedChanges, {
@@ -206,6 +207,13 @@ export default class StagingView {
     if (this.props.mergeConflicts.length === 0) { return null; }
     const filePaths = this.props.mergeConflicts.map(conflict => conflict.filePath);
     return this.props.attemptFileStageOperation(filePaths, 'unstaged');
+  }
+
+  @autobind
+  discardAll() {
+    if (this.props.unstagedChanges.length === 0) { return null; }
+    const filePaths = this.props.unstagedChanges.map(filePatch => filePatch.filePath);
+    return this.props.discardWorkDirChangesForPaths(filePaths);
   }
 
   confirmSelectedItems() {
@@ -410,7 +418,7 @@ export default class StagingView {
           <header className="github-StagingView-header">
             <span className="icon icon-list-unordered" />
             <span className="github-StagingView-title">Unstaged Changes</span>
-            {this.props.unstagedChanges.length ? this.renderStageAllButton() : null}
+            {this.props.unstagedChanges.length ? this.renderStageAllAndDiscardButtons() : null}
           </header>
           {this.props.hasUndoHistory ? this.renderUndoButton() : null}
 
@@ -527,10 +535,21 @@ export default class StagingView {
     }
   }
 
-  renderStageAllButton() {
+  @autobind
+  renderStageAllAndDiscardButtons() {
     return (
-      <button className="github-StagingView-headerButton icon icon-move-down"
-        onclick={this.stageAll}>Stage All</button>
+      <div>
+        <button
+          className="github-StagingView-headerButton icon icon-flame"
+          onClick={this.discardAll}>
+          Discard All
+        </button>
+        <button
+          className="github-StagingView-headerButton icon icon-move-down"
+          onclick={this.stageAll}>
+          Stage All
+        </button>
+      </div>
     );
   }
 

--- a/menus/git.cson
+++ b/menus/git.cson
@@ -115,20 +115,20 @@
   ]
   '.github-UnstagedChanges .github-StagingView-header': [
     {
-      'label': 'Stage All'
-      'command': 'github:stage-all'
+      'label': 'Stage All Changes'
+      'command': 'github:stage-all-changes'
     }
     {
       'type': 'separator'
     }
     {
-      'label': 'Discard All'
-      'command': 'github:discard-all'
+      'label': 'Discard All Changes'
+      'command': 'github:discard-all-changes'
     }
   ]
   '.github-StagedChanges .github-StagingView-header': [
     {
-      'label': 'Unstage All'
-      'command': 'github:unstage-all'
+      'label': 'Unstage All Changes'
+      'command': 'github:unstage-all-changes'
     }
   ]

--- a/menus/git.cson
+++ b/menus/git.cson
@@ -113,3 +113,22 @@
       'command': 'github:open-link-in-browser'
     }
   ]
+  '.github-UnstagedChanges .github-StagingView-header': [
+    {
+      'label': 'Stage All'
+      'command': 'github:stage-all'
+    }
+    {
+      'type': 'separator'
+    }
+    {
+      'label': 'Discard All'
+      'command': 'github:discard-all'
+    }
+  ]
+  '.github-StagedChanges .github-StagingView-header': [
+    {
+      'label': 'Unstage All'
+      'command': 'github:unstage-all'
+    }
+  ]

--- a/menus/git.cson
+++ b/menus/git.cson
@@ -38,7 +38,7 @@
       'command': 'github:open-file'
     }
   ]
-  '.github-UnstagedChanges .github-FilePatchListView': [
+  '.github-UnstagedChanges .github-FilePatchListView .github-FilePatchListView-item': [
     {
       'label': 'Stage'
       'command': 'core:confirm'
@@ -51,13 +51,13 @@
       'command': 'github:discard-changes-in-selected-files'
     }
   ]
-  '.github-StagedChanges .github-FilePatchListView': [
+  '.github-StagedChanges .github-FilePatchListView .github-FilePatchListView-item': [
     {
       'label': 'Unstage'
       'command': 'core:confirm'
     }
   ]
-  '.github-MergeConflictPaths .github-FilePatchListView': [
+  '.github-MergeConflictPaths .github-FilePatchListView .github-MergeConflictListView-item': [
     {
       'label': 'Stage'
       'command': 'core:confirm'

--- a/styles/hunk-view.less
+++ b/styles/hunk-view.less
@@ -30,6 +30,8 @@
   &-stageButton,
   &-discardButton {
     line-height: 1;
+    padding-left: @component-padding;
+    padding-right: @component-padding;
     font-family: @font-family;
     border: none;
     border-left: 1px solid @panel-heading-border-color;
@@ -37,6 +39,12 @@
     cursor: default;
     &:hover  { background-color: @button-background-color-hover; }
     &:active { background-color: @panel-heading-border-color; }
+  }
+
+  // pixel fit the icon
+  &-discardButton:before {
+    text-align: left;
+    width: auto;
   }
 
   &-line {


### PR DESCRIPTION
Fixes #611
Fixes #751 

* ~~Adds a 'Discard All' button in Unstaged Changes list header (does this take up too much space? should we just use an icon? or remove and have users to use command or context menu)~~
* Adds command 'github:discard-all-changes' to the workspace
* Adds context-menu items for Unstaged/Staged Changes list headers
  * Unstaged Changes: 'Discard All Changes' and 'Stage All Changes'
  * Staged Changes: 'Unstage All Changes'
* Makes it so that context-menu items in list show appear only when an item is right-clicked (not just empty space)