### PR TITLE
BetterPropTypes: a less verbose PropTypes

### DIFF
--- a/lib/better-prop-types.js
+++ b/lib/better-prop-types.js
@@ -1,0 +1,73 @@
+import PropTypes from 'prop-types';
+
+const betterPropTypes = new Proxy(processSpec, {
+  apply(target, thisArg, argumentsList) {
+    return processSpec(...argumentsList);
+  },
+
+  get(target, property, receiver) {
+    if (property === 'opt' || property === 'optional') {
+      return spec => {
+        return betterPropTypes.shape(spec).opt;
+      };
+    } else if (PropTypes[property]) {
+      const val = {
+        _bpt: true,
+        proxyFor: property,
+        isRequired: true,
+        args: null,
+        get opt() { val.isRequired = false; return val; },
+        get optional() { val.isRequired = false; return val; },
+      };
+      return new Proxy(() => {}, {
+        apply(funcTarget, thisArg, args) {
+          val.args = args.map(arg => {
+            if (arg._bpt) {
+              return transformProxy(arg);
+            } else if (typeof arg === 'object' && !Array.isArray(arg)) {
+              const innerSpec = betterPropTypes(arg);
+              return PropTypes.shape(innerSpec).isRequired;
+            } else {
+              return arg;
+            }
+          });
+          return val;
+        },
+
+        get(_target, prop, _receiver) {
+          return val[prop];
+        },
+
+        set(_target, prop, value, _receiver) {
+          val[prop] = value;
+        },
+      });
+    } else {
+      throw new Error(`Cannot proxy unknown prop type ${property}`);
+    }
+  },
+});
+
+function processSpec(spec) {
+  Object.keys(spec).forEach(key => {
+    const propType = spec[key];
+    if (propType._bpt) {
+      spec[key] = transformProxy(propType);
+    } else if (typeof propType === 'object' && !Array.isArray(propType)) {
+      const innerSpec = betterPropTypes(propType);
+      spec[key] = PropTypes.shape(innerSpec).isRequired;
+    }
+  });
+
+  return spec;
+}
+
+function transformProxy({proxyFor, isRequired, args}) {
+  let proxied = PropTypes[proxyFor];
+  if (args) {
+    proxied = proxied(...args);
+  }
+  return isRequired ? proxied.isRequired : proxied;
+}
+
+export default betterPropTypes;


### PR DESCRIPTION
Through my work on this package, I've started to notice a couple things about components' `propTypes`.

First, especially with Relay containers, there are lots of `shape`s. These can go deep, depending on the data you're querying. For example, for a container with

```graphql
fragment PrInfoContainer_pullRequest on PullRequest {
  id url number title state createdAt
  author {
    login avatarUrl
    ... on User { url }
    ... on Bot { url }
  }
  repository { name owner { login } }
  reactionGroups {
    content users { totalCount }
  }
  commitsCount:commits { totalCount }
  labels(first:100) {
    edges {
      node {
        name color
      }
    }
  }
}
```

you'd need the following `propTypes` to fully type-check the response:

```javascript
static propTypes = {
  relay: PropTypes.shape({
    refetch: PropTypes.func.isRequired,
  }).isRequired,
  pinnedByUrl: PropTypes.bool,
  onUnpinPr: PropTypes.func,
  pullRequest: PropTypes.shape({
    id: PropTypes.string.isRequired,
    title: PropTypes.string,
    bodyHTML: PropTypes.string,
    number: PropTypes.number,
    repository: PropTypes.shape({
      name: PropTypes.string.isRequired,
      owner: PropTypes.shape({
        login: PropTypes.string,
      }),
    }),
    state: PropTypes.oneOf([
      'OPEN', 'CLOSED', 'MERGED',
    ]).isRequired,
    author: PropTypes.shape({
      login: PropTypes.string.isRequired,
      avatarUrl: PropTypes.string.isRequired,
      url: PropTypes.string.isRequired,
    }).isRequired,
    reactionGroups: PropTypes.arrayOf(
      PropTypes.shape({
        content: PropTypes.string.isRequired,
        users: PropTypes.shape({
          totalCount: PropTypes.number.isRequired,
        }).isRequired,
      }),
    ).isRequired,
  }).isRequired,
}
```

(Granted, this component probably contains a few other components waiting to be extracted, but nested `shape`s are still pretty common.)

Second, more often than not, fields are `.isRequired`. I'd argue that most components are built to accept most of their props by default, and only certain props should *explicitly* be made optional, but `prop-types` reverses this, making things optional by default.

---

This PR introduces `BetterPropTypes`, a DSL for declaring `propTypes` in a less verbose way. The main changes are:

1. **`.isRequired` by default** — you have to explicitly make a field optional by calling `.opt` or `.optional`
2. **`.shape` is replaced by plain objects** — this makes declaring nested data way easier

For example,

```javascript
import PropTypes from 'prop-types';
// ...
static propTypes = {
  callback: PropTypes.func.isRequired,
  data: PropTypes.shape({
    id: PropTypes.string.isRequired,
    user: PropTypes.shape({
      name: PropTypes.string.isRequired,
    }).isRequired,
    friends: PropTypes.arrayOf(
      PropTypes.shape({
        id: PropTypes.string.isRequired,
        user: PropTypes.shape({
          name: PropTypes.string.isRequired,
        }).isRequired,
      })
    ),
  }).isRequired,
}
```

becomes


```javascript
import pt from 'better-prop-types';
// ...
static propTypes = {
  callback: pt.func,
  data: {
    id: pt.string,
    user: {
      name: pt.string,
    },
    friends: pt.arrayOf({
      id: pt.string,
      user: {
        name: pt.string,
      },
    })
  },
}
```

Plain objects are turned into `PropTypes.shape(...).isRequired` by default, and can be made optional via an explicit `pt.opt(...)`.

---

I've converted a few components in the project to the new DSL as a test, and have fixed a few edges cases in the process, but I'm sure there are more. If we were to move to this, I'd provide a test suite (and likely extract this into its own package).

For now, I'd love to hear 💭 s about whether or not this is a good idea.

![Good idea? Bad idea?](http://i.imgur.com/iH5nnIb.gif)

Warning for those interested in the code: here there be ~~dragons~~ Proxies.