### PR TITLE
Open diff from editor

### DIFF
--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -267,6 +267,10 @@ export default class FilePatchController extends React.Component {
     return this.props.repository.hasDiscardHistory(this.props.filePatch.getPath());
   }
 
+  goToDiffLine(lineNumber) {
+    return this.filePatchView.goToDiffLine(lineNumber);
+  }
+
   /**
    * Used to detect the context when this PaneItem is active
    */

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -273,13 +273,15 @@ export default class GitTabController {
   @autobind
   viewUnstagedChangesForCurrentFile() {
     const editor = this.props.workspace.getActiveTextEditor();
-    const lineNumber = editor.getCursorBufferPosition().row;
     const absFilePath = editor.getPath();
     const repoPath = this.getActiveRepository().getWorkingDirectoryPath();
     if (absFilePath.startsWith(repoPath)) {
       const filePath = absFilePath.slice(repoPath.length + 1);
       this.quietlySelectItem(filePath, 'unstaged');
-      return this.props.showFilePatchForPath(filePath, 'unstaged', {activate: true});
+      return this.props.showFilePatchForPath(filePath, 'unstaged', {
+        activate: true,
+        lineNumber: editor.getCursorBufferPosition().row + 1,
+      });
     } else {
       throw new Error(`${absFilePath} does not belong to repo ${repoPath}`);
     }
@@ -288,13 +290,16 @@ export default class GitTabController {
   @autobind
   viewStagedChangesForCurrentFile() {
     const editor = this.props.workspace.getActiveTextEditor();
-    const lineNumber = editor.getCursorBufferPosition().row;
     const absFilePath = editor.getPath();
     const repoPath = this.getActiveRepository().getWorkingDirectoryPath();
     if (absFilePath.startsWith(repoPath)) {
       const filePath = absFilePath.slice(repoPath.length + 1);
       this.quietlySelectItem(filePath, 'staged');
-      return this.props.showFilePatchForPath(filePath, 'staged', {activate: true, amending: this.props.isAmending});
+      return this.props.showFilePatchForPath(filePath, 'staged', {
+        activate: true,
+        lineNumber: editor.getCursorBufferPosition().row + 1,
+        amending: this.props.isAmending,
+      });
     } else {
       throw new Error(`${absFilePath} does not belong to repo ${repoPath}`);
     }

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -3,7 +3,7 @@
 
 import path from 'path';
 import etch from 'etch';
-import {Disposable} from 'event-kit';
+import {CompositeDisposable, Disposable} from 'event-kit';
 
 import GitTabView from '../views/git-tab-view';
 import ModelObserver from '../models/model-observer';
@@ -33,7 +33,14 @@ export default class GitTabController {
     etch.initialize(this);
 
     this.element.addEventListener('focusin', this.rememberLastFocus);
-    this.subscriptions = new Disposable(() => this.element.removeEventListener('focusin', this.rememberLastFocus));
+    this.subscriptions = new CompositeDisposable();
+    this.subscriptions.add(
+      new Disposable(() => this.element.removeEventListener('focusin', this.rememberLastFocus)),
+      this.props.commandRegistry.add('atom-workspace', {
+        'github:view-unstaged-changes-for-current-file': this.viewUnstagedChangesForCurrentFile,
+        'github:view-staged-changes-for-current-file': this.viewStagedChangesForCurrentFile,
+      }),
+    );
   }
 
   serialize() {
@@ -260,6 +267,36 @@ export default class GitTabController {
       return repository.stageFilesFromParentCommit(filePaths);
     } else {
       return repository.unstageFiles(filePaths);
+    }
+  }
+
+  @autobind
+  viewUnstagedChangesForCurrentFile() {
+    const editor = this.props.workspace.getActiveTextEditor();
+    const lineNumber = editor.getCursorBufferPosition().row;
+    const absFilePath = editor.getPath();
+    const repoPath = this.getActiveRepository().getWorkingDirectoryPath();
+    if (absFilePath.startsWith(repoPath)) {
+      const filePath = absFilePath.slice(repoPath.length + 1);
+      this.quietlySelectItem(filePath, 'unstaged');
+      return this.props.showFilePatchForPath(filePath, 'unstaged', {activate: true});
+    } else {
+      throw new Error(`${absFilePath} does not belong to repo ${repoPath}`);
+    }
+  }
+
+  @autobind
+  viewStagedChangesForCurrentFile() {
+    const editor = this.props.workspace.getActiveTextEditor();
+    const lineNumber = editor.getCursorBufferPosition().row;
+    const absFilePath = editor.getPath();
+    const repoPath = this.getActiveRepository().getWorkingDirectoryPath();
+    if (absFilePath.startsWith(repoPath)) {
+      const filePath = absFilePath.slice(repoPath.length + 1);
+      this.quietlySelectItem(filePath, 'staged');
+      return this.props.showFilePatchForPath(filePath, 'staged', {activate: true, amending: this.props.isAmending});
+    } else {
+      throw new Error(`${absFilePath} does not belong to repo ${repoPath}`);
     }
   }
 

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -3,7 +3,7 @@
 
 import path from 'path';
 import etch from 'etch';
-import {CompositeDisposable, Disposable} from 'event-kit';
+import {Disposable} from 'event-kit';
 
 import GitTabView from '../views/git-tab-view';
 import ModelObserver from '../models/model-observer';
@@ -33,14 +33,7 @@ export default class GitTabController {
     etch.initialize(this);
 
     this.element.addEventListener('focusin', this.rememberLastFocus);
-    this.subscriptions = new CompositeDisposable();
-    this.subscriptions.add(
-      new Disposable(() => this.element.removeEventListener('focusin', this.rememberLastFocus)),
-      this.props.commandRegistry.add('atom-workspace', {
-        'github:view-unstaged-changes-for-current-file': this.viewUnstagedChangesForCurrentFile,
-        'github:view-staged-changes-for-current-file': this.viewStagedChangesForCurrentFile,
-      }),
-    );
+    this.subscriptions = new Disposable(() => this.element.removeEventListener('focusin', this.rememberLastFocus));
   }
 
   serialize() {
@@ -267,41 +260,6 @@ export default class GitTabController {
       return repository.stageFilesFromParentCommit(filePaths);
     } else {
       return repository.unstageFiles(filePaths);
-    }
-  }
-
-  @autobind
-  viewUnstagedChangesForCurrentFile() {
-    const editor = this.props.workspace.getActiveTextEditor();
-    const absFilePath = editor.getPath();
-    const repoPath = this.getActiveRepository().getWorkingDirectoryPath();
-    if (absFilePath.startsWith(repoPath)) {
-      const filePath = absFilePath.slice(repoPath.length + 1);
-      this.quietlySelectItem(filePath, 'unstaged');
-      return this.props.showFilePatchForPath(filePath, 'unstaged', {
-        activate: true,
-        lineNumber: editor.getCursorBufferPosition().row + 1,
-      });
-    } else {
-      throw new Error(`${absFilePath} does not belong to repo ${repoPath}`);
-    }
-  }
-
-  @autobind
-  viewStagedChangesForCurrentFile() {
-    const editor = this.props.workspace.getActiveTextEditor();
-    const absFilePath = editor.getPath();
-    const repoPath = this.getActiveRepository().getWorkingDirectoryPath();
-    if (absFilePath.startsWith(repoPath)) {
-      const filePath = absFilePath.slice(repoPath.length + 1);
-      this.quietlySelectItem(filePath, 'staged');
-      return this.props.showFilePatchForPath(filePath, 'staged', {
-        activate: true,
-        lineNumber: editor.getCursorBufferPosition().row + 1,
-        amending: this.props.isAmending,
-      });
-    } else {
-      throw new Error(`${absFilePath} does not belong to repo ${repoPath}`);
     }
   }
 

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -364,7 +364,7 @@ export default class GitTabController {
 
   @autobind
   quietlySelectItem(filePath, stagingStatus) {
-    return this.refs.gitTab.quitelySelectItem(filePath, stagingStatus);
+    return this.refs.gitTab.quietlySelectItem(filePath, stagingStatus);
   }
 
   @autobind

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -201,6 +201,7 @@ export default class RootController extends React.Component {
               didDiveIntoFilePath={this.diveIntoFilePatchForPath}
               didSelectMergeConflictFile={this.showMergeConflictFileForPath}
               didDiveIntoMergeConflictPath={this.diveIntoMergeConflictFileForPath}
+              showFilePatchForPath={this.showFilePatchForPath}
               didChangeAmending={this.didChangeAmending}
               focusFilePatchView={this.focusFilePatchView}
               ensureGitTab={this.gitTabTracker.ensureVisible}

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -43,7 +43,7 @@ export default class RootController extends React.Component {
   static propTypes = {
     workspace: PropTypes.object.isRequired,
     commandRegistry: PropTypes.object.isRequired,
-    notificationManager: PropTypes.object.isReuired,
+    notificationManager: PropTypes.object.isRequired,
     tooltips: PropTypes.object.isRequired,
     config: PropTypes.object.isRequired,
     confirm: PropTypes.func.isRequired,

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -291,6 +291,7 @@ export default class RootController extends React.Component {
           ref={c => { this.filePatchControllerPane = c; }}
           onDidCloseItem={() => { this.setState({...nullFilePatchState}); }}>
           <FilePatchController
+            ref={c => { this.filePatchController = c; }}
             activeWorkingDirectory={this.props.activeWorkingDirectory}
             repository={this.props.repository}
             commandRegistry={this.props.commandRegistry}
@@ -475,7 +476,7 @@ export default class RootController extends React.Component {
   }
 
   @autobind
-  async showFilePatchForPath(filePath, stagingStatus, {activate, amending} = {}) {
+  async showFilePatchForPath(filePath, stagingStatus, {activate, amending, lineNumber} = {}) {
     if (!filePath) { return null; }
     const repository = this.props.repository;
     if (!repository) { return null; }
@@ -489,6 +490,9 @@ export default class RootController extends React.Component {
           // TODO: can be better done w/ a prop?
           if (activate && this.filePatchControllerPane) {
             this.filePatchControllerPane.activate();
+            if (lineNumber) {
+              this.filePatchController.goToDiffLine(lineNumber);
+            }
           }
           this.props.switchboard.didFinishRender('RootController.showFilePatchForPath');
           resolve();
@@ -573,6 +577,12 @@ export default class RootController extends React.Component {
     const item = this.filePatchControllerPane.getPaneItem();
     const viewElement = item.getElement().querySelector('[tabindex]');
     viewElement.focus();
+  }
+
+
+  @autobind
+  goToDiffLine(lineNumber) {
+    return this.filePatchController.goToDiffLine(lineNumber);
   }
 
   @autobind

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -43,7 +43,7 @@ export default class RootController extends React.Component {
   static propTypes = {
     workspace: PropTypes.object.isRequired,
     commandRegistry: PropTypes.object.isRequired,
-    notificationManager: PropTypes.object.isRequired,
+    notificationManager: PropTypes.object.isReuired,
     tooltips: PropTypes.object.isRequired,
     config: PropTypes.object.isRequired,
     confirm: PropTypes.func.isRequired,
@@ -587,17 +587,24 @@ export default class RootController extends React.Component {
     viewElement.focus();
   }
 
-  @autobind
-  viewUnstagedChangesForCurrentFile() {
+  viewChangesForCurrentFile(stagingStatus) {
     const editor = this.props.workspace.getActiveTextEditor();
     const absFilePath = editor.getPath();
     const repoPath = this.props.repository.getWorkingDirectoryPath();
     if (absFilePath.startsWith(repoPath)) {
       const filePath = absFilePath.slice(repoPath.length + 1);
-      this.quietlySelectItem(filePath, 'unstaged');
-      return this.showFilePatchForPath(filePath, 'unstaged', {
+      this.quietlySelectItem(filePath, stagingStatus);
+      const splitDirection = this.props.config.get('github.viewChangesForCurrentFileDiffPaneSplitDirection');
+      const pane = atom.workspace.getActivePane();
+      if (splitDirection === 'right') {
+        pane.splitRight();
+      } else if (splitDirection === 'down') {
+        pane.splitDown();
+      }
+      return this.showFilePatchForPath(filePath, stagingStatus, {
         activate: true,
         lineNumber: editor.getCursorBufferPosition().row + 1,
+        amending: stagingStatus === 'staged' && this.state.isAmending,
       });
     } else {
       throw new Error(`${absFilePath} does not belong to repo ${repoPath}`);
@@ -605,21 +612,13 @@ export default class RootController extends React.Component {
   }
 
   @autobind
+  viewUnstagedChangesForCurrentFile() {
+    this.viewChangesForCurrentFile('unstaged');
+  }
+
+  @autobind
   viewStagedChangesForCurrentFile() {
-    const editor = this.props.workspace.getActiveTextEditor();
-    const absFilePath = editor.getPath();
-    const repoPath = this.props.repository.getWorkingDirectoryPath();
-    if (absFilePath.startsWith(repoPath)) {
-      const filePath = absFilePath.slice(repoPath.length + 1);
-      this.quietlySelectItem(filePath, 'staged');
-      return this.showFilePatchForPath(filePath, 'staged', {
-        activate: true,
-        lineNumber: editor.getCursorBufferPosition().row + 1,
-        amending: this.state.isAmending,
-      });
-    } else {
-      throw new Error(`${absFilePath} does not belong to repo ${repoPath}`);
-    }
+    this.viewChangesForCurrentFile('staged');
   }
 
   @autobind

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -146,8 +146,14 @@ export default class RootController extends React.Component {
           <Command command="github:toggle-github-tab" callback={this.githubTabTracker.toggle} />
           <Command command="github:toggle-github-tab-focus" callback={this.githubTabTracker.toggleFocus} />
           <Command command="github:clone" callback={this.openCloneDialog} />
-          <Command command="github:view-unstaged-changes-for-current-file" callback={this.viewUnstagedChangesForCurrentFile} />
-          <Command command="github:view-staged-changes-for-current-file" callback={this.viewStagedChangesForCurrentFile} />
+          <Command
+            command="github:view-unstaged-changes-for-current-file"
+            callback={this.viewUnstagedChangesForCurrentFile}
+          />
+          <Command
+            command="github:view-staged-changes-for-current-file"
+            callback={this.viewStagedChangesForCurrentFile}
+          />
         </Commands>
         {this.renderStatusBarTile()}
         {this.renderPanels()}

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -146,6 +146,8 @@ export default class RootController extends React.Component {
           <Command command="github:toggle-github-tab" callback={this.githubTabTracker.toggle} />
           <Command command="github:toggle-github-tab-focus" callback={this.githubTabTracker.toggleFocus} />
           <Command command="github:clone" callback={this.openCloneDialog} />
+          <Command command="github:view-unstaged-changes-for-current-file" callback={this.viewUnstagedChangesForCurrentFile} />
+          <Command command="github:view-staged-changes-for-current-file" callback={this.viewStagedChangesForCurrentFile} />
         </Commands>
         {this.renderStatusBarTile()}
         {this.renderPanels()}
@@ -579,6 +581,40 @@ export default class RootController extends React.Component {
     viewElement.focus();
   }
 
+  @autobind
+  viewUnstagedChangesForCurrentFile() {
+    const editor = this.props.workspace.getActiveTextEditor();
+    const absFilePath = editor.getPath();
+    const repoPath = this.props.repository.getWorkingDirectoryPath();
+    if (absFilePath.startsWith(repoPath)) {
+      const filePath = absFilePath.slice(repoPath.length + 1);
+      this.quietlySelectItem(filePath, 'unstaged');
+      return this.showFilePatchForPath(filePath, 'unstaged', {
+        activate: true,
+        lineNumber: editor.getCursorBufferPosition().row + 1,
+      });
+    } else {
+      throw new Error(`${absFilePath} does not belong to repo ${repoPath}`);
+    }
+  }
+
+  @autobind
+  viewStagedChangesForCurrentFile() {
+    const editor = this.props.workspace.getActiveTextEditor();
+    const absFilePath = editor.getPath();
+    const repoPath = this.props.repository.getWorkingDirectoryPath();
+    if (absFilePath.startsWith(repoPath)) {
+      const filePath = absFilePath.slice(repoPath.length + 1);
+      this.quietlySelectItem(filePath, 'staged');
+      return this.showFilePatchForPath(filePath, 'staged', {
+        activate: true,
+        lineNumber: editor.getCursorBufferPosition().row + 1,
+        amending: this.state.isAmending,
+      });
+    } else {
+      throw new Error(`${absFilePath} does not belong to repo ${repoPath}`);
+    }
+  }
 
   @autobind
   goToDiffLine(lineNumber) {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -515,8 +515,8 @@ export default class RootController extends React.Component {
   }
 
   @autobind
-  async diveIntoFilePatchForPath(filePath, stagingStatus, {amending} = {}) {
-    await this.showFilePatchForPath(filePath, stagingStatus, {activate: true, amending});
+  async diveIntoFilePatchForPath(filePath, stagingStatus, options = {}) {
+    await this.showFilePatchForPath(filePath, stagingStatus, {...options, activate: true});
     this.focusFilePatchView();
   }
 
@@ -601,8 +601,7 @@ export default class RootController extends React.Component {
       } else if (splitDirection === 'down') {
         pane.splitDown();
       }
-      return this.showFilePatchForPath(filePath, stagingStatus, {
-        activate: true,
+      return this.diveIntoFilePatchForPath(filePath, stagingStatus, {
         lineNumber: editor.getCursorBufferPosition().row + 1,
         amending: stagingStatus === 'staged' && this.state.isAmending,
       });

--- a/lib/views/file-patch-selection.js
+++ b/lib/views/file-patch-selection.js
@@ -324,4 +324,29 @@ export default class FilePatchSelection {
   getLineSelectionTailIndex() {
     return this.linesSelection.getTailIndex();
   }
+
+  goToDiffLine(lineNumber) {
+    const lines = this.linesSelection.getItems();
+
+    let closestLine;
+    let closestLineDistance = Infinity;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!this.linesSelection.isItemSelectable(line)) { continue; }
+      if (line.newLineNumber === lineNumber) {
+        return this.selectLine(line);
+      } else {
+        const newDistance = Math.abs(line.newLineNumber - lineNumber);
+        if (newDistance < closestLineDistance) {
+          closestLineDistance = newDistance;
+          closestLine = line;
+        } else {
+          return this.selectLine(closestLine);
+        }
+      }
+    }
+
+    return this.selectLine(closestLine);
+  }
 }

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -468,4 +468,8 @@ export default class FilePatchView extends React.Component {
     const selectedLines = this.state.selection.getSelectedLines();
     return selectedLines.size ? this.props.discardLines(selectedLines) : null;
   }
+
+  goToDiffLine(lineNumber) {
+    this.setState(prevState => ({selection: prevState.selection.goToDiffLine(lineNumber)}));
+  }
 }

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -182,7 +182,7 @@ export default class GitTabView {
   }
 
   @autobind
-  quitelySelectItem(filePath, stagingStatus) {
+  quietlySelectItem(filePath, stagingStatus) {
     return this.refs.stagingView.quietlySelectItem(filePath, stagingStatus);
   }
 }

--- a/lib/views/hunk-view.js
+++ b/lib/views/hunk-view.js
@@ -95,7 +95,14 @@ export default class HunkView extends React.Component {
   }
 
   componentDidUpdate() {
-    if (this.props.headHunk === this.props.hunk) {
+    const selectedLine = Array.from(this.props.selectedLines)[0];
+    if (selectedLine && this.lineElements.get(selectedLine)) {
+      // QUESTION: why is this setTimeout needed?
+      const element = this.lineElements.get(selectedLine);
+      setTimeout(() => {
+        element.scrollIntoViewIfNeeded();
+      }, 0);
+    } else if (this.props.headHunk === this.props.hunk) {
       this.element.scrollIntoViewIfNeeded();
     } else if (this.props.headLine && this.lineElements.has(this.props.headLine)) {
       this.lineElements.get(this.props.headLine).scrollIntoViewIfNeeded();

--- a/menus/git.cson
+++ b/menus/git.cson
@@ -113,3 +113,13 @@
       'command': 'github:open-link-in-browser'
     }
   ]
+  'atom-text-editor': [
+    {
+      'label': 'View Unstaged Changes',
+      'command': 'github:view-unstaged-changes-for-current-file'
+    }
+    {
+      'label': 'View Staged Changes',
+      'command': 'github:view-staged-changes-for-current-file'
+    }
+  ]

--- a/package.json
+++ b/package.json
@@ -111,6 +111,17 @@
       "default": 300,
       "description": "How long to wait before showing a diff view after navigating to an entry with the keyboard"
     },
+    "viewChangesForCurrentFileDiffPaneSplitDirection": {
+      "type": "string",
+      "default": "none",
+      "enum": [
+        "none",
+        "right",
+        "down"
+      ],
+      "title": "Direction to open diff pane",
+      "description": "Direction to split the active pane when showing diff associated with open file. If 'none', the results will be shown in the active pane."
+    },
     "gitDiagnostics": {
       "type": "boolean",
       "default": false,

--- a/test/views/file-patch-selection.test.js
+++ b/test/views/file-patch-selection.test.js
@@ -914,6 +914,47 @@ describe('FilePatchSelection', function() {
       assertEqualSets(selection13.getSelectedLines(), new Set([getFirstChangedLine(hunks[0])]));
     });
   });
+
+  describe('goToDiffLine(lineNumber)', function() {
+    it('selects the closest selectable hunk line', function() {
+      const hunks = [
+        new Hunk(1, 1, 2, 4, '', [
+          new HunkLine('line-1', 'unchanged', 1, 1),
+          new HunkLine('line-2', 'added', -1, 2),
+          new HunkLine('line-3', 'added', -1, 3),
+          new HunkLine('line-4', 'unchanged', 2, 4),
+        ]),
+        new Hunk(5, 7, 3, 4, '', [
+          new HunkLine('line-7', 'unchanged', 5, 7),
+          new HunkLine('line-8', 'unchanged', 6, 8),
+          new HunkLine('line-9', 'added', -1, 9),
+          new HunkLine('line-10', 'unchanged', 7, 10),
+        ]),
+      ];
+
+      const selection0 = new FilePatchSelection(hunks);
+      const selection1 = selection0.goToDiffLine(2);
+      assert.equal(Array.from(selection1.getSelectedLines())[0].getText(), 'line-2');
+      assertEqualSets(selection1.getSelectedLines(), new Set([hunks[0].lines[1]]));
+
+      const selection2 = selection1.goToDiffLine(9);
+      assert.equal(Array.from(selection2.getSelectedLines())[0].getText(), 'line-9');
+      assertEqualSets(selection2.getSelectedLines(), new Set([hunks[1].lines[2]]));
+
+      // selects closest added hunk line
+      const selection3 = selection2.goToDiffLine(5);
+      assert.equal(Array.from(selection3.getSelectedLines())[0].getText(), 'line-3');
+      assertEqualSets(selection3.getSelectedLines(), new Set([hunks[0].lines[2]]));
+
+      const selection4 = selection3.goToDiffLine(8);
+      assert.equal(Array.from(selection4.getSelectedLines())[0].getText(), 'line-9');
+      assertEqualSets(selection4.getSelectedLines(), new Set([hunks[1].lines[2]]));
+
+      const selection5 = selection4.goToDiffLine(11);
+      assert.equal(Array.from(selection5.getSelectedLines())[0].getText(), 'line-9');
+      assertEqualSets(selection5.getSelectedLines(), new Set([hunks[1].lines[2]]));
+    });
+  });
 });
 
 function getChangedLines(hunk) {


### PR DESCRIPTION
Closes #888 
Closes #46

This PR adds commands for easily viewing the diff associated with the active editor: 
* `github:view-unstaged-changes-for-current-file`
* `github:view-staged-changes-for-current-file`

The RootController class 
1. grabs the active editor
1. determines the cursor location 
1. selects the associated item in the list view
1. opens the staged or unstaged file diff associated with the file
1. selects the closest `added` hunk line based on cursor position and scrolls it into view if necessary 

As part of this the FilePatchSelection API was extended to include a `goToDiffLine(lineNumber)` method which selects the closest `added` line based on the passed in line number. This can be used for a `github:go-to-diff-line` command similar to Atom's go-to-line functionality in editors. This is outside of the scope of the current PR, and may be implemented separately at a later point. 
