### PR TITLE
Improve cache invalidation test reliability

### DIFF
--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -70,7 +70,6 @@ export default class Present extends State {
 
   acceptInvalidation(spec, args) {
     const keys = spec(...args);
-    console.log(`invalidating: ${keys.join(', ')}`);
     this.cache.invalidate(keys);
     this.didUpdate();
   }

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -70,6 +70,7 @@ export default class Present extends State {
 
   acceptInvalidation(spec, args) {
     const keys = spec(...args);
+    console.log(`invalidating: ${keys.join(', ')}`);
     this.cache.invalidate(keys);
     this.didUpdate();
   }
@@ -754,6 +755,10 @@ class CacheKey {
       cache.removeFromGroup(group, this);
     }
   }
+
+  toString() {
+    return `CacheKey(${this.primary})`;
+  }
 }
 
 class GroupKey {
@@ -765,6 +770,10 @@ class GroupKey {
     for (const matchingKey of cache.keysInGroup(this.group)) {
       matchingKey.removeFromCache(cache, this.group);
     }
+  }
+
+  toString() {
+    return `GroupKey(${this.group})`;
   }
 }
 

--- a/lib/models/repository-states/state.js
+++ b/lib/models/repository-states/state.js
@@ -353,6 +353,11 @@ export default class State {
     return Promise.resolve(nullBranch);
   }
 
+  @shouldDelegate
+  getHeadDescription() {
+    return Promise.resolve('(no repository)');
+  }
+
   // Merging and rebasing status
 
   @shouldDelegate

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -288,6 +288,7 @@ const delegates = [
 
   'getBranches',
   'getCurrentBranch',
+  'getHeadDescription',
 
   'isMerging',
   'isRebasing',

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -930,7 +930,10 @@ describe('Repository', function() {
     });
   });
 
