### PR TITLE
Focus merge conflict file when opening and error decorating destroyed marker

### DIFF
--- a/lib/controllers/repository-conflict-controller.js
+++ b/lib/controllers/repository-conflict-controller.js
@@ -47,11 +47,16 @@ export default class RepositoryConflictController extends React.Component {
   }
 
   componentDidMount() {
-    this.subscriptions.add(this.props.workspace.observeTextEditors(() => {
+    const updateState = () => {
       this.setState({
         openEditors: this.props.workspace.getTextEditors(),
       });
-    }));
+    };
+
+    this.subscriptions.add(
+      this.props.workspace.observeTextEditors(updateState),
+      this.props.workspace.onDidDestroyPaneItem(updateState),
+    );
   }
 
   render() {

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -390,7 +390,7 @@ export default class StagingView {
   async didSelectSingleItem(selectedItem, openNew = false) {
     if (this.selection.getActiveListKey() === 'conflicts') {
       if (openNew) {
-        await this.showMergeConflictFileForPath(selectedItem.filePath);
+        await this.showMergeConflictFileForPath(selectedItem.filePath, {activate: true});
       }
     } else {
       const pendingItem = this.getPendingFilePatchItem();


### PR DESCRIPTION
This PR:

* Makes sure that files under conflict opened from the staging view are focused correctly, and
* Resolves an error where closing a text editor under conflict did not destroy the underlying `Decoration` components

Fixes #1120 
Fixes #971