### PR TITLE
Set the full commit message as tooltip

### DIFF
--- a/lib/containers/timeline-items/commit-container.js
+++ b/lib/containers/timeline-items/commit-container.js
@@ -20,7 +20,7 @@ export class Commit extends React.Component {
         />
         <span
           className="commit-message-headline"
-          title={commit.messageHeadline}
+          title={commit.message}
           dangerouslySetInnerHTML={{__html: commit.messageHeadlineHTML}}
         />
         <span className="commit-sha">{commit.oid.slice(0, 8)}</span>
@@ -39,7 +39,7 @@ export default Relay.createContainer(Commit, {
             login
           }
         }
-        oid messageHeadline messageHeadlineHTML
+        oid message messageHeadlineHTML
       }
     `,
   },


### PR DESCRIPTION
### Description of the Change

Removed `messageHeadline` attribute from `Commit` container, and replaced it with `message` which contains the full text of the commit message.

### Applicable Issues

Resolves: #880

### Additional info

![screenshot](https://cloud.githubusercontent.com/assets/12673605/26526619/b090e3fc-4389-11e7-99cf-f445a37f28c3.png)