-  describe('cache invalidation', function() {
+  describe.only('cache invalidation', function() {
+    // These tests do a *lot* of git operations
+    this.timeout(this.timeout() * 2);
+
     const preventDefault = event => event.preventDefault();
 
     beforeEach(function() {
@@ -1023,12 +1026,12 @@ describe('Repository', function() {
         withFile(fileName);
       }
 
-      const withBranch = (branchName, description) => {
-        calls.set(`getAheadCount ${description}`, {
+      const withBranch = branchName => {
+        calls.set(`getAheadCount ${branchName}`, {
           serial: true,
           op: () => repository.getAheadCount(branchName),
         });
-        calls.set(`getBehindCount ${description}`, {
+        calls.set(`getBehindCount ${branchName}`, {
           serial: true,
           op: () => repository.getBehindCount(branchName),
         });
@@ -1209,7 +1212,7 @@ describe('Repository', function() {
         const patch = await repository.getFilePatchForPath('a.txt');
         await writeFile(path.join(workdir, 'a.txt'), 'foo\nfoo-1\nfoo-2\n');
 
-        await assertCorrectInvalidation({repository}, async () => {
+        await assertCorrectInvalidation({repository, verbose: true}, async () => {
           await repository.applyPatchToIndex(patch);
         });
       });

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -932,7 +932,7 @@ describe('Repository', function() {
 
   describe('cache invalidation', function() {
     // These tests do a *lot* of git operations
-    this.timeout(this.timeout() * 2);
+    this.timeout(Math.max(20000, this.timeout() * 2));
 
     const preventDefault = event => event.preventDefault();
 

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1380,7 +1380,6 @@ describe('Repository', function() {
 
         sub.add(observer.onDidChange(events => {
           observedEvents.push(...events);
-          console.log(`> events received:\n ${events.map(e => e.path).join('\n ')}`);
           eventCallback();
         }));
 
@@ -1397,8 +1396,6 @@ describe('Repository', function() {
                 for (const suffix of pending) {
                   if (eventPath.endsWith(suffix)) {
                     pending.delete(suffix);
-                    console.log(`> event ${eventPath} matched ${suffix}`);
-                    console.log(`> remaining: ${Array.from(pending).join(', ')}`)
                     return true;
                   }
                 }
@@ -1410,13 +1407,11 @@ describe('Repository', function() {
             }
 
             if (pending.size === 0) {
-              console.log('> all events received');
               resolve();
             }
           };
 
           if (observedEvents.length > 0) {
-            console.log('> triggering initial callback');
             eventCallback();
           }
         });
@@ -1493,28 +1488,21 @@ describe('Repository', function() {
         });
       });
 
-      stress(400, 'when committing', async function() {
-        console.log('---> start');
+      it('when committing', async function() {
         const {repository, observer} = await wireUpObserver();
 
         await writeFile(path.join(workdir, 'a.txt'), 'boop\n');
         await repository.stageFiles(['a.txt']);
 
-        console.log('---> collecting baseline');
         await assertCorrectInvalidation({repository}, async () => {
-          console.log('---> starting watcher');
           await observer.start();
-          console.log('---> performing commit');
           await repository.git.commit('boop your snoot');
-          console.log('---> waiting for filesystem events');
           await expectEvents(
             repository,
             path.join('.git', 'index'),
             path.join('.git', 'refs', 'heads', 'master'),
           );
-          console.log('---> collecting cached data');
         });
-        console.log('---> complete');
       });
 
       it('when merging', async function() {

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1463,7 +1463,7 @@ describe('Repository', function() {
         });
       });
 
-      stress(50, 'when applying a patch to the index', async function() {
+      it('when applying a patch to the index', async function() {
         const {repository, observer} = await wireUpObserver();
 
         await writeFile(path.join(workdir, 'a.txt'), 'boop\n');

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1380,6 +1380,7 @@ describe('Repository', function() {
 
         sub.add(observer.onDidChange(events => {
           observedEvents.push(...events);
+          console.log(`> events received:\n ${events.map(e => e.path).join('\n ')}`);
           eventCallback();
         }));
 
@@ -1396,6 +1397,8 @@ describe('Repository', function() {
                 for (const suffix of pending) {
                   if (eventPath.endsWith(suffix)) {
                     pending.delete(suffix);
+                    console.log(`> event ${eventPath} matched ${suffix}`);
+                    console.log(`> remaining: ${Array.from(pending).join(', ')}`)
                     return true;
                   }
                 }
@@ -1407,11 +1410,13 @@ describe('Repository', function() {
             }
 
             if (pending.size === 0) {
+              console.log('> all events received');
               resolve();
             }
           };
 
           if (observedEvents.length > 0) {
+            console.log('> triggering initial callback');
             eventCallback();
           }
         });
@@ -1488,21 +1493,28 @@ describe('Repository', function() {
         });
       });
 
-      it('when committing', async function() {
+      stress(100, 'when committing', async function() {
+        console.log('---> start');
         const {repository, observer} = await wireUpObserver();
 
         await writeFile(path.join(workdir, 'a.txt'), 'boop\n');
         await repository.stageFiles(['a.txt']);
 
+        console.log('---> collecting baseline');
         await assertCorrectInvalidation({repository}, async () => {
+          console.log('---> starting watcher');
           await observer.start();
+          console.log('---> performing commit');
           await repository.git.commit('boop your snoot');
+          console.log('---> waiting for filesystem events');
           await expectEvents(
             repository,
             path.join('.git', 'index'),
             path.join('.git', 'refs', 'heads', 'master'),
           );
+          console.log('---> collecting cached data');
         });
+        console.log('---> complete');
       });
 
       it('when merging', async function() {

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -930,7 +930,7 @@ describe('Repository', function() {
     });
   });
 
-  describe.only('cache invalidation', function() {
+  describe('cache invalidation', function() {
     // These tests do a *lot* of git operations
     this.timeout(this.timeout() * 2);
 

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1493,7 +1493,7 @@ describe('Repository', function() {
         });
       });
 
-      stress(100, 'when committing', async function() {
+      stress(400, 'when committing', async function() {
         console.log('---> start');
         const {repository, observer} = await wireUpObserver();
 

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1391,7 +1391,7 @@ describe('Repository', function() {
         return new Promise((resolve, reject) => {
           eventCallback = () => {
             const matchingPaths = observedEvents
-              .map(event => fs.realpathSync(event.path))
+              .map(event => event.path)
               .filter(eventPath => {
                 for (const suffix of pending) {
                   if (eventPath.endsWith(suffix)) {

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1197,7 +1197,7 @@ describe('Repository', function() {
         const patch = await repository.getFilePatchForPath('a.txt');
         await writeFile(path.join(workdir, 'a.txt'), 'foo\nfoo-1\nfoo-2\n');
 
-        await assertCorrectInvalidation({repository, verbose: true}, async () => {
+        await assertCorrectInvalidation({repository}, async () => {
           await repository.applyPatchToIndex(patch);
         });
       });

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1001,6 +1001,7 @@ describe('Repository', function() {
         op: () => repository.getBranches(),
       });
       calls.set('getCurrentBranch', {
+        serial: true,
         op: () => repository.getCurrentBranch(),
       });
       calls.set('getRemotes', {

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1062,10 +1062,10 @@ describe('Repository', function() {
         const results = new Map();
 
         for (const [name, call] of methods) {
-          const promise = call.op();
+          const promise = call();
           results.set(name, promise);
           if (process.platform === 'win32') {
-            await promise;
+            await promise.catch(() => {});
           }
         }
 

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -984,27 +984,39 @@ describe('Repository', function() {
       const repository = options.repository;
       const calls = new Map();
 
-      calls.set('getStatusesForChangedFiles', () => repository.getStatusesForChangedFiles());
-      calls.set('getStagedChangesSinceParentCommit', () => repository.getStagedChangesSinceParentCommit());
-      calls.set('getLastCommit', () => repository.getLastCommit());
-      calls.set('getBranches', () => repository.getBranches());
-      calls.set('getCurrentBranch', () => repository.getCurrentBranch());
-      calls.set('getRemotes', () => repository.getRemotes());
+      calls.set('getStatusesForChangedFiles', {
+        serial: true,
+        op: () => repository.getStatusesForChangedFiles(),
+      });
+      calls.set('getStagedChangesSinceParentCommit', {
+        op: () => repository.getStagedChangesSinceParentCommit(),
+      });
+      calls.set('getLastCommit', {
+        op: () => repository.getLastCommit(),
+      });
+      calls.set('getBranches', {
+        op: () => repository.getBranches(),
+      });
+      calls.set('getCurrentBranch', {
+        op: () => repository.getCurrentBranch(),
+      });
+      calls.set('getRemotes', {
+        op: () => repository.getRemotes(),
+      });
 
       const withFile = fileName => {
-        calls.set(
-          `getFilePatchForPath {unstaged} ${fileName}`,
-          () => repository.getFilePatchForPath(fileName, {staged: false}),
-        );
-        calls.set(
-          `getFilePatchForPath {staged} ${fileName}`,
-          () => repository.getFilePatchForPath(fileName, {staged: true}),
-        );
-        calls.set(
-          `getFilePatchForPath {staged, amending} ${fileName}`,
-          () => repository.getFilePatchForPath(fileName, {staged: true, amending: true}),
-        );
-        calls.set(`readFileFromIndex ${fileName}`, () => repository.readFileFromIndex(fileName));
+        calls.set(`getFilePatchForPath {unstaged} ${fileName}`, {
+          op: () => repository.getFilePatchForPath(fileName, {staged: false}),
+        });
+        calls.set(`getFilePatchForPath {staged} ${fileName}`, {
+          op: () => repository.getFilePatchForPath(fileName, {staged: true}),
+        });
+        calls.set(`getFilePatchForPath {staged, amending} ${fileName}`, {
+          op: () => repository.getFilePatchForPath(fileName, {staged: true, amending: true}),
+        });
+        calls.set(`readFileFromIndex ${fileName}`, {
+          op: () => repository.readFileFromIndex(fileName),
+        });
       };
 
       for (const fileName of await filesWithinRepository(options.repository)) {
@@ -1012,16 +1024,26 @@ describe('Repository', function() {
       }
 
       const withBranch = (branchName, description) => {
-        calls.set(`getAheadCount ${description}`, () => repository.getAheadCount(branchName));
-        calls.set(`getBehindCount ${description}`, () => repository.getBehindCount(branchName));
+        calls.set(`getAheadCount ${description}`, {
+          serial: true,
+          op: () => repository.getAheadCount(branchName),
+        });
+        calls.set(`getBehindCount ${description}`, {
+          serial: true,
+          op: () => repository.getBehindCount(branchName),
+        });
       };
       for (const branchName of await repository.git.getBranches()) {
         withBranch(branchName);
       }
 
       for (const optionName of (options.optionNames || [])) {
-        calls.set(`getConfig ${optionName}`, () => repository.getConfig(optionName));
-        calls.set(`getConfig {local} ${optionName}`, () => repository.getConfig(optionName, {local: true}));
+        calls.set(`getConfig ${optionName}`, {
+          op: () => repository.getConfig(optionName),
+        });
+        calls.set(`getConfig {local} ${optionName}`, {
+          op: () => repository.getConfig(optionName, {local: true}),
+        });
       }
 
       return calls;
@@ -1036,11 +1058,29 @@ describe('Repository', function() {
         methods.delete(opName);
       }
 
-      const record = () => {
+      const record = async () => {
         const results = new Map();
+
+        const serial = [];
+        const parallel = [];
         for (const [name, call] of methods) {
-          results.set(name, call());
+          if (call.serial) {
+            serial.push([name, call]);
+          } else {
+            parallel.push([name, call]);
+          }
         }
+
+        for (const [name, call] of serial) {
+          const promise = call.op();
+          results.set(name, promise);
+          await promise;
+        }
+
+        for (const [name, call] of parallel) {
+          results.set(name, call.op());
+        }
+
         return results;
       };
 
@@ -1074,9 +1114,9 @@ describe('Repository', function() {
         );
       };
 
-      const before = record();
+      const before = await record();
       await operation();
-      const cached = record();
+      const cached = await record();
 
       options.repository.state.cache.clear();
       const after = await record();

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1404,7 +1404,7 @@ describe('Repository', function() {
       function expectEvents(repository, ...fileNames) {
         const pending = new Set(
           fileNames.map(fileName => {
-            return fs.realPathSync(
+            return fs.realpathSync(
               path.join(repository.getWorkingDirectoryPath(), ...fileName.split(/[\\/]/)),
             );
           }),
@@ -1412,7 +1412,7 @@ describe('Repository', function() {
         return new Promise((resolve, reject) => {
           eventCallback = () => {
             const matchingPaths = observedEvents
-              .map(event => fs.realPathSync(event.path))
+              .map(event => fs.realpathSync(event.path))
               .filter(eventPath => pending.delete(eventPath));
 
             if (matchingPaths.length > 0) {

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1404,13 +1404,15 @@ describe('Repository', function() {
       function expectEvents(repository, ...fileNames) {
         const pending = new Set(
           fileNames.map(fileName => {
-            return path.join(repository.getWorkingDirectoryPath(), ...fileName.split(/[\\/]/));
+            return fs.realPathSync(
+              path.join(repository.getWorkingDirectoryPath(), ...fileName.split(/[\\/]/)),
+            );
           }),
         );
         return new Promise((resolve, reject) => {
           eventCallback = () => {
             const matchingPaths = observedEvents
-              .map(event => event.path)
+              .map(event => fs.realPathSync(event.path))
               .filter(eventPath => pending.delete(eventPath));
 
             if (matchingPaths.length > 0) {

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1429,7 +1429,7 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await repository.git.stageFiles(['a.txt']);
-          await expectEvents(repository, '.git/index');
+          await expectEvents(repository, path.join('.git', 'index'));
         });
       });
 
@@ -1442,7 +1442,7 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await repository.git.unstageFiles(['a.txt']);
-          await expectEvents(repository, '.git/index');
+          await expectEvents(repository, path.join('.git', 'index'));
         });
       });
 
@@ -1452,7 +1452,7 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await repository.git.unstageFiles(['a.txt'], 'HEAD~');
-          await expectEvents(repository, '.git/index');
+          await expectEvents(repository, path.join('.git', 'index'));
         });
       });
 
@@ -1465,7 +1465,10 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await repository.git.applyPatch(patch.getHeaderString() + patch.toString(), {index: true});
-          await expectEvents(repository, '.git/index');
+          await expectEvents(
+            repository,
+            path.join('.git', 'index'),
+          );
         });
       });
 
@@ -1478,7 +1481,10 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await repository.git.applyPatch(patch.getHeaderString() + patch.toString());
-          await expectEvents(repository, 'a.txt');
+          await expectEvents(
+            repository,
+            'a.txt',
+          );
         });
       });
 
@@ -1491,7 +1497,11 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await repository.git.commit('boop your snoot');
-          await expectEvents(repository, '.git/index', '.git/refs/heads/master');
+          await expectEvents(
+            repository,
+            path.join('.git', 'index'),
+            path.join('.git', 'refs', 'heads', 'master'),
+          );
         });
       });
 
@@ -1501,7 +1511,12 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await assert.isRejected(repository.git.merge('origin/branch'));
-          await expectEvents(repository, '.git/index', 'modified-on-both-ours.txt', '.git/MERGE_HEAD');
+          await expectEvents(
+            repository,
+            path.join('.git', 'index'),
+            'modified-on-both-ours.txt',
+            path.join('.git', 'MERGE_HEAD'),
+          );
         });
       });
 
@@ -1512,7 +1527,12 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await repository.git.abortMerge();
-          await expectEvents(repository, '.git/index', 'modified-on-both-ours.txt', '.git/MERGE_HEAD');
+          await expectEvents(
+            repository,
+            path.join('.git', 'index'),
+            'modified-on-both-ours.txt',
+            path.join('.git', 'MERGE_HEAD'),
+          );
         });
       });
 
@@ -1522,7 +1542,13 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await repository.git.checkout('HEAD^');
-          await expectEvents(repository, '.git/index', '.git/HEAD', 'b.txt', 'c.txt');
+          await expectEvents(
+            repository,
+            path.join('.git', 'index'),
+            path.join('.git', 'HEAD'),
+            'b.txt',
+            'c.txt',
+          );
         });
       });
 
@@ -1532,7 +1558,11 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await repository.git.checkoutFiles(['b.txt'], 'HEAD^');
-          await expectEvents(repository, 'b.txt', '.git/index');
+          await expectEvents(
+            repository,
+            'b.txt',
+            path.join('.git', 'index'),
+          );
         });
       });
 
@@ -1546,7 +1576,10 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await repository.git.fetch('origin', 'master');
-          await expectEvents(repository, '.git/refs/remotes/origin/master');
+          await expectEvents(
+            repository,
+            path.join('.git', 'refs', 'remotes', 'origin', 'master'),
+          );
         });
       });
 
@@ -1561,7 +1594,13 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await assert.isRejected(repository.git.pull('origin', 'master'));
-          await expectEvents(repository, 'file.txt', '.git/refs/remotes/origin/master', '.git/MERGE_HEAD', '.git/index');
+          await expectEvents(
+            repository,
+            'file.txt',
+            path.join('.git', 'refs', 'remotes', 'origin', 'master'),
+            path.join('.git', 'MERGE_HEAD'),
+            path.join('.git', 'index'),
+          );
         });
       });
 
@@ -1576,7 +1615,10 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await repository.git.push('origin', 'master');
-          await expectEvents(repository, '.git/refs/remotes/origin/master');
+          await expectEvents(
+            repository,
+            path.join('.git', 'refs', 'remotes', 'origin', 'master'),
+          );
         });
       });
 
@@ -1587,7 +1629,10 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository, optionNames}, async () => {
           await observer.start();
           await repository.git.setConfig('core.editor', 'ed # :trollface:');
-          await expectEvents(repository, '.git/config');
+          await expectEvents(
+            repository,
+            path.join('.git', 'config'),
+          );
         });
       });
 
@@ -1597,7 +1642,10 @@ describe('Repository', function() {
         await assertCorrectInvalidation({repository}, async () => {
           await observer.start();
           await writeFile(path.join(workdir, 'b.txt'), 'new contents\n');
-          await expectEvents(repository, 'b.txt');
+          await expectEvents(
+            repository,
+            'b.txt',
+          );
         });
       });
     });


### PR DESCRIPTION
When collecting Repository return values before and after git operations to validate the cache, perform calls that are backed by `git status` in serial rather than parallel. This should avoid filesystem race conditions in git's index manipulation.

Fixes #1082 (...Hopefully).