### PR TITLE
Create a new pull request from unsuccessful PR selection views

### DIFF
--- a/lib/action-pipeline.js
+++ b/lib/action-pipeline.js
@@ -1,0 +1,76 @@
+function partial(fn, ...args) {
+  return function wrapped() {
+    return fn(...args);
+  };
+}
+
+export class ActionPipeline {
+  constructor(action) {
+    this.action = action;
+    this.middleware = [];
+    this.middlewareNames = [];
+  }
+
+  run(fn, ...args) {
+    // eslint-disable-next-line prefer-spread
+    return this.middleware
+      .map(middleware => middleware.fn)
+      .reduceRight((acc, nextFn) => partial(nextFn, acc, ...args), partial(fn, ...args))
+      .apply(undefined, args);
+  }
+
+  addMiddleware(name, fn) {
+    if (!name) {
+      throw new Error('Middleware must be registered with a unique middleware name');
+    }
+
+    if (this.middleware.some(mw => name === mw.name)) {
+      throw new Error(`A middleware with the name ${name} is already registered`);
+    }
+
+    this.middleware.push({name, fn});
+  }
+
+  removeMiddleware(name) {
+    this.middleware = this.middleware.filter(mw => mw.name !== name);
+  }
+
+  insertMiddlewareBefore(needle, name, fn) {
+    const index = this.middleware.findIndex(middleware => middleware.name === needle);
+    if (index === -1) {
+      throw new Error(`Cannot find existing middleware ${needle}`);
+    }
+
+    this.middleware.splice(index, 0, {name, fn});
+  }
+
+  insertMiddlewareAfter(needle, name, fn) {
+    const index = this.middleware.findIndex(middleware => middleware.name === needle);
+    if (index === -1) {
+      throw new Error(`Cannot find existing middleware ${needle}`);
+    }
+
+    this.middleware.splice(index + 1, 0, {name, fn});
+  }
+}
+
+export class ActionPipelineManager {
+  constructor({actionNames}) {
+    this.actions = {};
+    this.pipelines = new Map();
+
+    actionNames.forEach(actionName => {
+      const key = Symbol(actionName);
+      this.actions[actionName] = key;
+      this.pipelines.set(key, new ActionPipeline(key));
+    });
+  }
+
+  getPipeline(action) {
+    if (!action || !this.pipelines.has(action)) {
+      throw new Error(`${action} is not a known action`);
+    }
+
+    return this.pipelines.get(action);
+  }
+}

--- a/lib/action-pipeline.js
+++ b/lib/action-pipeline.js
@@ -74,3 +74,7 @@ export class ActionPipelineManager {
     return this.pipelines.get(action);
   }
 }
+
+// export default new ActionPipelineManager({
+//   actions: ['COMMIT', 'STAGE', 'UNSTAGE', 'PUSH', 'PULL'].map(toSymbol),
+// });

