### PR TITLE
Implement filter panel for filtering down file lists

### DIFF
--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -513,7 +513,6 @@ export default class StagingView {
             <span className="github-StagingView-title">Unstaged Changes</span>
             {this.props.unstagedChanges.length ? this.renderStageAllButton() : null}
           </header>
-          {this.props.hasUndoHistory ? this.renderUndoButton() : null}
 
           <div ref="unstagedChanges" className="github-StagingView-list github-FilePatchListView">
             {
@@ -531,6 +530,7 @@ export default class StagingView {
               ))
             }
           </div>
+          {this.props.hasUndoHistory ? this.renderUndoButton() : null}
           {this.renderTruncatedMessage(this.props.unstagedChanges)}
         </div>
         { this.renderMergeConflicts() }

--- a/styles/staging-view.less
+++ b/styles/staging-view.less
@@ -59,7 +59,7 @@
 
     &--fullWidth {
       border-left: none;
-      border-bottom: 1px solid @panel-heading-border-color;
+      border-top: 1px solid @panel-heading-border-color;
     }
   }
 
@@ -86,6 +86,7 @@
 
 .github-StagingView-group-truncatedMsg {
   padding: @component-padding / 2 @component-padding;
+  border-top: 1px solid @panel-heading-border-color;
 }
 
 .github-StagingView-group.is-focused .is-selected {


### PR DESCRIPTION
In some cases, the list of staged/unstaged/unmerged files can get to be pretty unmanageable. For these cases, it would be nice to have an easy mechanism for filtering the list down. I'm imagining a UI kinda like this:

![cursor_and___atom_and_octicons](https://user-images.githubusercontent.com/189606/29580841-42f7511e-872c-11e7-86ca-4c3111304c76.png)

When the "settings" button to the right of the list header is clicked, a filter panel will drop down.

![cursor_and___atom_and_staging-view_js_ ___github_github_and_octicons](https://user-images.githubusercontent.com/189606/29581368-e6eb48e2-872d-11e7-83c1-a0302f5ea448.png)

Modifying the options updates the UI in real time; the list is filtered and an indication of how many files have been filtered out is shown. Additionally, at the bottom of the file list, a "fake" entry shows that some files aren't shown, and clicking this will ensure that the filter box is open.

![cursor_and___atom](https://user-images.githubusercontent.com/189606/29582096-4d8cd186-8730-11e7-89df-8d4582edafc5.png)

To note, these screenshots are just mocks. There's definitely some additional UX thinking that could be done here.

* What types of things might we want to filter out (other than by path glob and tracked/untracked status)?
* What's a good UI for providing an affordance for "clearing" the filters
* Should the filters be allowed to be closed as long as they are active?
* Is the filter button clear enough?
* Where else can the UX be improved?

/cc @simurai in particular for 💭 s

Fixes #888