### PR TITLE
Fix discarding changes from key binding in staging view

### DIFF
--- a/keymaps/git.cson
+++ b/keymaps/git.cson
@@ -27,7 +27,7 @@
   'o': 'github:open-file'
   'left': 'core:move-left'
 
-'.github-StagingView .github-UnstagedChanges .github-FilePatchListView':
+'.github-StagingView.unstaged-changes-focused':
   'cmd-backspace': 'github:discard-changes-in-selected-files'
   'ctrl-backspace': 'github:discard-changes-in-selected-files'
 

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -92,6 +92,7 @@ export default class StagingView {
       'github:open-file': () => this.openFile(),
       'github:resolve-file-as-ours': () => this.resolveCurrentAsOurs(),
       'github:resolve-file-as-theirs': () => this.resolveCurrentAsTheirs(),
+      'github:discard-changes-in-selected-files': () => this.discardChanges(),
       'core:undo': () => this.props.hasUndoHistory && this.undoLastDiscard(),
     }));
     this.subscriptions.add(this.props.commandRegistry.add('atom-workspace', {
@@ -99,9 +100,6 @@ export default class StagingView {
       'github:unstage-all-changes': () => this.unstageAll(),
       'github:discard-all-changes': () => this.discardAll(),
       'github:undo-last-discard-in-git-tab': () => this.props.hasUndoHistory && this.undoLastDiscard(),
-    }));
-    this.subscriptions.add(this.props.commandRegistry.add(this.refs.unstagedChanges, {
-      'github:discard-changes-in-selected-files': () => this.discardChanges(),
     }));
     window.addEventListener('mouseup', this.mouseup);
     this.subscriptions.add(


### PR DESCRIPTION
Previously, using `ctrl-backspace` or `cmd-backspace` in the staging view to discard changes did not work. Upon some investigation, I discovered that the following problems that were preventing it from working as intended:

* The selector associated with the key binding targeted an element that doesn't actually receive focus, and so was not matching when we ran the command.
* The command was bound to the unstaged changes view, but the *focusable* element is actually the staging view itself, which is the parent of the unstaged changes view. The context menu fires the command event on the target of the right click, but key bindings always fire the command on the focusable element, so the child element never received it from the binding.

By fixing both of these issues, we can now discard unstaged changes from the keybord. Yay!