### PR TITLE
Display status bar info for pending pane items

### DIFF
--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -141,7 +141,7 @@ export default class GithubPackage {
         this.rerender();
       }),
       this.project.onDidChangePaths(this.scheduleActiveContextUpdate),
-      this.workspace.onDidChangeActivePaneItem(this.scheduleActiveContextUpdate),
+      this.workspace.getCenter().onDidChangeActivePaneItem(this.scheduleActiveContextUpdate),
       this.styleCalculator.startWatching(
         'github-package-styles',
         ['editor.fontSize', 'editor.fontFamily', 'editor.lineHeight'],
@@ -323,8 +323,7 @@ export default class GithubPackage {
    * Derive the git working directory context that should be used for the package's git operations based on the current
    * state of the Atom workspace. In priority, this prefers:
    *
-   * - A git working directory that contains the workspace's active pane item.
-   * - A git working directory that contains the pane item in the workspace's center.
+   * - A git working directory that contains the active pane item in the workspace's center.
    * - A git working directory corresponding to a single Project.
    * - When initially activating the package, the working directory that was active when the package was last
    *   serialized.
@@ -360,21 +359,15 @@ export default class GithubPackage {
     };
 
     const items = [
-      this.workspace.getActivePaneItem(),
       this.workspace.getCenter && this.workspace.getCenter().getActivePaneItem(),
     ];
-    const [active, center = {}] = await Promise.all(items.map(fromPaneItem));
+    const [active = {}] = await Promise.all(items.map(fromPaneItem));
 
     this.contextPool.set(workdirs, savedState);
 
     if (active.itemPath) {
       // Prefer an active item
       return this.contextPool.getContext(active.itemWorkdir || active.itemPath);
-    }
-
-    if (center.itemPath) {
-      // Try the item active in the Workspace's center
-      return this.contextPool.getContext(center.itemWorkdir || center.itemPath);
     }
 
     if (this.project.getPaths().length === 1) {

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -358,10 +358,7 @@ export default class GithubPackage {
       return {itemPath, itemWorkdir};
     };
 
-    const items = [
-      this.workspace.getCenter && this.workspace.getCenter().getActivePaneItem(),
-    ];
-    const [active = {}] = await Promise.all(items.map(fromPaneItem));
+    const active = await fromPaneItem(this.workspace.getCenter().getActivePaneItem());
 
     this.contextPool.set(workdirs, savedState);
 


### PR DESCRIPTION
As one part of resolving https://github.com/atom/status-bar/issues/194, this PR updates this package to expect any git-backed pane items (e.g., text editors, image files, etc.) to exist in the workspace center.

### Alternate Designs

See https://github.com/atom/atom/pull/14695

### Benefits

The package will be able to display the git branch and push/pull status for pending pane items as the user navigates the tree-view.

### Possible Drawbacks

See https://github.com/atom/atom/pull/14695

### Applicable Issues

- https://github.com/atom/atom/issues/14648
- https://github.com/atom/status-bar/issues/194

### Demo

#### Before

In the demo below, we start with an _active_ text editor for the `.gitignore`, and then we open another text editor for the `.gitmodules` file (in a different project) in a pending pane. When opening the pending text editor, the status bar shows the git branch and push/pull status for the previous editor. We have to take the additional step of clicking on the pane item in order to get the status bar to reflect the file's correct git branch and push/pull status.

![github-before](https://cloud.githubusercontent.com/assets/2988/26787953/acec1bd0-49d9-11e7-9bba-f9cab29883bc.gif)

#### After

In the demo below, we follow the same steps as above. This time, when opening the pending text editor, the status bar immediately shows the correct git branch and push/pull status for the pending pane item.

![github-after](https://cloud.githubusercontent.com/assets/2988/26787952/ace960e8-49d9-11e7-8d4a-08121b90a1d7.gif)
