### PR TITLE
Fix bad IPC messages

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -80,7 +80,7 @@ ipc.on(channelName, (event, {type, data}) => {
         event.sender.sendTo(managerWebContentsId, channelName, {
           sourceWebContentsId,
           type: 'git-spawn-error',
-          id, err,
+          data: {id, err},
         });
       });
 
@@ -88,7 +88,7 @@ ipc.on(channelName, (event, {type, data}) => {
         event.sender.sendTo(managerWebContentsId, channelName, {
           sourceWebContentsId,
           type: 'git-stdin-error',
-          id, stdin: options.stdin, err,
+          data: {id, stdin: options.stdin, err},
         });
       });
     };


### PR DESCRIPTION
A couple of the IPC messages had `id` and other fields loose on the top level object instead of correctly nested in a `data` key.

Fixes #881

/cc @kuychaco 