### PR TITLE
add context menu labels when items are selected

### DIFF
--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -27,7 +27,7 @@ const defaultState = {
 
 export default class GithubPackage {
   constructor(workspace, project, commandRegistry, notificationManager, tooltips, styles, grammars, confirm, config,
-      configDirPath, getLoadSettings, contextMenu) {
+      configDirPath, getLoadSettings) {
     this.workspace = workspace;
     this.project = project;
     this.commandRegistry = commandRegistry;
@@ -37,7 +37,6 @@ export default class GithubPackage {
     this.styles = styles;
     this.grammars = grammars;
     this.configPath = path.join(configDirPath, 'github.cson');
-    this.contextMenu = contextMenu;
 
     this.styleCalculator = new StyleCalculator(this.styles, this.config);
     this.confirm = confirm;
@@ -171,7 +170,7 @@ export default class GithubPackage {
         }
       }),
       this.workspace.addOpener(IssueishPaneItem.opener),
-      this.contextMenu.add({
+      atom.contextMenu.add({
         '.github-UnstagedChanges .github-FilePatchListView': [
           {
             label: 'Stage',

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -27,7 +27,7 @@ const defaultState = {
 
 export default class GithubPackage {
   constructor(workspace, project, commandRegistry, notificationManager, tooltips, styles, grammars, confirm, config,
-      configDirPath, getLoadSettings) {
+      configDirPath, getLoadSettings, contextMenu) {
     this.workspace = workspace;
     this.project = project;
     this.commandRegistry = commandRegistry;
@@ -37,6 +37,7 @@ export default class GithubPackage {
     this.styles = styles;
     this.grammars = grammars;
     this.configPath = path.join(configDirPath, 'github.cson');
+    this.contextMenu = contextMenu;
 
     this.styleCalculator = new StyleCalculator(this.styles, this.config);
     this.confirm = confirm;
@@ -130,6 +131,10 @@ export default class GithubPackage {
       await writeFile(this.configPath, '# Store non-visible GitHub package state.\n');
     }
 
+    const hasSelectedFiles = event => {
+      return !!event.target.closest('.github-FilePatchListView').querySelector('.is-selected');
+    };
+
     this.subscriptions.add(
       atom.config.onDidChange('github.useLegacyPanels', ({newValue}) => {
         if (newValue) {
@@ -166,6 +171,52 @@ export default class GithubPackage {
         }
       }),
       this.workspace.addOpener(IssueishPaneItem.opener),
+      this.contextMenu.add({
+        '.github-UnstagedChanges .github-FilePatchListView': [
+          {
+            label: 'Stage',
+            command: 'core:confirm',
+            shouldDisplay: hasSelectedFiles,
+          },
+          {
+            type: 'separator',
+            shouldDisplay: hasSelectedFiles,
+          },
+          {
+            label: 'Discard Changes',
+            command: 'github:discard-changes-in-selected-files',
+            shouldDisplay: hasSelectedFiles,
+          },
+        ],
+        '.github-StagedChanges .github-FilePatchListView': [
+          {
+            label: 'Unstage',
+            command: 'core:confirm',
+            shouldDisplay: hasSelectedFiles,
+          },
+        ],
+        '.github-MergeConflictPaths .github-FilePatchListView': [
+          {
+            label: 'Stage',
+            command: 'core:confirm',
+            shouldDisplay: hasSelectedFiles,
+          },
+          {
+            type: 'separator',
+            shouldDisplay: hasSelectedFiles,
+          },
+          {
+            label: 'Resolve File As Ours',
+            command: 'github:resolve-file-as-ours',
+            shouldDisplay: hasSelectedFiles,
+          },
+          {
+            label: 'Resolve File As Theirs',
+            command: 'github:resolve-file-as-theirs',
+            shouldDisplay: hasSelectedFiles,
+          },
+        ],
+      }),
     );
 
     this.activated = true;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const entry = {
     pack = new GithubPackage(
       atom.workspace, atom.project, atom.commands, atom.notifications, atom.tooltips,
       atom.styles, atom.grammars, atom.confirm.bind(atom), atom.config, atom.getConfigDirPath(),
-      atom.getLoadSettings.bind(atom),
+      atom.getLoadSettings.bind(atom), atom.contextMenu,
     );
   },
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const entry = {
     pack = new GithubPackage(
       atom.workspace, atom.project, atom.commands, atom.notifications, atom.tooltips,
       atom.styles, atom.grammars, atom.confirm.bind(atom), atom.config, atom.getConfigDirPath(),
-      atom.getLoadSettings.bind(atom), atom.contextMenu,
+      atom.getLoadSettings.bind(atom),
     );
   },
 };

--- a/menus/git.cson
+++ b/menus/git.cson
@@ -38,42 +38,6 @@
       'command': 'github:open-file'
     }
   ]
-  '.github-UnstagedChanges .github-FilePatchListView .github-FilePatchListView-item': [
-    {
-      'label': 'Stage'
-      'command': 'core:confirm'
-    }
-    {
-      'type': 'separator'
-    }
-    {
-      'label': 'Discard Changes'
-      'command': 'github:discard-changes-in-selected-files'
-    }
-  ]
-  '.github-StagedChanges .github-FilePatchListView .github-FilePatchListView-item': [
-    {
-      'label': 'Unstage'
-      'command': 'core:confirm'
-    }
-  ]
-  '.github-MergeConflictPaths .github-FilePatchListView .github-MergeConflictListView-item': [
-    {
-      'label': 'Stage'
-      'command': 'core:confirm'
-    },
-    {
-      'type': 'separator'
-    }
-    {
-      'label': 'Resolve File As Ours'
-      'command': 'github:resolve-file-as-ours'
-    },
-    {
-      'label': 'Resolve File As Theirs'
-      'command': 'github:resolve-file-as-theirs'
-    }
-  ]
   '.github-FilePatchView': [
     {
       'label': 'Open File'


### PR DESCRIPTION
### Description of the Change

If files are selected, right clicking on the empty space will bring up the commands in the context menu.

![github-context2](https://user-images.githubusercontent.com/97994/27232246-f4cded44-527a-11e7-9278-096d9b2f0f0b.gif)

### Benefits

People won't be confused when selecting files and right clicking just underneath them. 

### Possible Drawbacks

none?

### Applicable Issues

Fixes #940
somewhat rolls back #878
