### PR TITLE
Respect GIT_AUTHOR_*/GIT_COMMITTER_* environment variables

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -20,6 +20,11 @@ import WorkerManager from './worker-manager';
 const LINE_ENDING_REGEX = /\r?\n/;
 
 const GPG_HELPER_PATH = path.resolve(getPackageRoot(), 'bin', 'gpg-no-tty.sh');
+const ENV_VARS_TO_COPY = [
+  'GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL', 'GIT_AUTHOR_DATE',
+  'GIT_COMMITTER_NAME', 'GIT_COMMITTER_EMAIL', 'GIT_COMMITTER_DATE',
+  'EMAIL', // fallback
+];
 
 let headless = null;
 
@@ -79,6 +84,12 @@ export default class GitShellOutStrategy {
         GIT_TERMINAL_PROMPT: '0',
         PATH: process.env.PATH || '',
       };
+
+      ENV_VARS_TO_COPY.forEach(envVar => {
+        if (process.env[envVar] !== undefined) {
+          env[envVar] = process.env[envVar];
+        }
+      });
 
       if (useGitPromptServer) {
         gitPromptServer = new GitPromptServer();


### PR DESCRIPTION
`GIT_AUTHOR_*` and `GIT_COMMITTER_*` environment variables weren't being sent to the Git worker process, so pairing information (such as set by git-pear) didn't work.

/cc @smashwilson 
/cc @jasonrudolph for info