### PR TITLE
Various fixes

### DIFF
--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -56,6 +56,7 @@ export default class GitTabController {
         commandRegistry={this.props.commandRegistry}
         grammars={this.props.grammars}
         notificationManager={this.props.notificationManager}
+        project={this.props.project}
         confirm={this.props.confirm}
         initializeRepo={this.props.initializeRepo}
         didSelectFilePath={this.props.didSelectFilePath}

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -53,6 +53,7 @@ export default class RootController extends React.Component {
     tooltips: PropTypes.object.isRequired,
     grammars: PropTypes.object.isRequired,
     config: PropTypes.object.isRequired,
+    project: PropTypes.object.isRequired,
     confirm: PropTypes.func.isRequired,
     activeWorkingDirectory: PropTypes.string,
     getRepositoryForWorkdir: PropTypes.func.isRequired,
@@ -84,6 +85,8 @@ export default class RootController extends React.Component {
       cloneDialogActive: false,
       cloneDialogInProgress: false,
       initDialogActive: false,
+      initDialogPath: null,
+      initDialogResolve: null,
       credentialDialogQuery: null,
     };
 
@@ -194,6 +197,7 @@ export default class RootController extends React.Component {
             commandRegistry={this.props.commandRegistry}
             notificationManager={this.props.notificationManager}
             grammars={this.props.grammars}
+            project={this.props.project}
             confirm={this.props.confirm}
             repository={this.props.repository}
             initializeRepo={this.initializeRepo}
@@ -237,6 +241,7 @@ export default class RootController extends React.Component {
         <InitDialog
           config={this.props.config}
           commandRegistry={this.props.commandRegistry}
+          initPath={this.state.initDialogPath}
           didAccept={this.acceptInit}
           didCancel={this.cancelInit}
         />
@@ -362,13 +367,15 @@ export default class RootController extends React.Component {
   }
 
   @autobind
-  async initializeRepo() {
+  async initializeRepo(initDialogPath) {
     if (this.props.activeWorkingDirectory) {
       await this.acceptInit(this.props.activeWorkingDirectory);
       return;
     }
 
-    this.setState({initDialogActive: true});
+    return new Promise(resolve => {
+      this.setState({initDialogActive: true, initDialogPath, initDialogResolve: resolve});
+    });
   }
 
   @autobind
@@ -405,19 +412,21 @@ export default class RootController extends React.Component {
   async acceptInit(projectPath) {
     try {
       await this.props.createRepositoryForProjectPath(projectPath);
+      if (this.state.initDialogResolve) { this.state.initDialogResolve(true); }
     } catch (e) {
       this.props.notificationManager.addError(
         `Unable to initialize git repository in ${projectPath}`,
         {detail: e.stdErr, dismissable: true},
       );
     } finally {
-      this.setState({initDialogActive: false});
+      this.setState({initDialogActive: false, initDialogPath: null, initDialogResolve: null});
     }
   }
 
   @autobind
   cancelInit() {
-    this.setState({initDialogActive: false});
+    if (this.state.initDialogResolve) { this.state.initDialogResolve(false); }
+    this.setState({initDialogActive: false, initDialogPath: null, initDialogResolve: null});
   }
 
   @autobind
@@ -490,6 +499,28 @@ export default class RootController extends React.Component {
     const editor = this.props.workspace.getActiveTextEditor();
     const absFilePath = await realPath(editor.getPath());
     const repoPath = this.props.repository.getWorkingDirectoryPath();
+    if (repoPath === null) {
+      const [projectPath] = this.props.project.relativizePath(editor.getPath());
+      const notification = this.props.notificationManager.addInfo(
+        "Hmm, we don't have anything to compare this to.",
+        {
+          description: 'Create a Git repository in order to view changes to the files in your project.',
+          dismissable: true,
+          buttons: [{
+            className: 'btn btn-primary',
+            text: 'Create a repository now',
+            onDidClick: async () => {
+              notification.dismiss();
+              const created = await this.initializeRepo(projectPath);
+              // If the user confirmed repository creation,
+              // retry the operation that got them here in the first place
+              if (created) { this.viewChangesForCurrentFile(stagingStatus); }
+            },
+          }],
+        },
+      );
+      return;
+    }
     if (absFilePath.startsWith(repoPath)) {
       const filePath = absFilePath.slice(repoPath.length + 1);
       this.quietlySelectItem(filePath, stagingStatus);

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -368,6 +368,10 @@ export default class RootController extends React.Component {
 
   @autobind
   async initializeRepo(initDialogPath) {
+    if (this.state.initDialogActive) {
+      return null;
+    }
+
     if (this.props.activeWorkingDirectory) {
       await this.acceptInit(this.props.activeWorkingDirectory);
       return null;

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -55,7 +55,6 @@ export default class RootController extends React.Component {
     config: PropTypes.object.isRequired,
     project: PropTypes.object.isRequired,
     confirm: PropTypes.func.isRequired,
-    activeWorkingDirectory: PropTypes.string,
     getRepositoryForWorkdir: PropTypes.func.isRequired,
     createRepositoryForProjectPath: PropTypes.func,
     cloneRepositoryForProjectPath: PropTypes.func,
@@ -369,11 +368,6 @@ export default class RootController extends React.Component {
   @autobind
   async initializeRepo(initDialogPath) {
     if (this.state.initDialogActive) {
-      return null;
-    }
-
-    if (this.props.activeWorkingDirectory) {
-      await this.acceptInit(this.props.activeWorkingDirectory);
       return null;
     }
 

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -506,9 +506,9 @@ export default class RootController extends React.Component {
     if (repoPath === null) {
       const [projectPath] = this.props.project.relativizePath(editor.getPath());
       const notification = this.props.notificationManager.addInfo(
-        "Hmm, we don't have anything to compare this to.",
+        "Hmm, there's nothing to compare this file to",
         {
-          description: 'Create a Git repository in order to view changes to the files in your project.',
+          description: 'You can create a Git repository to track changes to the files in your project.',
           dismissable: true,
           buttons: [{
             className: 'btn btn-primary',

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -366,7 +366,7 @@ export default class RootController extends React.Component {
   }
 
   @autobind
-  async initializeRepo(initDialogPath) {
+  initializeRepo(initDialogPath) {
     if (this.state.initDialogActive) {
       return null;
     }

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -412,7 +412,7 @@ export default class RootController extends React.Component {
   async acceptInit(projectPath) {
     try {
       await this.props.createRepositoryForProjectPath(projectPath);
-      if (this.state.initDialogResolve) { this.state.initDialogResolve(true); }
+      if (this.state.initDialogResolve) { this.state.initDialogResolve(projectPath); }
     } catch (e) {
       this.props.notificationManager.addError(
         `Unable to initialize git repository in ${projectPath}`,
@@ -511,10 +511,10 @@ export default class RootController extends React.Component {
             text: 'Create a repository now',
             onDidClick: async () => {
               notification.dismiss();
-              const created = await this.initializeRepo(projectPath);
-              // If the user confirmed repository creation,
+              const createdPath = await this.initializeRepo(projectPath);
+              // If the user confirmed repository creation for this project path,
               // retry the operation that got them here in the first place
-              if (created) { this.viewChangesForCurrentFile(stagingStatus); }
+              if (createdPath === projectPath) { this.viewChangesForCurrentFile(stagingStatus); }
             },
           }],
         },

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -26,7 +26,7 @@ import RepositoryConflictController from './repository-conflict-controller';
 import ModelStateRegistry from '../models/model-state-registry';
 import Conflict from '../models/conflicts/conflict';
 import Switchboard from '../switchboard';
-import {copyFile, deleteFileOrFolder} from '../helpers';
+import {copyFile, deleteFileOrFolder, realPath} from '../helpers';
 import {GitError} from '../git-shell-out-strategy';
 
 function getPropsFromUri(uri) {
@@ -488,7 +488,7 @@ export default class RootController extends React.Component {
 
   async viewChangesForCurrentFile(stagingStatus) {
     const editor = this.props.workspace.getActiveTextEditor();
-    const absFilePath = editor.getPath();
+    const absFilePath = await realPath(editor.getPath());
     const repoPath = this.props.repository.getWorkingDirectoryPath();
     if (absFilePath.startsWith(repoPath)) {
       const filePath = absFilePath.slice(repoPath.length + 1);

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -370,7 +370,7 @@ export default class RootController extends React.Component {
   async initializeRepo(initDialogPath) {
     if (this.props.activeWorkingDirectory) {
       await this.acceptInit(this.props.activeWorkingDirectory);
-      return;
+      return null;
     }
 
     return new Promise(resolve => {

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -272,7 +272,6 @@ export default class GithubPackage {
         config={this.config}
         project={this.project}
         confirm={this.confirm}
-        activeWorkingDirectory={this.getActiveWorkdir()}
         repository={this.getActiveRepository()}
         resolutionProgress={this.getActiveResolutionProgress()}
         statusBar={this.statusBar}

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -270,6 +270,7 @@ export default class GithubPackage {
         tooltips={this.tooltips}
         grammars={this.grammars}
         config={this.config}
+        project={this.project}
         confirm={this.confirm}
         activeWorkingDirectory={this.getActiveWorkdir()}
         repository={this.getActiveRepository()}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -171,8 +171,14 @@ export function getTempDir(prefix = '') {
         return;
       }
 
-      fs.realpath(folder, (realError, rpath) => (realError ? reject(realError) : resolve(rpath)));
+      resolve(realPath(folder));
     });
+  });
+}
+
+export function realPath(folder) {
+  return new Promise((resolve, reject) => {
+    fs.realpath(folder, (err, rpath) => (err ? reject(err) : resolve(rpath)));
   });
 }
 

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -115,7 +115,15 @@ export default class GitTabView {
   @autobind
   async initializeRepo(event) {
     event.preventDefault();
-    await this.props.initializeRepo();
+    let initPath = null;
+    const activeEditor = this.props.workspace.getActiveTextEditor();
+    if (activeEditor) {
+      const [projectPath] = this.props.project.relativizePath(activeEditor.getPath());
+      if (projectPath) {
+        initPath = projectPath;
+      }
+    }
+    await this.props.initializeRepo(initPath);
   }
 
   rememberFocus(event) {

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -113,7 +113,7 @@ export default class GitTabView {
   }
 
   @autobind
-  async initializeRepo(event) {
+  initializeRepo(event) {
     event.preventDefault();
     let initPath = null;
     const activeEditor = this.props.workspace.getActiveTextEditor();
@@ -123,7 +123,7 @@ export default class GitTabView {
         initPath = projectPath;
       }
     }
-    await this.props.initializeRepo(initPath);
+    this.props.initializeRepo(initPath);
   }
 
   rememberFocus(event) {

--- a/lib/views/init-dialog.js
+++ b/lib/views/init-dialog.js
@@ -11,6 +11,7 @@ export default class InitDialog extends React.Component {
     commandRegistry: PropTypes.object.isRequired,
     didAccept: PropTypes.func,
     didCancel: PropTypes.func,
+    initPath: PropTypes.string,
   }
 
   static defaultProps = {

--- a/lib/views/init-dialog.js
+++ b/lib/views/init-dialog.js
@@ -25,13 +25,12 @@ export default class InitDialog extends React.Component {
       initDisabled: false,
     };
 
-    this.projectHome = this.props.config.get('core.projectHome');
     this.subs = new CompositeDisposable();
   }
 
   componentDidMount() {
     if (this.projectPathEditor) {
-      this.projectPathEditor.setText(this.props.config.get('core.projectHome'));
+      this.projectPathEditor.setText(this.props.initPath || this.props.config.get('core.projectHome'));
       this.projectPathModified = false;
     }
 

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -9,6 +9,7 @@ import {File} from 'atom';
 import path from 'path';
 import etch from 'etch';
 import {autobind} from 'core-decorators';
+import compareSets from 'compare-sets';
 
 import FilePatchListItemView from './file-patch-list-item-view';
 import MergeConflictListItemView from './merge-conflict-list-item-view';
@@ -132,6 +133,8 @@ export default class StagingView {
       stagedChanges: this.props.stagedChanges,
       mergeConflicts: this.props.mergeConflicts || [],
     });
+    const previouslySelectedItems = this.selection.getSelectedItems();
+
     this.selection.updateLists({
       unstaged: this.props.unstagedChanges,
       conflicts: this.props.mergeConflicts || [],
@@ -142,7 +145,11 @@ export default class StagingView {
       await this.resolutionProgressObserver.setActiveModel(this.props.resolutionProgress);
     }
 
-    this.debouncedDidChangeSelectedItem();
+    const {added, removed} = compareSets(previouslySelectedItems, this.selection.getSelectedItems());
+    if (added.size > 0 || removed.size > 0) {
+      this.debouncedDidChangeSelectedItem();
+    }
+
     return etch.update(this);
   }
 
@@ -175,7 +182,7 @@ export default class StagingView {
     }
 
     this.selection.coalesce();
-    this.didChangeSelectedItems();
+    this.debouncedDidChangeSelectedItem();
     etch.update(this);
     return true;
   }
@@ -187,7 +194,7 @@ export default class StagingView {
     }
 
     this.selection.coalesce();
-    this.didChangeSelectedItems();
+    this.debouncedDidChangeSelectedItem();
     etch.update(this);
     return true;
   }
@@ -198,7 +205,7 @@ export default class StagingView {
     }
 
     this.selection.coalesce();
-    this.didChangeSelectedItems();
+    this.debouncedDidChangeSelectedItem();
     etch.update(this);
     return true;
   }

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -330,19 +330,6 @@ describe('RootController', function() {
       }));
     });
 
-    it('initializes the current working directory if there is one', function() {
-      app = React.cloneElement(app, {
-        createRepositoryForProjectPath,
-        activeWorkingDirectory: '/some/workdir',
-      });
-      const wrapper = shallow(app);
-
-      wrapper.instance().initializeRepo();
-      resolveInit();
-
-      assert.isTrue(createRepositoryForProjectPath.calledWith('/some/workdir'));
-    });
-
     it('renders the modal init panel', function() {
       app = React.cloneElement(app, {createRepositoryForProjectPath});
       const wrapper = shallow(app);

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -1072,7 +1072,7 @@ describe('RootController', function() {
         sinon.stub(workspace, 'open').returns(filePatchItem);
         await wrapper.instance().viewUnstagedChangesForCurrentFile();
 
-        assert.equal(workspace.open.callCount, 1);
+        await assert.async.equal(workspace.open.callCount, 1);
         assert.deepEqual(workspace.open.args[0], [
           `atom-github://file-patch/a.txt?workdir=${workdirPath}&stagingStatus=unstaged`,
           {pending: true, activatePane: true, activateItem: true},
@@ -1105,7 +1105,7 @@ describe('RootController', function() {
         sinon.stub(workspace, 'open').returns(filePatchItem);
         await wrapper.instance().viewStagedChangesForCurrentFile();
 
-        assert.equal(workspace.open.callCount, 1);
+        await assert.async.equal(workspace.open.callCount, 1);
         assert.deepEqual(workspace.open.args[0], [
           `atom-github://file-patch/a.txt?workdir=${workdirPath}&stagingStatus=staged`,
           {pending: true, activatePane: true, activateItem: true},

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -169,7 +169,7 @@ describe('GitPromptServer', function() {
   });
 
   describe('askpass helper', function() {
-    it.only('prompts for user input and writes the response to stdout', async function() {
+    it('prompts for user input and writes the response to stdout', async function() {
       this.timeout(10000);
       this.retries(5);
 


### PR DESCRIPTION
Fixes #950 - Use real path when checking if file is in repo

Fixes #982 - Handle viewing changes for file not in repo; notify user that repo does not exist, and provide a button to create a new repo. If the user initializes the repo, we retry the original operation to view changes for the opened file.


