### PR TITLE
Revert "Upgrade libstdg++ on Travis for our beta build"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,9 @@ matrix:
     - ATOM_CHANNEL=beta
     addons:
       apt:
-        sources:
-        - ubuntu-toolchain-r-test
         packages:
         - clang-3.3
         - build-essential
-        - gcc-4.9
-        - g++-4.9
         - gnome-keyring
         - libsecret-1-dev
         - python-gnomekeyring


### PR DESCRIPTION
This is now unnecessary with the latest beta hotfix :tada:

Reverts atom/github#989.