### PR TITLE
Make PrSelectionByBranch resizable

### DIFF
--- a/lib/containers/pr-selection-by-branch-container.js
+++ b/lib/containers/pr-selection-by-branch-container.js
@@ -59,7 +59,7 @@ export class PrSelectionByBranch extends React.Component {
     const edges = repo.pullRequests.edges;
     if (edges.length === 1) {
       return (
-        <div>
+        <div className="github-PrSelectionByBranch-container">
           <div>
             <div className="github-PrUrlInputBox-pinButton" onClick={this.toggleInputBoxVisibility}>
               <Octicon

--- a/styles/pr-selection.less
+++ b/styles/pr-selection.less
@@ -5,6 +5,12 @@
   display: flex;
   overflow: auto;
 
+  &-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
   &-message {
     padding: 0 @component-padding;
     margin: @component-padding 0;


### PR DESCRIPTION
### Description of the Change

This makes the GitHub panel resizable again when a PR from the current branch is shown.

<img width="664" alt="menubar_and_github__preview__ ___github_github" src="https://user-images.githubusercontent.com/189606/29475380-4bdf77ea-8414-11e7-8261-a5fd56f97fdd.png">

### Applicable Issues

Fixes https://github.com/atom/github/issues/1117