### PR TITLE
After staging file via core:confirm, show the next diff

### DIFF
--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -218,7 +218,10 @@ export default class StagingView {
 
   confirmSelectedItems() {
     const itemPaths = Array.from(this.selection.getSelectedItems()).map(item => item.filePath);
-    return this.props.attemptFileStageOperation(itemPaths, this.selection.getActiveListKey());
+    this.props.attemptFileStageOperation(itemPaths, this.selection.getActiveListKey());
+    this.selection.coalesce();
+    this.debouncedDidChangeSelectedItem();
+    return etch.update(this);
   }
 
   getNextListUpdatePromise() {


### PR DESCRIPTION
### Description of the Change

As requested in https://github.com/atom/github/issues/854, when you have multiple files present in the staging view, hitting enter stages the file and shows the diff for the next file in the list. See before-and-after demo below.

### Alternate Designs

I didn't consider any other designs at this point. For now, I'm opening this PR to get some initial feedback on whether other people appreciate this UX change as much as I do. :innocent:

### Benefits

Streamlined workflow for people using keyboard to stage/unstage multiple files in succession.

### Possible Drawbacks

I'm not aware of any.

### Applicable Issues

Currently: https://github.com/atom/github/issues/864

Previously: https://github.com/atom/github/issues/854, https://github.com/atom/github/issues/645

### Demo

#### Before

![before](https://user-images.githubusercontent.com/2988/27459030-4ed5a59e-577a-11e7-8b81-fe3d252e37c7.gif)

#### After

![after](https://user-images.githubusercontent.com/2988/27459031-4ed5e93c-577a-11e7-9f33-3da2083b1304.gif)
