### PR TITLE
Fix tests that broke due to changes on Atom Beta

### DIFF
--- a/lib/controllers/commit-view-controller.js
+++ b/lib/controllers/commit-view-controller.js
@@ -206,9 +206,10 @@ export default class CommitViewController {
 
   closeAllOpenCommitMessageEditors() {
     this.props.workspace.getPanes().forEach(pane => {
-      pane.getItems().forEach(item => {
+      pane.getItems().forEach(async item => {
         if (item && item.getPath && item.getPath() === this.getCommitMessagePath()) {
-          if (!pane.destroyItem(item)) {
+          const destroyed = await pane.destroyItem(item);
+          if (!destroyed) {
             pane.activateItem(item);
           }
         }

--- a/test/controllers/commit-view-controller.test.js
+++ b/test/controllers/commit-view-controller.test.js
@@ -160,7 +160,7 @@ describe('CommitViewController', function() {
         assert.equal(editor.getText(), 'message in box');
 
         editor.setText('message in editor');
-        editor.save();
+        await editor.save();
 
         commandRegistry.dispatch(atomEnvironment.views.getView(editor), 'pane:split-right-and-copy-active-item');
         await assert.async.notEqual(workspace.getActiveTextEditor(), editor);
@@ -237,7 +237,7 @@ describe('CommitViewController', function() {
         assert.equal(editor.getPath(), controller.getCommitMessagePath());
 
         editor.setText('message in editor');
-        editor.save();
+        await editor.save();
         commandRegistry.dispatch(atomEnvironment.views.getView(workspace), 'github:commit');
 
         await assert.async.equal((await repository.getLastCommit()).getMessage(), 'message in editor');

--- a/test/models/workspace-change-observer.test.js
+++ b/test/models/workspace-change-observer.test.js
@@ -60,7 +60,7 @@ describe('WorkspaceChangeObserver', function() {
     await changeObserver.start();
 
     editor.setText('change');
-    editor.save();
+    await editor.save();
     await until(() => changeSpy.calledOnce);
 
     changeSpy.reset();
@@ -86,7 +86,7 @@ describe('WorkspaceChangeObserver', function() {
       editor.getBuffer().setPath(path.join(workdirPath, 'renamed-path.txt'));
 
       editor.setText('change');
-      editor.save();
+      await editor.save();
       await assert.async.isTrue(changeSpy.calledWith([{
         directory: workdirPath,
         file: 'renamed-path.txt',


### PR DESCRIPTION
A couple APIs changed in Atom core. `TextBuffer.prototype.save` is now asynchronous, as well as `Pane.prototype.destroyItem`

Depends on https://github.com/atom/atom/pull/14884