### PR TITLE
Keep state and dock toggling in sync

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -143,6 +143,9 @@ export default class RootController extends React.Component {
   componentWillReceiveProps(newProps) {
     this.repositoryObserver.setActiveModel(newProps.repository);
     this.repositoryStateRegistry.setModel(newProps.repository);
+
+    this.gitTabTracker.useLegacyPanels = newProps.useLegacyPanels;
+    this.githubTabTracker.useLegacyPanels = newProps.useLegacyPanels;
   }
 
   render() {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -884,6 +884,16 @@ class TabTracker {
     return false;
   }
 
+  reveal() {
+    const dockItem = this.getDockItem();
+    return dockItem ? dockItem.reveal() : Promise.resolve(null);
+  }
+
+  hide() {
+    const dockItem = this.getDockItem();
+    return dockItem ? dockItem.hide() : Promise.resolve(null);
+  }
+
   focus() {
     this.getControllerComponent().restoreFocus();
   }

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -820,13 +820,10 @@ class TabTracker {
     this.getState = getState;
     this.getWorkspace = getWorkspace;
     this.getController = getController;
+    this.getDockItem = getDockItem;
 
     this.setStateKey = value => {
       return new Promise(resolve => setState(value, resolve));
-    };
-    this.getDockItem = () => {
-      const item = getDockItem();
-      return item ? item.getDockItem() : null;
     };
   }
 
@@ -905,7 +902,7 @@ class TabTracker {
     const workspace = this.getWorkspace();
     return workspace.getPaneContainers()
       .filter(container => container === workspace.getCenter() || container.isVisible())
-      .some(container => container.getPanes().some(pane => pane.getActiveItem() === item));
+      .some(container => container.getPanes().some(pane => pane.getActiveItem() === item.getDockItem()));
   }
 
   hasFocus() {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -842,14 +842,29 @@ class TabTracker {
     const focusToRestore = document.activeElement;
     let shouldRestoreFocus = false;
 
-    await this.setStateKey(!this.getState());
+    // Rendered => the dock item is being rendered, whether or not the dock is visible or the item
+    //   is visible within its dock.
+    // Visible => the item is active and the dock item is active within its dock.
+    const wasRendered = this.getState();
+    const wasVisible = this.isVisible();
 
-    if (this.getDockItem()) {
-      // Super happy Docks ultra fun times
-      shouldRestoreFocus = await this.getWorkspace().toggle(this.getDockItem()) !== undefined;
-    } else {
-      // Legacy panels.
+    if (!wasRendered) {
+      // Not rendered.
+      await this.setStateKey(true);
+      await this.reveal();
       shouldRestoreFocus = true;
+    } else if (!wasVisible) {
+      // Rendered, but not an active item in a visible dock.
+      await this.reveal();
+      shouldRestoreFocus = true;
+    } else {
+      // Rendered and an active item within a visible dock.
+      if (this.useLegacyPanels) {
+        await this.setStateKey(false);
+      } else {
+        await this.hide();
+      }
+      shouldRestoreFocus = false;
     }
 
     if (shouldRestoreFocus) {
@@ -876,9 +891,7 @@ class TabTracker {
   async ensureVisible() {
     if (!this.isVisible()) {
       await this.setStateKey(true);
-      if (this.getDockItem()) {
-        await this.getWorkspace().open(this.getDockItem());
-      }
+      await this.reveal();
       return true;
     }
     return false;

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -842,14 +842,14 @@ class TabTracker {
     const focusToRestore = document.activeElement;
     let shouldRestoreFocus = false;
 
-    if (!this.getState()) {
-      await this.setStateKey(true);
-      shouldRestoreFocus = true;
-    } else if (this.getDockItem()) {
+    await this.setStateKey(!this.getState());
+
+    if (this.getDockItem()) {
+      // Super happy Docks ultra fun times
       shouldRestoreFocus = await this.getWorkspace().toggle(this.getDockItem()) !== undefined;
     } else {
       // Legacy panels.
-      await this.setStateKey(false);
+      shouldRestoreFocus = true;
     }
 
     if (shouldRestoreFocus) {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -110,6 +110,7 @@ export default class RootController extends React.Component {
     );
 
     this.gitTabTracker = new TabTracker('git', {
+      useLegacyPanels: this.props.useLegacyPanels,
       getState: () => this.state.gitTabActive,
       setState: (value, callback) => this.setState({gitTabActive: value}, callback),
       getController: () => this.gitTabController,
@@ -118,6 +119,7 @@ export default class RootController extends React.Component {
     });
 
     this.githubTabTracker = new TabTracker('github', {
+      useLegacyPanels: this.props.useLegacyPanels,
       getState: () => this.state.githubTabActive,
       setState: (value, callback) => this.setState({githubTabActive: value}, callback),
       getController: () => this.githubTabController,
@@ -811,9 +813,10 @@ export default class RootController extends React.Component {
 }
 
 class TabTracker {
-  constructor(name, {getState, setState, getController, getDockItem, getWorkspace}) {
+  constructor(name, {useLegacyPanels, getState, setState, getController, getDockItem, getWorkspace}) {
     this.name = name;
 
+    this.useLegacyPanels = useLegacyPanels;
     this.getState = getState;
     this.getWorkspace = getWorkspace;
     this.getController = getController;

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -77,11 +77,19 @@ export default class RootController extends React.Component {
 
   constructor(props, context) {
     super(props, context);
+
+    const renderGitTab = props.startOpen ||
+      (props.savedState.gitTabActive === undefined ?
+        !this.props.useLegacyPanels : this.props.savedState.gitTabActive);
+    const renderGitHubTab = props.startOpen ||
+      (props.savedState.githubTabActive === undefined ?
+        !this.props.useLegacyPanels : this.props.savedState.githubTabActive);
+
     this.state = {
       ...nullFilePatchState,
       amending: false,
-      gitTabActive: props.startOpen || props.savedState.gitTabActive,
-      githubTabActive: props.startOpen || props.savedState.githubTabActive || props.savedState.githubPanelActive,
+      gitTabActive: renderGitTab,
+      githubTabActive: renderGitHubTab,
       panelSize: props.savedState.panelSize || 400,
       activeTab: props.savedState.activeTab || 0,
       cloneDialogActive: false,

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -112,7 +112,11 @@ export default class RootController extends React.Component {
     this.gitTabTracker = new TabTracker('git', {
       useLegacyPanels: this.props.useLegacyPanels,
       getState: () => this.state.gitTabActive,
-      setState: (value, callback) => this.setState({gitTabActive: value}, callback),
+      setState: (value, {activateTab}, callback) => {
+        const newState = {gitTabActive: value};
+        if (activateTab) { newState.activeTab = 0; }
+        this.setState(newState, callback);
+      },
       getController: () => this.gitTabController,
       getDockItem: () => this.gitDockItem,
       getWorkspace: () => this.props.workspace,
@@ -121,7 +125,11 @@ export default class RootController extends React.Component {
     this.githubTabTracker = new TabTracker('github', {
       useLegacyPanels: this.props.useLegacyPanels,
       getState: () => this.state.githubTabActive,
-      setState: (value, callback) => this.setState({githubTabActive: value}, callback),
+      setState: (value, {activateTab}, callback) => {
+        const newState = {githubTabActive: value};
+        if (activateTab) { newState.activeTab = 1; }
+        this.setState(newState, callback);
+      },
       getController: () => this.githubTabController,
       getDockItem: () => this.githubDockItem,
       getWorkspace: () => this.props.workspace,
@@ -245,8 +253,8 @@ export default class RootController extends React.Component {
       <Panel
         workspace={this.props.workspace}
         location="right"
-        onDidClosePanel={() => this.setState({gitTabActive: false})}
-        visible={!!this.state.gitTabActive}>
+        onDidClosePanel={() => this.setState({gitTabActive: false, githubTabActive: false})}
+        visible={!!this.state.gitTabActive || !!this.state.githubTabActive}>
         <Resizer
           size={this.state.panelSize}
           onChange={this.handlePanelResize}
@@ -822,8 +830,8 @@ class TabTracker {
     this.getController = getController;
     this.getDockItem = getDockItem;
 
-    this.setStateKey = value => {
-      return new Promise(resolve => setState(value, resolve));
+    this.setStateKey = (value, options = {activateTab: false}) => {
+      return new Promise(resolve => setState(value, options, resolve));
     };
   }
 
@@ -850,7 +858,7 @@ class TabTracker {
 
     if (!wasRendered) {
       // Not rendered.
-      await this.setStateKey(true);
+      await this.setStateKey(true, {activateTab: true});
       await this.reveal();
       shouldRestoreFocus = true;
     } else if (!wasVisible) {
@@ -890,7 +898,7 @@ class TabTracker {
   @autobind
   async ensureVisible() {
     if (!this.isVisible()) {
-      await this.setStateKey(true);
+      await this.setStateKey(true, {activateTab: true});
       await this.reveal();
       return true;
     }

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -41,6 +41,7 @@ export default class GithubPackage {
     this.confirm = confirm;
     this.useLegacyPanels = !this.workspace.getLeftDock || this.config.get('github.useLegacyPanels');
     this.startOpen = false;
+    this.activated = false;
 
     const criteria = {
       projectPathCount: this.project.getPaths().length,
@@ -125,7 +126,7 @@ export default class GithubPackage {
     const firstRun = !await fileExists(this.configPath);
     this.startOpen = firstRun && !this.config.get('welcome.showOnStartup');
     if (firstRun) {
-      await writeFile(this.configPath, '# Store non-visible GitHub package state.');
+      await writeFile(this.configPath, '# Store non-visible GitHub package state.\n');
     }
 
     this.subscriptions.add(
@@ -166,6 +167,7 @@ export default class GithubPackage {
       this.workspace.addOpener(IssueishPaneItem.opener),
     );
 
+    this.activated = true;
     this.scheduleActiveContextUpdate(this.savedState);
     this.rerender();
   }
@@ -184,6 +186,10 @@ export default class GithubPackage {
   @autobind
   rerender(callback) {
     if (this.workspace.isDestroyed()) {
+      return;
+    }
+
+    if (!this.activated) {
       return;
     }
 

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -39,7 +39,7 @@ export default class GithubPackage {
 
     this.styleCalculator = new StyleCalculator(this.styles, this.config);
     this.confirm = confirm;
-    this.useLegacyPanels = false;
+    this.useLegacyPanels = !this.workspace.getLeftDock || this.config.get('github.useLegacyPanels');
     this.startOpen = false;
 
     const criteria = {
@@ -126,10 +126,6 @@ export default class GithubPackage {
     this.startOpen = firstRun && !this.config.get('welcome.showOnStartup');
     if (firstRun) {
       await writeFile(this.configPath, '# Store non-visible GitHub package state.');
-    }
-
-    if (!this.workspace.getLeftDock || this.config.get('github.useLegacyPanels')) {
-      this.useLegacyPanels = true;
     }
 
     this.subscriptions.add(

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -23,8 +23,6 @@ import AsyncQueue from './async-queue';
 import WorkerManager from './worker-manager';
 
 const defaultState = {
-  firstRun: true,
-  resolutionProgressByPath: {},
 };
 
 export default class GithubPackage {

--- a/lib/views/dock-item.js
+++ b/lib/views/dock-item.js
@@ -35,6 +35,14 @@ export default class DockItem extends React.Component {
     onDidCloseItem: dockItem => {},
   }
 
+  constructor(props, context) {
+    super(props, context);
+
+    this.dockItemPromise = new Promise(resolve => {
+      this.resolveDockItemPromise = resolve;
+    });
+  }
+
   componentDidMount() {
     this.setupDockItem();
   }
@@ -79,6 +87,7 @@ export default class DockItem extends React.Component {
     if (stub) {
       stub.setRealItem(itemToAdd);
       this.dockItem = stub;
+      this.resolveDockItemPromise(this.dockItem);
       if (this.props.activate) {
         this.activate();
       }
@@ -86,6 +95,7 @@ export default class DockItem extends React.Component {
       Promise.resolve(this.props.workspace.open(itemToAdd, {activatePane: false}))
         .then(item => {
           this.dockItem = item;
+          this.resolveDockItemPromise(this.dockItem);
           if (this.props.activate) { this.activate(); }
         });
     }
@@ -100,10 +110,6 @@ export default class DockItem extends React.Component {
     );
   }
 
-  getDockItem() {
-    return this.dockItem;
-  }
-
   componentWillUnmount() {
     this.subscriptions && this.subscriptions.dispose();
     if (this.dockItem && !this.didCloseItem) {
@@ -113,6 +119,14 @@ export default class DockItem extends React.Component {
       }
       pane.destroyItem(this.dockItem);
     }
+  }
+
+  getDockItem() {
+    return this.dockItem;
+  }
+
+  getDockItemPromise() {
+    return this.dockItemPromise;
   }
 
   activate() {

--- a/lib/views/dock-item.js
+++ b/lib/views/dock-item.js
@@ -129,6 +129,18 @@ export default class DockItem extends React.Component {
     return this.dockItemPromise;
   }
 
+  async reveal() {
+    const dockItem = await this.getDockItemPromise();
+    return this.props.workspace.open(dockItem, {
+      searchAllPanes: true,
+    });
+  }
+
+  async hide() {
+    const dockItem = await this.getDockItemPromise();
+    return this.props.workspace.hide(dockItem);
+  }
+
   activate() {
     setTimeout(() => {
       if (!this.dockItem || this.didCloseItem || this.props.workspace.isDestroyed()) {

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -380,13 +380,13 @@ import RootController from '../../lib/controllers/root-controller';
 
           const FAKE_PANE_ITEM = Symbol('fake pane item');
           mockDockItem = {
-            visible: false,
+            active: false,
             reveal() {
-              this.visible = true;
+              this.active = true;
               return Promise.resolve();
             },
             hide() {
-              this.visible = false;
+              this.active = false;
               return Promise.resolve();
             },
             getDockItem() {
@@ -399,97 +399,97 @@ import RootController from '../../lib/controllers/root-controller';
 
             sinon.stub(workspace.getRightDock(), 'isVisible').returns(true);
             sinon.stub(workspace.getRightDock(), 'getPanes').callsFake(() => [{
-              getActiveItem() { return mockDockItem.visible ? FAKE_PANE_ITEM : null; },
+              getActiveItem() { return mockDockItem.active ? FAKE_PANE_ITEM : null; },
             }]);
           }
         });
 
-        function assertTabState({rendered, visible}) {
+        function assertTabState({rendered, active}) {
           if (useDocks()) {
             const isRendered = wrapper.find('DockItem').find({stubItemSelector: `${tabName}-tab-controller`}).exists();
-            const isVisible = mockDockItem.visible;
+            const isActive = mockDockItem.active;
 
             assert.equal(isRendered, rendered);
-            assert.equal(isVisible, visible);
+            assert.equal(isActive, active);
           } else {
             // Legacy panels API.
             // Legacy panels are always rendered, so disregard "rendered" assertions.
             const title = {git: 'Git', github: 'GitHub (preview)'}[tabName];
 
-            const isVisible = wrapper.find('Panel').find({visible: true})
+            const isActive = wrapper.find('Panel').find({visible: true})
               .find('Tabs').find({activeIndex: tabIndex})
               .find('TabPanel').find({title})
               .exists();
 
-            assert.equal(isVisible, visible);
+            assert.equal(isActive, active);
           }
         }
 
         describe('toggle()', function() {
           it(`renders and reveals the ${tabName} tab when item is not rendered`, async function() {
-            assertTabState({rendered: false, visible: false});
+            assertTabState({rendered: false, active: false});
 
             await tabTracker.toggle();
 
-            assertTabState({rendered: true, visible: true});
+            assertTabState({rendered: true, active: true});
           });
 
           if (!useLegacyPanels) {
-            it(`reveals the ${tabName} tab when the item is rendered but not visible`, async function() {
+            it(`reveals the ${tabName} tab when the item is rendered but not active`, async function() {
               wrapper.setState({[stateKey]: true});
 
-              assertTabState({rendered: true, visible: false});
+              assertTabState({rendered: true, active: false});
 
               await tabTracker.toggle();
 
-              assertTabState({rendered: true, visible: true});
+              assertTabState({rendered: true, active: true});
             });
           }
 
           it(`hides the ${tabName} tab when open`, async function() {
             wrapper.setState({[stateKey]: true, activeTab: tabIndex});
-            mockDockItem.visible = true;
+            mockDockItem.active = true;
 
-            assertTabState({rendered: true, visible: true});
+            assertTabState({rendered: true, active: true});
 
             await tabTracker.toggle();
 
-            assertTabState({rendered: true, visible: false});
+            assertTabState({rendered: true, active: false});
           });
         });
 
         describe('toggleFocus()', function() {
           it(`opens and focuses the ${tabName} tab when it is initially closed`, async function() {
-            assertTabState({rendered: false, visible: false});
+            assertTabState({rendered: false, active: false});
             sinon.stub(tabTracker, 'hasFocus').returns(false);
 
             await tabTracker.toggleFocus();
 
-            assertTabState({rendered: true, visible: true});
+            assertTabState({rendered: true, active: true});
             assert.isTrue(tabTracker.focus.called);
             assert.isFalse(workspace.getActivePane().activate.called);
           });
 
           it(`focuses the ${tabName} tab when it is already open, but blurred`, async function() {
             await tabTracker.ensureVisible();
-            assertTabState({rendered: true, visible: true});
+            assertTabState({rendered: true, active: true});
             sinon.stub(tabTracker, 'hasFocus').returns(false);
 
             await tabTracker.toggleFocus();
 
-            assertTabState({rendered: true, visible: true});
+            assertTabState({rendered: true, active: true});
             assert.isTrue(tabTracker.focus.called);
             assert.isFalse(workspace.getActivePane().activate.called);
           });
 
           it(`blurs the ${tabName} tab when it is already open and focused`, async function() {
             await tabTracker.ensureVisible();
-            assertTabState({rendered: true, visible: true});
+            assertTabState({rendered: true, active: true});
             sinon.stub(tabTracker, 'hasFocus').returns(true);
 
             await tabTracker.toggleFocus();
 
-            assertTabState({rendered: true, visible: true});
+            assertTabState({rendered: true, active: true});
             assert.isFalse(tabTracker.focus.called);
             assert.isTrue(workspace.getActivePane().activate.called);
           });
@@ -497,16 +497,16 @@ import RootController from '../../lib/controllers/root-controller';
 
         describe('ensureVisible()', function() {
           it(`opens the ${tabName} tab when it is initially closed`, async function() {
-            assertTabState({rendered: false, visible: false});
+            assertTabState({rendered: false, active: false});
             assert.isTrue(await tabTracker.ensureVisible());
-            assertTabState({rendered: true, visible: true});
+            assertTabState({rendered: true, active: true});
           });
 
           it(`does nothing when the ${tabName} tab is already open`, async function() {
             await tabTracker.toggle();
-            assertTabState({rendered: true, visible: true});
+            assertTabState({rendered: true, active: true});
             assert.isFalse(await tabTracker.ensureVisible());
-            assertTabState({rendered: true, visible: true});
+            assertTabState({rendered: true, active: true});
           });
         });
       });

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -111,6 +111,24 @@ import RootController from '../../lib/controllers/root-controller';
         });
       });
 
+      it('is rendered but not activated when startOpen prop is false', async function() {
+        const workdirPath = await cloneRepository('multiple-commits');
+        const repository = await buildRepository(workdirPath);
+
+        app = React.cloneElement(app, {repository, startOpen: false});
+        const wrapper = shallow(app);
+
+        assertInitialTabState({
+          wrapper, tabName: 'git',
+          rendered: true, activated: false, visible: false,
+        });
+
+        assertInitialTabState({
+          wrapper, tabName: 'github',
+          rendered: true, activated: false, visible: false,
+        });
+      });
+
       it('is initially activated when the startOpen prop is true', async function() {
         const workdirPath = await cloneRepository('multiple-commits');
         const repository = await buildRepository(workdirPath);

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -351,35 +351,66 @@ import RootController from '../../lib/controllers/root-controller';
       });
 
       describe('toggle()', function() {
+        const FAKEITEM = Symbol('fake dock item');
+        let treatAsActive;
+
         beforeEach(function() {
           if (useDocks()) {
-            sinon.spy(workspace, 'toggle');
+            treatAsActive = false;
             wrapper.instance().gitDockItem = {
-              getDockItem() { return {}; },
+              getDockItem() { return FAKEITEM; },
+              getDockItemPromise() { return Promise.resolve(FAKEITEM); },
             };
+
+            sinon.stub(workspace, 'toggle').callsFake(() => {
+              treatAsActive = !treatAsActive;
+            });
+
+            sinon.stub(workspace.getRightDock(), 'isVisible').returns(true);
+            sinon.stub(workspace.getRightDock(), 'getPanes').callsFake(() => {
+              return [{
+                getActiveItem: () => (treatAsActive ? FAKEITEM : null),
+              }];
+            });
           }
         });
 
-        it('shows the Git view when closed', async function() {
-          assert.isFalse(isGitPaneDisplayed(wrapper));
+        it('renders and reveals the Git view when item is not rendered', async function() {
           assert.isNotOk(wrapper.state('gitTabActive'));
+          treatAsActive = false;
 
           await gitTabTracker.toggle();
 
-          assert.isTrue(isGitPaneDisplayed(wrapper));
           assert.isTrue(wrapper.state('gitTabActive'));
           if (useDocks()) { assert.isTrue(workspace.toggle.called); }
         });
 
-        it('hides the Git view when open', async function() {
+        it('reveals the Git view when the item is rendered but not visible', async function() {
           wrapper.setState({gitTabActive: true});
-          assert.isTrue(isGitPaneDisplayed(wrapper));
+          treatAsActive = false;
 
           await gitTabTracker.toggle();
 
-          assert.isFalse(isGitPaneDisplayed(wrapper));
-          assert.isFalse(wrapper.state('gitTabActive'));
-          if (useDocks()) { assert.isTrue(workspace.toggle.called); }
+          if (useDocks()) {
+            assert.isTrue(wrapper.state('gitTabActive'));
+            assert.isTrue(workspace.toggle.called);
+          } else {
+            assert.isFalse(wrapper.state('gitTabActive'));
+          }
+        });
+
+        it('hides and unrenders the Git view when open', async function() {
+          wrapper.setState({gitTabActive: true});
+          treatAsActive = true;
+
+          await gitTabTracker.toggle();
+
+          if (useDocks()) {
+            assert.isTrue(wrapper.state('gitTabActive'));
+            assert.isTrue(workspace.toggle.called);
+          } else {
+            assert.isFalse(wrapper.state('gitTabActive'));
+          }
         });
       });
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -34,6 +34,8 @@ export async function cloneRepository(repoName = 'three-files') {
     await git.clone(path.join(__dirname, 'fixtures', `repo-${repoName}`, 'dot-git'), {noLocal: true});
     await git.exec(['config', '--local', 'core.autocrlf', 'false']);
     await git.exec(['config', '--local', 'commit.gpgsign', 'false']);
+    await git.exec(['config', '--local', 'user.email', 'nope@nah.com']);
+    await git.exec(['config', '--local', 'user.name', 'Someone']);
     await git.exec(['checkout', '--', '.']); // discard \r in working directory
     cachedClonedRepos[repoName] = cachedPath;
   }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -55,6 +55,8 @@ export async function initRepository(repoName) {
   const workingDirPath = temp.mkdirSync('git-fixture-');
   const git = new GitShellOutStrategy(workingDirPath);
   await git.exec(['init']);
+  await git.exec(['config', '--local', 'user.email', 'nope@nah.com']);
+  await git.exec(['config', '--local', 'user.name', 'Someone']);
   return fs.realpathSync(workingDirPath);
 }
 
@@ -80,6 +82,8 @@ export async function setUpLocalAndRemoteRepositories(repoName = 'multiple-commi
   await localGit.clone(baseRepoPath, {noLocal: true});
   await localGit.exec(['remote', 'set-url', 'origin', remoteRepoPath]);
   await localGit.exec(['config', '--local', 'commit.gpgsign', 'false']);
+  await localGit.exec(['config', '--local', 'user.email', 'nope@nah.com']);
+  await localGit.exec(['config', '--local', 'user.name', 'Someone']);
   return {baseRepoPath, remoteRepoPath, localRepoPath};
 }
 


### PR DESCRIPTION
When `gitTabActive` was "false" and the toggle method was invoked, the state was being toggle to "true" correctly, but the DockItem was not being toggled correctly in the workspace. As a result, it took _two_ invocations of `github:toggle-git-tab` to show the Git tab if the dock it was in was not visible.

Probably addresses #891.

- [x] Clarify state transitions in `TabTracker.toggle()` with and without legacy panels active. With legacy panels, the `gitTabActive` component state dictates the visibility of the panel completely, so toggling should only flip the state; with the dock API, `gitTabActive` controls whether or not the tab is _rendered_, not visible, so `.toggle()` may need to reveal the dock.
- [x] Bring the RootController tests up to date. There are a few still failing because `isGitPaneDisplayed` doesn't account for the docks API.
- [x] For new projects when the docks API is available, default the Git and GitHub tabs to _rendered_ but not _activated_. Meaning, if you open Atom on a new project, the right dock is hidden, but if you open it yourself the Git and GitHub tabs are present by default.