### PR TITLE
Handle repositories that are very large and/or that exist in home or root directories

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -19,11 +19,20 @@ import GitTimingsView from './views/git-timings-view';
 import WorkerManager from './worker-manager';
 
 const LINE_ENDING_REGEX = /\r?\n/;
+const MAX_STATUS_OUTPUT_LENGTH = 1024 * 1024 * 10;
 
 let headless = null;
 let execPathPromise = null;
 
 export class GitError extends Error {
+  constructor(message) {
+    super(message);
+    this.message = message;
+    this.stack = new Error().stack;
+  }
+}
+
+export class LargeRepoError extends Error {
   constructor(message) {
     super(message);
     this.message = message;
@@ -357,6 +366,10 @@ export default class GitShellOutStrategy {
   async getStatusBundle() {
     const args = ['status', '--porcelain=v2', '--branch', '--untracked-files=all', '--ignore-submodules=dirty', '-z'];
     const output = await this.exec(args);
+    if (output.length > MAX_STATUS_OUTPUT_LENGTH) {
+      throw new LargeRepoError();
+    }
+
     const results = await parseStatus(output);
 
     for (const entryType in results) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
+import os from 'os';
 import temp from 'temp';
 import {ncp} from 'ncp';
 
@@ -113,6 +114,14 @@ export function firstImplementer(...targets) {
       }, Object.prototype);
     },
   });
