### PR TITLE
Ensure FilePatchController sees paths with native path separators

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -26,14 +26,14 @@ import RepositoryConflictController from './repository-conflict-controller';
 import ModelStateRegistry from '../models/model-state-registry';
 import Conflict from '../models/conflicts/conflict';
 import Switchboard from '../switchboard';
-import {copyFile, deleteFileOrFolder, realPath} from '../helpers';
+import {copyFile, deleteFileOrFolder, realPath, toNativePathSep} from '../helpers';
 import {GitError} from '../git-shell-out-strategy';
 
 function getPropsFromUri(uri) {
   // atom-github://file-patch/file.txt?workdir=/foo/bar/baz&stagingStatus=staged
   const {protocol, hostname, pathname, query} = url.parse(uri, true);
   if (protocol === 'atom-github:' && hostname === 'file-patch') {
-    const filePath = pathname.slice(1);
+    const filePath = toNativePathSep(pathname.slice(1))
     const {stagingStatus, workdir} = query;
     return {
       filePath,

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -33,7 +33,7 @@ function getPropsFromUri(uri) {
   // atom-github://file-patch/file.txt?workdir=/foo/bar/baz&stagingStatus=staged
   const {protocol, hostname, pathname, query} = url.parse(uri, true);
   if (protocol === 'atom-github:' && hostname === 'file-patch') {
-    const filePath = toNativePathSep(pathname.slice(1))
+    const filePath = toNativePathSep(pathname.slice(1));
     const {stagingStatus, workdir} = query;
     return {
       filePath,

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -135,7 +135,7 @@ describe('RootController', function() {
     });
 
     if (path.sep !== '/') {
-      it('reconstitutes paths from the pane URI with the correct path separator', async function () {
+      it('reconstitutes paths from the pane URI with the correct path separator', async function() {
         const workdirPath = await cloneRepository('three-files');
         const repository = await buildRepository(workdirPath);
 

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -133,6 +133,21 @@ describe('RootController', function() {
       assert.isTrue(wrapper.find({filePath: 'b.txt', initialStagingStatus: 'staged'}).exists());
       assert.isTrue(wrapper.find({filePath: 'c.txt', initialStagingStatus: 'staged'}).exists());
     });
+
+    if (path.sep !== '/') {
+      it('reconstitutes paths from the pane URI with the correct path separator', async function () {
+        const workdirPath = await cloneRepository('three-files');
+        const repository = await buildRepository(workdirPath);
+
+        app = React.cloneElement(app, {repository, filePatchItems: [
+          {key: 1, uri: 'atom-github://file-patch/foo/bar/baz/filename.txt?workdir=/foo/bar/baz&stagingStatus=unstaged'},
+        ]});
+        const wrapper = shallow(app);
+
+        assert.equal(wrapper.find('FilePatchController').length, 1);
+        assert.isTrue(wrapper.find({filePath: path.join('foo', 'bar', 'baz', 'filename.txt')}).exists());
+      });
+    }
   });
 
   describe('when amend mode is toggled in the staging panel while viewing a staged change', function() {


### PR DESCRIPTION
Use the `toNativePathSep` helper to normalize path separators in the path parsed from the pane item URI.

/cc @damieng @50Wliu who were also bitten by this.

Fixes #1092.