### PR TITLE
Respect TEST_JUNIT_XML_PATH if present

### DIFF
--- a/test/runner.js
+++ b/test/runner.js
@@ -24,7 +24,12 @@ module.exports = createRunner({
   overrideTestPaths: [/spec$/, /test/],
 }, mocha => {
   mocha.timeout(parseInt(process.env.MOCHA_TIMEOUT || '5000', 10));
-  if (process.env.APPVEYOR_API_URL) {
+
+  if (process.env.TEST_JUNIT_XML_PATH) {
+    mocha.reporter(require('mocha-junit-and-console-reporter'), {
+      mochaFile: process.env.TEST_JUNIT_XML_PATH,
+    });
+  } else if (process.env.APPVEYOR_API_URL) {
     mocha.reporter(require('mocha-appveyor-reporter'));
   } else if (process.env.CIRCLECI === 'true') {
     mocha.reporter(require('mocha-junit-and-console-reporter'), {


### PR DESCRIPTION
The atom/atom test suite sets [an environment variable `TEST_JUNIT_XML_PATH`](https://github.com/atom/atom/blob/44f3cf73eaae5e4ad02842fa493d0d26a6c34552/script/test#L38-L43) to a path that it expects packages to write JUnit-format XML test results to. This will attribute our test results properly within the atom/atom test suite instead of just reporting them as ["mocha"](https://circleci.com/gh/atom/atom/4739).