+}
+
+function isRoot(dir) {
+  return path.resolve(dir, '..') === dir;
+}
+
+export function isValidWorkdir(dir) {
+  return dir !== os.homedir() && !isRoot(dir);
 }
 
 export function readFile(absoluteFilePath, encoding = 'utf8') {

--- a/lib/models/repository-states/index.js
+++ b/lib/models/repository-states/index.js
@@ -12,3 +12,4 @@ import './initializing';
 import './cloning';
 import './present';
 import './destroyed';
+import './too-large';

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -2,6 +2,7 @@ import path from 'path';
 
 import State from './state';
 
+import {LargeRepoError} from '../../git-shell-out-strategy';
 import {deleteFileOrFolder} from '../../helpers';
 import {FOCUS} from '../workspace-change-observer';
 import FilePatch from '../file-patch';
@@ -388,13 +389,27 @@ export default class Present extends State {
 
   getStatusBundle() {
     return this.cache.getOrSet(Keys.statusBundle, async () => {
-      const bundle = await this.git().getStatusBundle();
-      const results = await this.formatChangedFiles(bundle);
-      results.branch = bundle.branch;
-      if (!results.branch.aheadBehind) {
-        results.branch.aheadBehind = {ahead: null, behind: null};
+      try {
+        const bundle = await this.git().getStatusBundle();
+        const results = await this.formatChangedFiles(bundle);
+        results.branch = bundle.branch;
+        if (!results.branch.aheadBehind) {
+          results.branch.aheadBehind = {ahead: null, behind: null};
+        }
+        return results;
+      } catch (err) {
+        if (err instanceof LargeRepoError) {
+          this.transitionTo('TooLarge');
+          return {
+            branch: {},
+            stagedFiles: [],
+            unstagedFiles: [],
+            mergeConflictFiles: [],
+          };
+        } else {
+          throw err;
+        }
       }
-      return results;
     });
   }
 

--- a/lib/models/repository-states/state.js
+++ b/lib/models/repository-states/state.js
@@ -69,6 +69,11 @@ export default class State {
   }
 
   @shouldDelegate
+  isTooLarge() {
+    return false;
+  }
+
+  @shouldDelegate
   isDestroyed() {
     return false;
   }

--- a/lib/models/repository-states/too-large.js
+++ b/lib/models/repository-states/too-large.js
@@ -1,0 +1,12 @@
+import State from './state';
+
+/**
+ * The repository is too large for Atom to handle
+ */
+export default class TooLarge extends State {
+  isTooLarge() {
+    return true;
+  }
+}
+
+State.register(TooLarge);

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -229,6 +229,7 @@ const delegates = [
   'isLoading',
   'isEmpty',
   'isPresent',
+  'isTooLarge',
   'isDestroyed',
 
   'isUndetermined',

--- a/lib/models/workdir-cache.js
+++ b/lib/models/workdir-cache.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 
-import {readFile} from '../helpers';
+import {readFile, isValidWorkdir} from '../helpers';
 
 /**
  * Locate the nearest git working directory above a given starting point, caching results.
@@ -56,6 +56,10 @@ export default class WorkdirCache {
       let currentDir = initialDir;
 
       const check = () => {
+        if (!isValidWorkdir(currentDir)) {
+          return walk();
+        }
+
         const dotGit = path.join(currentDir, '.git');
         fs.stat(dotGit, async (statError, stat) => {
           if (statError) {
@@ -79,6 +83,7 @@ export default class WorkdirCache {
           // .git directory found! Mission accomplished.
           return resolve(currentDir);
         });
+        return null;
       };
 
       const walk = () => {

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -67,8 +67,11 @@ export default class GitTabView {
     } else if (this.props.repository.showGitTabInit()) {
       const inProgress = this.props.repository.showGitTabInitInProgress();
       const message = this.props.repository.hasDirectory() ?
-        'Initialize this project directory with a git repository' :
-        'Initialize a new project directory with a git repository';
+        (
+          <span>Initialize <strong>{this.props.repository.getWorkingDirectoryPath()}</strong> with a
+          Git repository</span>
+        ) :
+          <span>Initialize a new project directory with a Git repository</span>;
 
       return (
         <div className="github-Panel is-empty" tabIndex="-1">

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -1,8 +1,6 @@
 /** @jsx etch.dom */
 /* eslint react/no-unknown-property: "off" */
 
-import os from 'os';
-
 import etch from 'etch';
 import {autobind} from 'core-decorators';
 import cx from 'classnames';
@@ -10,6 +8,7 @@ import cx from 'classnames';
 import StagingView from './staging-view';
 import GitLogo from './git-logo';
 import CommitViewController from '../controllers/commit-view-controller';
+import {isValidWorkdir} from '../helpers';
 
 export default class GitTabView {
   static focus = {
@@ -43,18 +42,25 @@ export default class GitTabView {
               <GitLogo />
             </div>
             <h3>Too many changes</h3>
-            {workingDir === os.homedir()
-              ? <div className="initialize-repo-description">
-                  The repository at <strong>{workingDir}</strong> has too many changed files
-                  to display in Atom. In addition, the repository is located at your
-                  home directory, which may be unintended. <a href="https://gist.github.com/BinaryMuse/something">More details</a>
-              </div>
-              : <div className="initialize-repo-description">
-                  The repository at <strong>{workingDir}</strong> has too many changed files
-                  to display in Atom. Ensure that you have set up an appropriate <code>.gitignore</code> file.
-                  <a href="https://gist.github.com/BinaryMuse/something">More details</a>
-              </div>
-            }
+            <div className="initialize-repo-description">
+              The repository at <strong>{workingDir}</strong> has too many changed files
+              to display in Atom. Ensure that you have set up an appropriate <code>.gitignore</code> file.
+            </div>
+          </div>
+        </div>
+      );
+    } else if (this.props.repository.hasDirectory() &&
+               !isValidWorkdir(this.props.repository.getWorkingDirectoryPath())) {
+      return (
+        <div className="github-Panel is-empty" tabIndex="-1">
+          <div ref="noRepoMessage" className="github-Panel no-repository">
+            <div className="large-icon">
+              <GitLogo />
+            </div>
+            <h3>Unsupported directory</h3>
+            <div className="initialize-repo-description">
+              Atom does not support managing Git repositories in your home or root directories.
+            </div>
           </div>
         </div>
       );

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -42,16 +42,17 @@ export default class GitTabView {
             <div className="large-icon">
               <GitLogo />
             </div>
+            <h3>Too many changes</h3>
             {workingDir === os.homedir()
               ? <div className="initialize-repo-description">
-                  The number of changed files in the repository at <strong>{workingDir}</strong> is
-                  too large for Atom to manage. In addition, the repository is located at your
+                  The repository at <strong>{workingDir}</strong> has too many changed files
+                  to display in Atom. In addition, the repository is located at your
                   home directory, which may be unintended. <a href="https://gist.github.com/BinaryMuse/something">More details</a>
               </div>
               : <div className="initialize-repo-description">
-                  The number of changed files in the repository at <strong>{workingDir}</strong> is
-                  too large for Atom to manage. Ensure that the repository path is correct and
-                  that you have set up an appropriate <code>.gitignore</code> file. <a href="https://gist.github.com/BinaryMuse/something">More details</a>
+                  The repository at <strong>{workingDir}</strong> has too many changed files
+                  to display in Atom. Ensure that you have set up an appropriate <code>.gitignore</code> file.
+                  <a href="https://gist.github.com/BinaryMuse/something">More details</a>
               </div>
             }
           </div>

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -1,6 +1,8 @@
 /** @jsx etch.dom */
 /* eslint react/no-unknown-property: "off" */
 
+import os from 'os';
+
 import etch from 'etch';
 import {autobind} from 'core-decorators';
 import cx from 'classnames';
@@ -32,7 +34,30 @@ export default class GitTabView {
   }
 
   render() {
-    if (this.props.repository.showGitTabInit()) {
+    if (this.props.repository.isTooLarge()) {
+      const workingDir = this.props.repository.getWorkingDirectoryPath();
+      return (
+        <div className="github-Panel is-empty" tabIndex="-1">
+          <div ref="noRepoMessage" className="github-Panel no-repository">
+            <div className="large-icon">
+              <GitLogo />
+            </div>
+            {workingDir === os.homedir()
+              ? <div className="initialize-repo-description">
+                  The number of changed files in the repository at <strong>{workingDir}</strong> is
+                  too large for Atom to manage. In addition, the repository is located at your
+                  home directory, which may be unintended. <a href="https://gist.github.com/BinaryMuse/something">More details</a>
+              </div>
+              : <div className="initialize-repo-description">
+                  The number of changed files in the repository at <strong>{workingDir}</strong> is
+                  too large for Atom to manage. Ensure that the repository path is correct and
+                  that you have set up an appropriate <code>.gitignore</code> file. <a href="https://gist.github.com/BinaryMuse/something">More details</a>
+              </div>
+            }
+          </div>
+        </div>
+      );
+    } else if (this.props.repository.showGitTabInit()) {
       const inProgress = this.props.repository.showGitTabInitInProgress();
       const message = this.props.repository.hasDirectory() ?
         'Initialize this project directory with a git repository' :


### PR DESCRIPTION
Repositories that have output for our `status` call that is greater than a given threshold (set to 10 MB here) are considered too large for Atom to handle and are moved to the `TooLarge` state, which we detect and use to show a friendly message to users.

![cursor_and__](https://user-images.githubusercontent.com/189606/30138700-94f95c5c-931e-11e7-98a4-aaae6430962d.png)

Additionally, if we detect the repository is in the user's home directory, we show slightly different messaging.

![cursor_and_git_ __](https://user-images.githubusercontent.com/189606/30138676-734912fa-931e-11e7-9643-76ecf5e59247.png)

Messaging is WIP; ping @jasonrudolph for awesome Atom voice 💭 s. ❤️ 

Fixes #953 
Fixes atom/atom#15443
Fixes atom/atom#15493

TODO:

- [x] Messaging
- [x] ~Create Discuss posts to link to~
- [x] Styling