--- a/lib/containers/pr-selection-by-branch-container.js
+++ b/lib/containers/pr-selection-by-branch-container.js
@@ -39,9 +39,9 @@ export class PrSelectionByBranch extends React.Component {
   renderSubview() {
     const repo = this.props.repository;
     const {variables} = this.props;
+    const newPrUrl = `https://github.com/${variables.repoOwner}/${variables.repoName}` +
+                     `/compare/${variables.branchName}?expand=1`;
     if (!repo || !repo.pullRequests.edges.length) {
-      const newPrUrl = `https://github.com/${variables.repoOwner}/${variables.repoName}` +
-                       `/compare/${variables.branchName}?expand=1`;
       return (
         <div className="github-PrUrlInputBox-Container">
           <PrUrlInputBox onSubmit={this.props.onSelectPr}>
@@ -102,7 +102,7 @@ export class PrSelectionByBranch extends React.Component {
       );
     }
 
-    return this.renderPrSelectionList(edges, repo.pullRequests.totalCount);
+    return this.renderPrSelectionList(edges, repo.pullRequests.totalCount, newPrUrl);
   }
 
   @autobind
@@ -110,7 +110,7 @@ export class PrSelectionByBranch extends React.Component {
     this.setState({displayInputBox: !this.state.displayInputBox});
   }
 
-  renderPrSelectionList(edges, totalCount) {
+  renderPrSelectionList(edges, totalCount, newPrUrl) {
     const {variables} = this.props;
     return (
       <div className="github-PrSelectionByBranch-listContainer">
@@ -123,6 +123,9 @@ export class PrSelectionByBranch extends React.Component {
         </div>
         <div className="github-PrSelectionByBranch-input">
           <PrUrlInputBox onSubmit={this.props.onSelectPr} />
+        </div>
+        <div className="github-PrSelectionByBranch-message">
+          Or, if you've pushed your changes to GitHub, you can <a href={newPrUrl}>open a new pull request</a>.
         </div>
         <ul className="github-PrSelectionByBranch-list">
           {edges.map(this.displayPullRequestItem)}

--- a/lib/containers/pr-selection-by-branch-container.js
+++ b/lib/containers/pr-selection-by-branch-container.js
@@ -40,17 +40,28 @@ export class PrSelectionByBranch extends React.Component {
     const repo = this.props.repository;
     const {variables} = this.props;
     if (!repo || !repo.pullRequests.edges.length) {
+      const newPrUrl = `https://github.com/${variables.repoOwner}/${variables.repoName}` +
+                       `/compare/${variables.branchName}?expand=1`;
       return (
         <div className="github-PrUrlInputBox-Container">
           <PrUrlInputBox onSubmit={this.props.onSelectPr}>
-            <p className="icon icon-git-pull-request" />
-            <p>
-              No pull request could be found for the branch <span className="highlight">{variables.branchName}</span>
-              on the repository <span className="highlight">{variables.repoOwner}/{variables.repoName}</span>.
-            </p>
-            <p>
-              You can manually pin a GitHub pull request to the current branch by entering its URL:
-            </p>
+            {inputs => (
+              <div>
+                <p className="icon icon-git-pull-request" />
+                <p>
+                  No pull request could be found for the
+                  branch <span className="highlight">{variables.branchName}</span>
+                  on the repository <span className="highlight">{variables.repoOwner}/{variables.repoName}</span>.
+                </p>
+                <p>
+                  You can manually pin a GitHub pull request to the current branch by entering its URL:
+                </p>
+                {inputs}
+                <p>
+                  Or, if you've pushed your changes to GitHub, you can <a href={newPrUrl}>open a new pull request</a>.
+                </p>
+              </div>
+            )}
           </PrUrlInputBox>
         </div>
       );
@@ -71,13 +82,18 @@ export class PrSelectionByBranch extends React.Component {
             </div>
             {this.state.displayInputBox &&
               <PrUrlInputBox onSubmit={this.props.onSelectPr}>
-                <p>
-                  We found a pull request associated with the branch {variables.branchName} on the
-                  repository {variables.repoOwner}/{variables.repoName}.
-                </p>
-                <p>
-                  You can manually pin a different GitHub pull request to the current branch by entering its URL:
-                </p>
+                {inputs => (
+                  <div>
+                    <p>
+                      We found a pull request associated with the branch {variables.branchName} on the
+                      repository {variables.repoOwner}/{variables.repoName}.
+                    </p>
+                    <p>
+                      You can manually pin a different GitHub pull request to the current branch by entering its URL:
+                    </p>
+                    {inputs}
+                  </div>
+                )}
               </PrUrlInputBox>
             }
           </div>

--- a/lib/containers/pr-selection-by-branch-container.js
+++ b/lib/containers/pr-selection-by-branch-container.js
@@ -45,25 +45,21 @@ export class PrSelectionByBranch extends React.Component {
     if (!repo || !repo.pullRequests.edges.length) {
       return (
         <div className="github-PrUrlInputBox-Container">
-          <PrUrlInputBox onSubmit={this.props.onSelectPr} refresh={this.props.refresh}>
-            {inputs => (
-              <div>
-                <p className="icon icon-git-pull-request" />
-                <p>
-                  No pull request could be found for the
-                  branch <span className="highlight">{variables.branchName}</span>
-                  on the repository <span className="highlight">{variables.repoOwner}/{variables.repoName}</span>.
-                </p>
-                <p>
-                  You can manually pin a GitHub pull request to the current branch by entering its URL:
-                </p>
-                {inputs}
-                <p>
-                  Or, if you've pushed your changes to GitHub, you can <a href={newPrUrl}>open a new pull request</a>.
-                </p>
-              </div>
-            )}
-          </PrUrlInputBox>
+          <div className="github-PrUrlInputBox-Subview">
+            <p className="icon icon-git-pull-request" />
+            <p>
+              No pull request could be found for the
+              branch <span className="highlight">{variables.branchName}</span>
+              on the repository <span className="highlight">{variables.repoOwner}/{variables.repoName}</span>.
+            </p>
+            <p>
+              You can manually pin a GitHub pull request to the current branch by entering its URL:
+            </p>
+            <PrUrlInputBox onSubmit={this.props.onSelectPr} refresh={this.props.refresh} />
+            <p>
+              Or, if you've pushed your changes to GitHub, you can <a href={newPrUrl}>open a new pull request</a>.
+            </p>
+          </div>
         </div>
       );
     }
@@ -72,32 +68,27 @@ export class PrSelectionByBranch extends React.Component {
     if (edges.length === 1) {
       return (
         <div className="github-PrSelectionByBranch-container">
-          <div>
-            <div className="github-PrUrlInputBox-pinButton" onClick={this.toggleInputBoxVisibility}>
-              <Octicon
-                title="Click here to select another PR."
-                icon="pin"
-                className="pinned-by-url"
-              />
-              Specify Pull Request URL to pin
-            </div>
-            {this.state.displayInputBox &&
-              <PrUrlInputBox onSubmit={this.props.onSelectPr}>
-                {inputs => (
-                  <div>
-                    <p>
-                      We found a pull request associated with the branch {variables.branchName} on the
-                      repository {variables.repoOwner}/{variables.repoName}.
-                    </p>
-                    <p>
-                      You can manually pin a different GitHub pull request to the current branch by entering its URL:
-                    </p>
-                    {inputs}
-                  </div>
-                )}
-              </PrUrlInputBox>
-            }
+          <div className="github-PrUrlInputBox-pinButton" onClick={this.toggleInputBoxVisibility}>
+            <Octicon
+              title="Click here to select another PR."
+              icon="pin"
+              className="pinned-by-url"
+            />
+            Specify Pull Request URL to pin
           </div>
+          {this.state.displayInputBox &&
+            <div className="github-PrUrlInputBox">
+              <div className="github-PrUrlInputBox-Subview">
+                <p>
+                  We found a pull request associated with the branch {variables.branchName} on the
+                  repository {variables.repoOwner}/{variables.repoName}.
+                </p>
+                <p>
+                  You can manually pin a different GitHub pull request to the current branch by entering its URL:
+                </p>
+                <PrUrlInputBox onSubmit={this.props.onSelectPr} />
+              </div>
+            </div>}
           <PrInfoContainer pullRequest={edges[0].node} />
         </div>
       );

--- a/lib/containers/pr-selection-by-branch-container.js
+++ b/lib/containers/pr-selection-by-branch-container.js
@@ -16,6 +16,7 @@ export class PrSelectionByBranch extends React.Component {
     }),
     onSelectPr: PropTypes.func.isRequired,
     onUnpinPr: PropTypes.func.isRequired,
+    refresh: PropTypes.func.isRequired,
     variables: PropTypes.shape({
       repoOwner: PropTypes.string.isRequired,
       repoName: PropTypes.string.isRequired,
@@ -44,7 +45,7 @@ export class PrSelectionByBranch extends React.Component {
     if (!repo || !repo.pullRequests.edges.length) {
       return (
         <div className="github-PrUrlInputBox-Container">
-          <PrUrlInputBox onSubmit={this.props.onSelectPr}>
+          <PrUrlInputBox onSubmit={this.props.onSelectPr} refresh={this.props.refresh}>
             {inputs => (
               <div>
                 <p className="icon icon-git-pull-request" />
@@ -122,7 +123,7 @@ export class PrSelectionByBranch extends React.Component {
           any pull request URL to pin it manually:
         </div>
         <div className="github-PrSelectionByBranch-input">
-          <PrUrlInputBox onSubmit={this.props.onSelectPr} />
+          <PrUrlInputBox onSubmit={this.props.onSelectPr} refresh={this.props.refresh} />
         </div>
         <div className="github-PrSelectionByBranch-message">
           Or, if you've pushed your changes to GitHub, you can <a href={newPrUrl}>open a new pull request</a>.

--- a/lib/containers/pr-selection-by-url-container.js
+++ b/lib/containers/pr-selection-by-url-container.js
@@ -22,15 +22,20 @@ export class PrSelectionByUrl extends React.Component {
       return (
         <div className="github-PrUrlInputBox-Container">
           <PrUrlInputBox onSubmit={this.props.onSelectPr}>
-            <p>
-              <span style={{display: 'block'}}>This branch is pinned to the pull request
-              at this URL:</span>
-              <input value={this.props.variables.prUrl} style={{width: '100%'}} readOnly />
-              <span style={{display: 'block'}}>but we couldn't find a pull request at that URL.</span>
-            </p>
-            <p>
-              You can manually pin another GitHub pull request to the current branch by entering its URL:
-            </p>
+            {inputs => (
+              <div>
+                <p>
+                  <span style={{display: 'block'}}>This branch is pinned to the pull request
+                  at this URL:</span>
+                  <input value={this.props.variables.prUrl} style={{width: '100%'}} readOnly />
+                  <span style={{display: 'block'}}>but we couldn't find a pull request at that URL.</span>
+                </p>
+                <p>
+                  You can manually pin another GitHub pull request to the current branch by entering its URL:
+                </p>
+                {inputs}
+              </div>
+            )}
           </PrUrlInputBox>
         </div>
       );

--- a/lib/containers/pr-selection-by-url-container.js
+++ b/lib/containers/pr-selection-by-url-container.js
@@ -11,6 +11,7 @@ export class PrSelectionByUrl extends React.Component {
     prUrl: PropTypes.string,
     onSelectPr: PropTypes.func.isRequired,
     onUnpinPr: PropTypes.func.isRequired,
+    refresh: PropTypes.func.isRequired,
     variables: PropTypes.shape({
       prUrl: PropTypes.string.isRequired,
     }),
@@ -21,7 +22,7 @@ export class PrSelectionByUrl extends React.Component {
     if (!resource || resource.__typename !== 'PullRequest') {
       return (
         <div className="github-PrUrlInputBox-Container">
-          <PrUrlInputBox onSubmit={this.props.onSelectPr}>
+          <PrUrlInputBox onSubmit={this.props.onSelectPr} refresh={this.props.refresh}>
             {inputs => (
               <div>
                 <p>

--- a/lib/containers/pr-selection-by-url-container.js
+++ b/lib/containers/pr-selection-by-url-container.js
@@ -22,22 +22,18 @@ export class PrSelectionByUrl extends React.Component {
     if (!resource || resource.__typename !== 'PullRequest') {
       return (
         <div className="github-PrUrlInputBox-Container">
-          <PrUrlInputBox onSubmit={this.props.onSelectPr} refresh={this.props.refresh}>
-            {inputs => (
-              <div>
-                <p>
-                  <span style={{display: 'block'}}>This branch is pinned to the pull request
-                  at this URL:</span>
-                  <input value={this.props.variables.prUrl} style={{width: '100%'}} readOnly />
-                  <span style={{display: 'block'}}>but we couldn't find a pull request at that URL.</span>
-                </p>
-                <p>
-                  You can manually pin another GitHub pull request to the current branch by entering its URL:
-                </p>
-                {inputs}
-              </div>
-            )}
-          </PrUrlInputBox>
+          <div className="github-PrUrlInputBox-Subview">
+            <p>
+              <span style={{display: 'block'}}>This branch is pinned to the pull request
+              at this URL:</span>
+              <input value={this.props.variables.prUrl} style={{width: '100%'}} readOnly />
+              <span style={{display: 'block'}}>but we couldn't find a pull request at that URL.</span>
+            </p>
+            <p>
+              You can manually pin another GitHub pull request to the current branch by entering its URL:
+            </p>
+            <PrUrlInputBox onSubmit={this.props.onSelectPr} refresh={this.props.refresh} />
+          </div>
         </div>
       );
     }

--- a/lib/controllers/pr-info-controller.js
+++ b/lib/controllers/pr-info-controller.js
@@ -25,6 +25,10 @@ export default class PrInfoController extends React.Component {
     onUnpinPr: PropTypes.func.isRequired,
   }
 
+  state = {
+    key: 1,
+  }
+
   render() {
     if (this.props.token === UNAUTHENTICATED) {
       return null;
@@ -37,6 +41,11 @@ export default class PrInfoController extends React.Component {
     }
   }
 
+  @autobind
+  hardRefresh() {
+    this.setState(state => ({key: state.key + 1}));
+  }
+
   renderSpecificPr() {
     const {token, host} = this.props;
 
@@ -47,6 +56,7 @@ export default class PrInfoController extends React.Component {
 
     return (
       <QueryRenderer
+        key={this.state.key}
         environment={environment}
         query={graphql`
           query PrInfoControllerByUrlQuery($prUrl: URI!) {
@@ -63,6 +73,7 @@ export default class PrInfoController extends React.Component {
             return (
               <PrSelectionByUrlContainer
                 {...props}
+                refresh={this.hardRefresh}
                 variables={variables}
                 onSelectPr={this.props.onSelectPr}
                 onUnpinPr={this.props.onUnpinPr}
@@ -87,6 +98,7 @@ export default class PrInfoController extends React.Component {
     };
     return (
       <QueryRenderer
+        key={this.state.key}
         environment={environment}
         query={graphql`
           query PrInfoControllerByBranchQuery(
@@ -105,6 +117,7 @@ export default class PrInfoController extends React.Component {
             return (
               <PrSelectionByBranchContainer
                 {...props}
+                refresh={this.hardRefresh}
                 variables={variables}
                 onSelectPr={this.props.onSelectPr}
                 onUnpinPr={this.props.onUnpinPr}

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -165,6 +165,7 @@ export default class RootController extends React.Component {
     return (
       <StatusBar statusBar={this.props.statusBar} onConsumeStatusBar={sb => this.onConsumeStatusBar(sb)}>
         <StatusBarTileController
+          pipelineManager={this.props.pipelineManager}
           workspace={this.props.workspace}
           repository={this.props.repository}
           commandRegistry={this.props.commandRegistry}

--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -227,31 +227,36 @@ export default class StatusBarTileController extends React.Component {
 
   @autobind
   async push({force, setUpstream}) {
-    await this.attemptGitOperation(
-      () => this.doPush({force, setUpstream}),
-      error => {
-        if (/rejected[\s\S]*failed to push/.test(error.stdErr)) {
-          return {
-            message: 'Push rejected',
-            description: 'The tip of your current branch is behind its remote counterpart.' +
-              ' Try pulling before pushing again. Or, to force push, hold `cmd` or `ctrl` while clicking.',
-          };
-        }
+    const pipeline = this.props.pipelineManager.getPipeline(this.props.pipelineManager.actions.PUSH);
+    pipeline.run(async () => {
+      await this.attemptGitOperation(
+        () => this.doPush({force, setUpstream}),
+        error => {
+          // if (/rejected[\s\S]*failed to push/.test(error.stdErr)) {
+          //   return {
+          //     message: 'Push rejected',
+          //     description: 'The tip of your current branch is behind its remote counterpart.' +
+          //       ' Try pulling before pushing again. Or, to force push, hold `cmd` or `ctrl` while clicking.',
+          //   };
+          // }
+          //
+          // return {message: 'Unable to push', description: `<pre>${error.stdErr}</pre>`};
+          throw error;
+        },
+      );
 
-        return {message: 'Unable to push', description: `<pre>${error.stdErr}</pre>`};
-      },
-    );
+    }, {force, setUpstream});
   }
 
   async doPush(options) {
-    if (options.force) {
-      const choice = this.props.confirm({
-        message: 'Are you sure you want to force push?',
-        detailedMessage: 'This operation could result in losing data on the remote.',
-        buttons: ['Force Push', 'Cancel Push'],
-      });
-      if (choice !== 0) { return; }
-    }
+    // if (options.force) {
+    //   const choice = this.props.confirm({
+    //     message: 'Are you sure you want to force push?',
+    //     detailedMessage: 'This operation could result in losing data on the remote.',
+    //     buttons: ['Force Push', 'Cancel Push'],
+    //   });
+    //   if (choice !== 0) { return; }
+    // }
 
     await this.setInProgressWhile(() => {
       return this.props.repository.push(this.props.currentBranch.getName(), options);

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -19,6 +19,7 @@ import Switchboard from './switchboard';
 import yardstick from './yardstick';
 import GitTimingsView from './views/git-timings-view';
 import ContextMenuInterceptor from './context-menu-interceptor';
+import {ActionPipelineManager} from './action-pipeline';
 import AsyncQueue from './async-queue';
 import WorkerManager from './worker-manager';
 
@@ -80,6 +81,37 @@ export default class GithubPackage {
     this.setupYardstick();
 
     this.filePatchItems = [];
+    this.pipelineManager = new ActionPipelineManager({
+      actionNames: [
+        'COMMIT', 'PUSH', 'PULL',
+      ],
+    });
+    const pushPipeline = this.pipelineManager.getPipeline(this.pipelineManager.actions.PUSH);
+    pushPipeline.addMiddleware('confirm-force-push', (next, options) => {
+      if (options.force) {
+        const choice = this.confirm({
+          message: 'Are you sure you want to force push?',
+          detailedMessage: 'This operation could result in losing data on the remote.',
+          buttons: ['Force Push', 'Cancel Push'],
+        });
+        if (choice !== 0) { return null; } else { return next(); }
+      } else {
+        return next();
+      }
+    });
+    pushPipeline.addMiddleware('failed-to-push-error', async (next, options) => {
+      try {
+        const result = await next();
+        return result;
+      } catch (error) {
+        console.error(error);
+        if (/rejected[\s\S]*failed to push/.test(error.stdErr)) {
+          const desc = 'The tip of your current branch is behind its remote counterpart.' +
+            ' Try pulling before pushing again. Or, to force push, hold `cmd` or `ctrl` while clicking.';
+          this.notificationManager.addError('Unsable to push', {description: desc});
+        }
+      }
+    });
   }
 
   setupYardstick() {
@@ -262,6 +294,7 @@ export default class GithubPackage {
 
     ReactDom.render(
       <RootController
+        pipelineManager={this.pipelineManager}
         ref={c => { this.controller = c; }}
         workspace={this.workspace}
         deserializers={this.deserializers}

--- a/lib/models/repository-pipeline.js
+++ b/lib/models/repository-pipeline.js
@@ -1,0 +1,41 @@
+import {ActionPipelineManager, ActionPipeline} from '../action-pipeline';
+
+class NullActionPipeline extends ActionPipeline {
+  run(fn, ...args) {
+    return fn(...args);
+  }
+
+  addMiddleware() {
+    throw new Error('Cannot add middleware to a null pipeline');
+  }
+
+  removeMiddleware() {
+    throw new Error('Cannot remove middleware from a null pipeline');
+  }
+
+  insertMiddlewareBefore() {
+    throw new Error('Cannot add middleware to a null pipeline');
+  }
+
+  insertMiddlewareAfter() {
+    throw new Error('Cannot add middleware to a null pipeline');
+  }
+}
+
+const nullPipeline = new NullActionPipeline(Symbol('NullAction'));
+
+export class NullRepositoryPipeline {
+  getPipeline(actionName) {
+    return nullPipeline;
+  }
+}
+
+const REPO_ACTIONS = [
+  'PUSH', 'PULL', 'COMMIT', 'CLONE', 'INIT',
+];
+
+export function createRepositoryPipeline() {
+  return new ActionPipelineManager({
+    actionName: REPO_ACTIONS,
+  });
+}

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -3,6 +3,7 @@ import path from 'path';
 import {Emitter} from 'event-kit';
 
 import CompositeGitStrategy from '../composite-git-strategy';
+import {NullRepositoryPipeline, createRepositoryPipeline} from './repository-pipeline';
 import {readFile} from '../helpers';
 import Remote, {nullRemote} from './remote';
 import {Loading, Absent, LoadingGuess, AbsentGuess} from './repository-states';
@@ -35,6 +36,7 @@ export default class Repository {
   constructor(workingDirectoryPath, gitStrategy = null, options = {}) {
     this.workingDirectoryPath = workingDirectoryPath;
     this.git = gitStrategy || CompositeGitStrategy.create(workingDirectoryPath);
+    this.pipelines = options.pipelines || new NullRepositoryPipeline();
 
     this.emitter = new Emitter();
 
@@ -96,6 +98,26 @@ export default class Repository {
    */
   setPromptCallback(callback) {
     this.git.getImplementers().forEach(strategy => strategy.setPromptCallback(callback));
+  }
+
+  // Pipelines
+
+  getPipeline(actionName) {
+    const action = this.pipelines.actions[actionName];
+    return this.pipelines.getPipeline(action);
+  }
+
+  executePipelineAction(actionName, baseOptions, fn) {
+    if (baseOptions.repository) {
+      throw new Error('baseOptions may nto contain a `repository` key');
+    }
+
+    const pipeline = this.getPipeline(actionName);
+    const opts = {
+      ...baseOptions,
+      repository: this,
+    };
+    return pipeline.run(fn, opts);
   }
 
   // Event subscription ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/lib/views/pr-url-input-box.js
+++ b/lib/views/pr-url-input-box.js
@@ -5,7 +5,7 @@ import {autobind} from 'core-decorators';
 export default class PrUrlInputBox extends React.Component {
   static propTypes = {
     onSubmit: PropTypes.func.isRequired,
-    children: PropTypes.node,
+    children: PropTypes.func,
   }
 
   constructor(props, context) {
@@ -16,23 +16,30 @@ export default class PrUrlInputBox extends React.Component {
   }
 
   render() {
-    return (
-      <form className="github-PrUrlInputBox-Subview" onSubmit={this.handleSubmitUrl}>
-        {this.props.children}
+    const ourChildren = (
+      [
         <input
+          key="pr-url-input-box-1"
           type="text"
           className="input-text native-key-bindings"
           placeholder="e.g. https://github.com/owner/repo/pull/123"
           value={this.state.url}
           onChange={this.handleUrlChange}
-        />
-        <div>
+        />,
+        <div
+          key="pr-url-input-box-2">
           <input
             type="submit"
             value="Submit"
             onClick={this.handleSubmitUrlClick} className="btn btn-primary icon icon-check inline-block-tight"
           />
-        </div>
+        </div>,
+      ]
+    );
+
+    return (
+      <form className="github-PrUrlInputBox-Subview" onSubmit={this.handleSubmitUrl}>
+        {this.props.children ? this.props.children(ourChildren) : ourChildren}
       </form>
     );
   }

--- a/lib/views/pr-url-input-box.js
+++ b/lib/views/pr-url-input-box.js
@@ -5,6 +5,7 @@ import {autobind} from 'core-decorators';
 export default class PrUrlInputBox extends React.Component {
   static propTypes = {
     onSubmit: PropTypes.func.isRequired,
+    refresh: PropTypes.func,
     children: PropTypes.func,
   }
 
@@ -33,6 +34,14 @@ export default class PrUrlInputBox extends React.Component {
             value="Submit"
             onClick={this.handleSubmitUrlClick} className="btn btn-primary icon icon-check inline-block-tight"
           />
+          {this.props.refresh &&
+            <input
+              type="button"
+              value="Search Again"
+              onClick={this.props.refresh}
+              className="btn inline-block-tight"
+            />
+          }
         </div>,
       ]
     );

--- a/lib/views/pr-url-input-box.js
+++ b/lib/views/pr-url-input-box.js
@@ -6,7 +6,6 @@ export default class PrUrlInputBox extends React.Component {
   static propTypes = {
     onSubmit: PropTypes.func.isRequired,
     refresh: PropTypes.func,
-    children: PropTypes.func,
   }
 
   constructor(props, context) {
@@ -17,18 +16,16 @@ export default class PrUrlInputBox extends React.Component {
   }
 
   render() {
-    const ourChildren = (
-      [
+    return (
+      <form onSubmit={this.handleSubmitUrl} className="github-PrUrlInputBox-Subview">
         <input
-          key="pr-url-input-box-1"
           type="text"
           className="input-text native-key-bindings"
           placeholder="e.g. https://github.com/owner/repo/pull/123"
           value={this.state.url}
           onChange={this.handleUrlChange}
-        />,
-        <div
-          key="pr-url-input-box-2">
+        />
+        <div>
           <input
             type="submit"
             value="Submit"
@@ -42,13 +39,7 @@ export default class PrUrlInputBox extends React.Component {
               className="btn inline-block-tight"
             />
           }
-        </div>,
-      ]
-    );
-
-    return (
-      <form className="github-PrUrlInputBox-Subview" onSubmit={this.handleSubmitUrl}>
-        {this.props.children ? this.props.children(ourChildren) : ourChildren}
+        </div>
       </form>
     );
   }

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -390,6 +390,7 @@ export default class StagingView {
   async didSelectSingleItem(selectedItem, openNew = false) {
     if (this.selection.getActiveListKey() === 'conflicts') {
       if (openNew) {
+        console.log('openNew is true');
         await this.showMergeConflictFileForPath(selectedItem.filePath);
       }
     } else {
@@ -415,6 +416,7 @@ export default class StagingView {
   }
 
   async showMergeConflictFileForPath(relativeFilePath, {activate} = {activate: false}) {
+    console.log('showMergeConflictFileForPath', activate);
     const absolutePath = path.join(this.props.workingDirectoryPath, relativeFilePath);
     if (await this.fileExists(absolutePath)) {
       return this.props.workspace.open(absolutePath, {activatePane: activate, activateItem: activate, pending: true});

--- a/styles/pr-selection.less
+++ b/styles/pr-selection.less
@@ -40,4 +40,7 @@
     }
   }
 
+  a {
+    color: @text-color-info;
+  }
 }

--- a/styles/pr-url-input-box.less
+++ b/styles/pr-url-input-box.less
@@ -38,7 +38,11 @@
     align-self: center;
     align-items: center;
 
-    > button, > input {
+    > div {
+      text-align: center;
+    }
+
+    > button, > div > button, > input, > div > input {
       margin: @component-padding;
     }
 
@@ -65,6 +69,10 @@
 
     input[type=text] {
       width: 100%;
+    }
+
+    input[type=submit] {
+      margin-bottom: @component-padding;
     }
   }
 

--- a/styles/pr-url-input-box.less
+++ b/styles/pr-url-input-box.less
@@ -37,13 +37,14 @@
     flex-direction: column;
     align-self: center;
     align-items: center;
+    text-align: center;
 
-    > div {
-      text-align: center;
-    }
+    form {
+      width: 100%;
 
-    > button, > div > button, > input, > div > input {
-      margin: @component-padding;
+      > button, > input {
+        margin: @component-padding;
+      }
     }
 
     .icon-git-pull-request:before {
@@ -64,6 +65,12 @@
 
       a {
         color: @text-color-info;
+      }
+    }
+
+    &-input {
+      > form > div {
+        text-align: center;
       }
     }
 

--- a/styles/pr-url-input-box.less
+++ b/styles/pr-url-input-box.less
@@ -71,7 +71,7 @@
       width: 100%;
     }
 
-    input[type=submit] {
+    input[type=submit], input[type=button] {
       margin-bottom: @component-padding;
     }
   }

--- a/test/action-pipeline.test.js
+++ b/test/action-pipeline.test.js
@@ -1,0 +1,160 @@
+import {ActionPipelineManager, ActionPipeline} from '../lib/action-pipeline';
+
+describe.only('ActionPipelineManager', function() {
+  it('manages pipelines a set of actions', function() {
+    const actionNames = ['ONE', 'TWO'];
+    const manager = new ActionPipelineManager({actionNames});
+
+    assert.ok(manager.getPipeline(manager.actions.ONE));
+    assert.ok(manager.getPipeline(manager.actions.TWO));
+    assert.throws(() => manager.getPipeline(manager.actions.THREE), /not a known action/);
+
+    const pipeline = manager.getPipeline(manager.actions.ONE);
+    assert.equal(manager.actions.ONE, pipeline.action);
+  });
+});
+
+describe.only('ActionPipeline', function() {
+  let pipeline;
+  beforeEach(function() {
+    pipeline = new ActionPipeline(Symbol('TEST_ACTION'));
+  });
+
+  it('runs actions with no middleware', async function() {
+    const base = (a, b) => a + b;
+    const result = await pipeline.run(base, 1, 2);
+    assert.equal(result, 3);
+  });
+
+  it('requires middleware to have a name', function() {
+    assert.throws(() => pipeline.addMiddleware(null, () => null), /must be registered with a unique middleware name/);
+  });
+
+  it('only allows a single instance of a given middleware based on name', function() {
+    pipeline.addMiddleware('testMiddleware', () => null);
+    assert.throws(() => pipeline.addMiddleware('testMiddleware', () => null),
+      /testMiddleware.*already registered/);
+  });
+
+  it('registers middleware to run around the function', async function() {
+    const capturedArgs = [];
+    const capturedResults = [];
+    const options = {a: 1, b: 2};
+
+    pipeline.addMiddleware('testMiddleware', (next, opts) => {
+      capturedArgs.push([opts.a, opts.b]);
+      opts.a += 1;
+      opts.b += 2;
+      const result = next();
+      capturedResults.push(result);
+      return result + 1;
+    });
+
+    pipeline.addMiddleware('testMiddleware2', (next, opts) => {
+      capturedArgs.push([opts.a, opts.b]);
+      opts.a *= 2;
+      opts.b *= 3;
+      const result = next();
+      capturedResults.push(result);
+      return result * 2;
+    });
+
+    const base = ({a, b}) => a + b;
+    const result = await pipeline.run(base, options);
+    assert.deepEqual(capturedArgs, [[1, 2], [2, 4]]);
+    assert.deepEqual(capturedResults, [16, 32]);
+    assert.equal(result, 33);
+  });
+
+  it('allows removing middleware by name', async function() {
+    const capturedArgs = [];
+    const capturedResults = [];
+    const options = {a: 1, b: 2};
+
+    pipeline.addMiddleware('testMiddleware', (next, opts) => {
+      capturedArgs.push([opts.a, opts.b]);
+      opts.a += 1;
+      opts.b += 2;
+      const result = next();
+      capturedResults.push(result);
+      return result + 1;
+    });
+
+    pipeline.addMiddleware('testMiddleware2', (next, opts) => {
+      capturedArgs.push([opts.a, opts.b]);
+      opts.a *= 2;
+      opts.b *= 3;
+      const result = next();
+      capturedResults.push(result);
+      return result * 2;
+    });
+
+    pipeline.removeMiddleware('testMiddleware');
+
+    const base = ({a, b}) => a + b;
+    const result = await pipeline.run(base, options);
+    assert.deepEqual(capturedArgs, [[1, 2]]);
+    assert.deepEqual(capturedResults, [8]);
+    assert.equal(result, 16);
+  });
+
+  it('allows inserting middleware before another by name', async function() {
+    const capturedArgs = [];
+    const capturedResults = [];
+    const options = {a: 1, b: 2};
+
+    pipeline.addMiddleware('testMiddleware', (next, opts) => {
+      capturedArgs.push([opts.a, opts.b]);
+      opts.a += 1;
+      opts.b += 2;
+      const result = next();
+      capturedResults.push(result);
+      return result + 1;
+    });
+
+    pipeline.insertMiddlewareBefore('testMiddleware', 'testMiddleware2', (next, opts) => {
+      capturedArgs.push([opts.a, opts.b]);
+      opts.a *= 2;
+      opts.b *= 3;
+      const result = next();
+      capturedResults.push(result);
+      return result * 2;
+    });
+
+    const base = ({a, b}) => a + b;
+    const result = await pipeline.run(base, options);
+    assert.deepEqual(capturedArgs, [[1, 2], [2, 6]]);
+    assert.deepEqual(capturedResults, [11, 12]);
+    assert.equal(result, 24);
+  });
+
+  it('allows inserting middleware after another by name', async function() {
+    const capturedArgs = [];
+    const capturedResults = [];
+    const options = {a: 1, b: 2};
+
+    pipeline.addMiddleware('testMiddleware', (next, opts) => {
+      capturedArgs.push([opts.a, opts.b]);
+      opts.a += 1;
+      opts.b += 2;
+      const result = next();
+      capturedResults.push(result);
+      return result + 1;
+    });
+
+    pipeline.insertMiddlewareAfter('testMiddleware', 'testMiddleware2', (next, opts) => {
+      capturedArgs.push([opts.a, opts.b]);
+      opts.a *= 2;
+      opts.b *= 3;
+      const result = next();
+      capturedResults.push(result);
+      return result * 2;
+    });
+
+    const base = ({a, b}) => a + b;
+    const result = await pipeline.run(base, options);
+    assert.deepEqual(capturedArgs, [[1, 2], [2, 4]]);
+    assert.deepEqual(capturedResults, [16, 32]);
+    assert.equal(result, 33);
+  });
+});

--- a/test/action-pipeline.test.js
+++ b/test/action-pipeline.test.js
@@ -1,6 +1,6 @@
 import {ActionPipelineManager, ActionPipeline} from '../lib/action-pipeline';
 
-describe.only('ActionPipelineManager', function() {
+describe('ActionPipelineManager', function() {
   it('manages pipelines a set of actions', function() {
     const actionNames = ['ONE', 'TWO'];
     const manager = new ActionPipelineManager({actionNames});
@@ -14,7 +14,7 @@ describe.only('ActionPipelineManager', function() {
   });
 });
 
-describe.only('ActionPipeline', function() {
+describe('ActionPipeline', function() {
   let pipeline;
   beforeEach(function() {
     pipeline = new ActionPipeline(Symbol('TEST_ACTION'));


### PR DESCRIPTION
When a PR can't be found for a branch, or many PRs are found for a branch, offer a link to the create PR page for the branch on GitHub.com.

Also adds a new button to re-do the search, useful if the user creates the PR in another window and wants to display it in Atom.

![cursor_and_github__preview__ ___atom](https://user-images.githubusercontent.com/189606/29642103-b06b07d2-881b-11e7-9c59-afbf6b699a2a.png)
