### PR TITLE
Add line-height to sync icon animation to center

### DIFF
--- a/styles/status-bar-tile-controller.less
+++ b/styles/status-bar-tile-controller.less
@@ -39,6 +39,7 @@
       100% { transform: rotate(360deg); }
     }
     animation: github-StatusBarSync-animation 2s linear 30; // limit to 1min in case something gets stuck
+    line-height: 0.9;
   }
 
   // Merge conflict icon


### PR DESCRIPTION
### Description of the Change
Right now the sync animation icon in the bottom toolbar rotates off center and moves up and down a bit rather than spinning in place. Adding this line height resolves that.

Current:
![current](https://user-images.githubusercontent.com/3970573/29552804-a46af9f0-86cd-11e7-9049-3af575cd24cc.gif)

Updated line-height:
![with line height](https://user-images.githubusercontent.com/3970573/29552811-acbc97da-86cd-11e7-8c8f-624ef9386d8e.gif)

### Alternate Designs

I considered where else to modify the css, or how else besides line height, but this seemed the most straight forward with the lowest likelihood of unintended side-effects

### Benefits

Animation will now look as intended

### Possible Drawbacks

Possible the css has other effects I couldn't see or find, but it seems very unlikely

### Applicable Issues

None found
