### PR TITLE
Fix `Repository#getGitDirectoryPath()` for absent or loading repos

### DIFF
--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -147,8 +147,11 @@ export default class Repository {
   getGitDirectoryPath() {
     if (this._gitDirectoryPath) {
       return this._gitDirectoryPath;
-    } else {
+    } else if (this.getWorkingDirectoryPath()) {
       return path.join(this.getWorkingDirectoryPath(), '.git');
+    } else {
+      // Absent/Loading/etc.
+      return null;
     }
   }
 

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -80,6 +80,11 @@ describe('Repository', function() {
       const repositoryWithGitFile = new Repository(workingDirPathWithGitFile);
       await assert.async.equal(repositoryWithGitFile.getGitDirectoryPath(), path.join(workingDirPath, '.git'));
     });
+
+    it('returns null for absent/loading repositories', function() {
+      const repo = Repository.absent();
+      repo.getGitDirectoryPath();
+    });
   });
 
   describe('init', function() {


### PR DESCRIPTION
This is the cause of the failing main process tests in https://github.com/atom/atom/pull/14959