### PR TITLE
Fix stale function reference when calling context menu handler

### DIFF
--- a/lib/context-menu-interceptor.js
+++ b/lib/context-menu-interceptor.js
@@ -24,7 +24,7 @@ export default class ContextMenuInterceptor extends React.Component {
   componentDidMount() {
     // Helpfully, addEventListener dedupes listeners for us.
     document.addEventListener('contextmenu', contextMenuHandler, {capture: true});
-    ContextMenuInterceptor.registration.set(this.element, this.props.onWillShowContextMenu);
+    ContextMenuInterceptor.registration.set(this.element, (...args) => this.props.onWillShowContextMenu(...args));
   }
 
   render() {


### PR DESCRIPTION
Fixes #885 

Upon mounting, ContextMenuInterceptor retained the onWillShowContextMenu
prop as a direct function reference; when updating the component with
a new onWillShowContextMenu, the retained function was not updated. As
a result, right-clicking on the wrapped element could potentially call
a previously-passed value of onWillShowContextMenu. The solution is to
instead retain a function that has dynamic access to the latest
onWillShowContextMenu prop.

An alternative solution was to update the retained function in a
componentDidUpdate hook, but by registering a function that has
the ability to look up the prop dynamically, this hook isn't necessary.