### PR TITLE
Pass credentials correctly when username is provided in the git URL

### DIFF
--- a/lib/views/credential-dialog.js
+++ b/lib/views/credential-dialog.js
@@ -76,7 +76,13 @@ export default class CredentialDialog extends React.Component {
 
   @autobind
   confirm() {
-    this.props.onSubmit(this.state);
+    const payload = {password: this.state.password};
+
+    if (this.props.includeUsername) {
+      payload.username = this.state.username;
+    }
+
+    this.props.onSubmit(payload);
   }
 
   @autobind

--- a/lib/views/credential-dialog.js
+++ b/lib/views/credential-dialog.js
@@ -47,7 +47,7 @@ export default class CredentialDialog extends React.Component {
               <input
                 type="text"
                 ref={e => (this.usernameInput = e)}
-                className="input-text"
+                className="input-text github-CredentialDialog-Username"
                 value={this.state.username}
                 onChange={this.onUsernameChange}
                 tabIndex="1"
@@ -59,7 +59,7 @@ export default class CredentialDialog extends React.Component {
             <input
               type="password"
               ref={e => (this.passwordInput = e)}
-              className="input-text"
+              className="input-text github-CredentialDialog-Password"
               value={this.state.password}
               onChange={this.onPasswordChange}
               tabIndex="2"

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -100,7 +100,7 @@ describe('GitPromptServer', function() {
 
       assert.ifError(err);
 
-      assert.equal(queried.prompt, 'Please enter your credentials for https://ultimate-answer.com');
+      assert.equal(queried.prompt, 'Please enter your credentials for https://dent-arthur-dent@ultimate-answer.com');
       assert.isFalse(queried.includeUsername);
 
       assert.equal(stdout,

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -76,7 +76,7 @@ describe('GitPromptServer', function() {
       assert.isFalse(await fileExists(path.join(server.tmpFolderPath, 'remember')));
     });
 
-    it('preserves a provided username', async function () {
+    it('preserves a provided username', async function() {
       this.timeout(10000);
 
       let queried = null;

--- a/test/views/credential-dialog.test.js
+++ b/test/views/credential-dialog.test.js
@@ -56,7 +56,7 @@ describe('CredentialDialog', function() {
       wrapper.find('.btn-primary').simulate('click');
 
       assert.deepEqual(didSubmit.firstCall.args[0], {
-        password: 'letmein'
+        password: 'twowordsuppercase'
       });
     });
   })

--- a/test/views/credential-dialog.test.js
+++ b/test/views/credential-dialog.test.js
@@ -16,7 +16,7 @@ describe('CredentialDialog', function() {
     app = (
       <CredentialDialog
         commandRegistry={atomEnv.commands}
-        prompt='speak friend and enter'
+        prompt="speak friend and enter"
         includeUsername={true}
         onSubmit={didSubmit}
         onCancel={didCancel}
@@ -26,13 +26,13 @@ describe('CredentialDialog', function() {
 
   afterEach(function() {
     atomEnv.destroy();
-  })
+  });
 
   const setTextIn = function(selector, text) {
     wrapper.find(selector).simulate('change', {target: {value: text}});
   };
 
-  describe('confirm', function () {
+  describe('confirm', function() {
     it('reports the current username and password', function() {
       wrapper = mount(app);
 
@@ -43,7 +43,7 @@ describe('CredentialDialog', function() {
 
       assert.deepEqual(didSubmit.firstCall.args[0], {
         username: 'someone',
-        password: 'letmein'
+        password: 'letmein',
       });
     });
 
@@ -56,8 +56,8 @@ describe('CredentialDialog', function() {
       wrapper.find('.btn-primary').simulate('click');
 
       assert.deepEqual(didSubmit.firstCall.args[0], {
-        password: 'twowordsuppercase'
+        password: 'twowordsuppercase',
       });
     });
-  })
-})
+  });
+});

--- a/test/views/credential-dialog.test.js
+++ b/test/views/credential-dialog.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import CredentialDialog from '../../lib/views/credential-dialog';
+
+describe('CredentialDialog', function() {
+  let atomEnv;
+  let app, wrapper, didSubmit, didCancel;
+
+  beforeEach(function() {
+    atomEnv = global.buildAtomEnvironment();
+
+    didSubmit = sinon.stub();
+    didCancel = sinon.stub();
+
+    app = (
+      <CredentialDialog
+        commandRegistry={atomEnv.commands}
+        prompt='speak friend and enter'
+        includeUsername={true}
+        onSubmit={didSubmit}
+        onCancel={didCancel}
+      />
+    );
+  });
+
+  afterEach(function() {
+    atomEnv.destroy();
+  })
+
+  const setTextIn = function(selector, text) {
+    wrapper.find(selector).simulate('change', {target: {value: text}});
+  };
+
+  describe('confirm', function () {
+    it('reports the current username and password', function() {
+      wrapper = mount(app);
+
+      setTextIn('.github-CredentialDialog-Username', 'someone');
+      setTextIn('.github-CredentialDialog-Password', 'letmein');
+
+      wrapper.find('.btn-primary').simulate('click');
+
+      assert.deepEqual(didSubmit.firstCall.args[0], {
+        username: 'someone',
+        password: 'letmein'
+      });
+    });
+
+    it('omits the username if includeUsername is false', function() {
+      wrapper = mount(React.cloneElement(app, {includeUsername: false}));
+
+      assert.isFalse(wrapper.find('.github-CredentialDialog-Username').exists());
+      setTextIn('.github-CredentialDialog-Password', 'twowordsuppercase');
+
+      wrapper.find('.btn-primary').simulate('click');
+
+      assert.deepEqual(didSubmit.firstCall.args[0], {
+        password: 'letmein'
+      });
+    });
+  })
+})


### PR DESCRIPTION
It turns out that `CredentialsDialog` was calling its submit callback with `{username: '', password: 'whatever'}` when `includeUsername` was false, which was causing our credential handler to stomp out the username that was provided originally.

I've added some tests that catch this case, and omitted the `username` key from the result object if `includeUsername` is true.

Fixes #941.