### PR TITLE
Fix regression for updating the discard history after loading

### DIFF
--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -54,6 +54,10 @@ export default class Present extends State {
       this.workdir(),
       {maxHistoryLength: 60},
     );
+
+    if (history) {
+      this.discardHistory.updateHistory(history);
+    }
   }
 
   isPresent() {


### PR DESCRIPTION
Fixes #1104 

This PR fixes a regression that was likely introduced during the refactor of the Repository model into a state machine. The result is that when Atom is reloaded, the discard history is updated appropriately in the model layer, and the "Undo discard" buttons appear in the UI so that previous states can be restored easily.