### PR TITLE
Wait for project watchers to start if the API is available

### DIFF
--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -597,11 +597,18 @@ describe('GithubPackage', function() {
 
       project.setPaths([workdirPath1, workdirPath2]);
       await githubPackage.activate();
-      await until('change observers have started', () => {
-        return [workdirPath1, workdirPath2].every(workdir => {
-          return contextPool.getContext(workdir).getChangeObserver().isStarted();
-        });
-      });
+
+      const watcherPromises = [
+        until(() => contextPool.getContext(workdirPath1).getChangeObserver().isStarted()),
+        until(() => contextPool.getContext(workdirPath2).getChangeObserver().isStarted()),
+      ];
+
+      if (project.getWatcherPromise) {
+        watcherPromises.push(project.getWatcherPromise(workdirPath1));
+        watcherPromises.push(project.getWatcherPromise(workdirPath2));
+      }
+
+      await Promise.all(watcherPromises);
 
       [atomGitRepository1, atomGitRepository2] = githubPackage.project.getRepositories();
       sinon.stub(atomGitRepository1, 'refreshStatus');

--- a/test/models/file-system-change-observer.test.js
+++ b/test/models/file-system-change-observer.test.js
@@ -13,9 +13,6 @@ describe('FileSystemChangeObserver', function() {
     const changeObserver = new FileSystemChangeObserver(repository);
     changeObserver.onDidChange(changeSpy);
     await changeObserver.start();
-    if (changeObserver.currentFileWatcher.getStartPromise) {
-      await changeObserver.currentFileWatcher.getStartPromise();
-    }
 
     fs.writeFileSync(path.join(workdirPath, 'a.txt'), 'a change\n');
     await assert.async.isTrue(changeSpy.called);


### PR DESCRIPTION
Use the `atom.project.getWatcherPromise()` method introduced in atom/atom#15377 to fix github-package tests that would sporadically fail because the project watcher was not listening for events before the `fs.writeSync` calls.