### PR TITLE
Move assertions in GitPromptServer tests out of the server process

### DIFF
--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -49,9 +49,10 @@ describe('GitPromptServer', function() {
     it('prompts for user input and writes collected credentials to stdout', async function() {
       this.timeout(10000);
 
+      let queried = null;
+
       function queryHandler(query) {
-        assert.equal(query.prompt, 'Please enter your credentials for https://what-is-your-favorite-color.com');
-        assert.isTrue(query.includeUsername);
+        queried = query;
         return {
           username: 'old-man-from-scene-24',
           password: 'Green. I mean blue! AAAhhhh...',
@@ -66,6 +67,9 @@ describe('GitPromptServer', function() {
       }
 
       const {err, stdout} = await runCredentialScript('get', queryHandler, processHandler);
+
+      assert.equal(queried.prompt, 'Please enter your credentials for https://what-is-your-favorite-color.com');
+      assert.isTrue(queried.includeUsername);
 
       assert.ifError(err);
       assert.equal(stdout,
@@ -166,10 +170,11 @@ describe('GitPromptServer', function() {
     it('prompts for user input and writes the response to stdout', async function() {
       this.timeout(10000);
 
+      let queried = null;
+
       const server = new GitPromptServer();
       const {askPass, socket, electron} = await server.start(query => {
-        assert.equal(query.prompt, 'Please enter your password for "updog"');
-        assert.isFalse(query.includeUsername);
+        queried = query;
         return {
           password: "What's 'updog'?",
         };
@@ -192,6 +197,9 @@ describe('GitPromptServer', function() {
 
       assert.ifError(err);
       assert.equal(stdout, "What's 'updog'?");
+
+      assert.equal(queried.prompt, 'Please enter your password for "updog"');
+      assert.isFalse(queried.includeUsername);
 
       await server.terminate();
     });


### PR DESCRIPTION
Some of our GitPromptServer specs performed chai assertions in a callback that was invoked as part of the _server_ process. This causes problems because it kills the server process before it writes the JSON response, which hangs the spec and triggers a spurious timeout.

I've changed those specs to capture the query into a variable and make assertions about it in the end, instead.

We still have some flakiness around these specs, but this should help by at least surfacing the correct error messages :eyes: