### PR TITLE
Collect an --exec-path from a native git installation, if any

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import os from 'os';
+import childProcess from 'child_process';
 import {remote} from 'electron';
 
 import {CompositeDisposable} from 'event-kit';
@@ -27,6 +28,7 @@ const ENV_VARS_TO_COPY = [
 ];
 
 let headless = null;
+let execPathPromise = null;
 
 export class GitError extends Error {
   constructor(message) {
@@ -67,7 +69,7 @@ export default class GitShellOutStrategy {
   }
 
   // Execute a command and read the output using the embedded Git environment
-  exec(args, {stdin, useGitPromptServer, writeOperation} = GitShellOutStrategy.defaultExecArgs) {
+  async exec(args, {stdin, useGitPromptServer, writeOperation} = GitShellOutStrategy.defaultExecArgs) {
     /* eslint-disable no-console */
     const subscriptions = new CompositeDisposable();
     const diagnosticsEnabled = process.env.ATOM_GITHUB_GIT_DIAGNOSTICS || atom.config.get('github.gitDiagnostics');
@@ -76,13 +78,37 @@ export default class GitShellOutStrategy {
     const timingMarker = GitTimingsView.generateMarker(`git ${args.join(' ')}`);
     timingMarker.mark('queued');
 
+    if (execPathPromise === null) {
+      // Attempt to collect the --exec-path from a native git installation.
+      execPathPromise = new Promise((resolve, reject) => {
+        childProcess.exec('git --exec-path', (error, stdout, stderr) => {
+          if (error) {
+            // Oh well
+            resolve(null);
+            return;
+          }
+
+          resolve(stdout.trim());
+        });
+      });
+    }
+    const execPath = await execPathPromise;
+
     return this.commandQueue.push(async () => {
       timingMarker.mark('prepare');
       let gitPromptServer;
 
+      const pathParts = [];
+      if (process.env.PATH) {
+        pathParts.push(process.env.PATH);
+      }
+      if (execPath) {
+        pathParts.push(execPath);
+      }
+
       const env = {
         GIT_TERMINAL_PROMPT: '0',
-        PATH: process.env.PATH || '',
+        PATH: pathParts.join(path.delimiter),
       };
 
       ENV_VARS_TO_COPY.forEach(envVar => {


### PR DESCRIPTION
Depending on the way that a user's native git is installed, some git binaries (notably bundled credential helpers, like `git-credential-osxkeychain`) are included on git's "exec path," but not by default on your system `${PATH}`. When we execute git commands through Dugite, Dugite's bundled git distribution has its _own_ exec path which doesn't include those binaries, leading to issues like #998.

I've added a one-time exec that attempts to collect the native git's `--exec-path`, then added it to the`${PATH}` used for git operations. If git can't be found or some other error occurs, no big deal.

This may still miss some cases where a user is adding the git executable to their path in a file that `/bin/sh` doesn't load (`~/.zshrc` maybe?). It will catch situations like "the XCode git install" though.