### PR TITLE
Always run GPG with --batch --no-tty

### DIFF
--- a/bin/gpg-wrapper.sh
+++ b/bin/gpg-wrapper.sh
@@ -7,7 +7,7 @@ unset GIT_CONFIG_PARAMETERS
 GPG_PROGRAM=$(git config gpg.program || echo 'gpg')
 PASSPHRASE_ARG=
 
-if [ -n "${ATOM_GITHUB_ASKPASS_PATH:-}" ] && [ -n "${GIT_ASKPASS:-}" ]; then
+if [ -n "${ATOM_GITHUB_GPG_PROMPT:-}" ] && [ -n "${GIT_ASKPASS:-}" ]; then
   SIGNING_KEY=$(git config user.signingkey)
   if [ -n "${SIGNING_KEY}" ]; then
     PROMPT="Please enter the passphrase for the GPG key '${SIGNING_KEY}'."

--- a/lib/git-prompt-server.js
+++ b/lib/git-prompt-server.js
@@ -1,84 +1,17 @@
 import net from 'net';
-import path from 'path';
-import os from 'os';
-
 import {Emitter} from 'event-kit';
 
-import {getPackageRoot, deleteFileOrFolder, getTempDir, copyFile, chmodFile} from './helpers';
-
-function getAtomHelperPath() {
-  if (process.platform === 'darwin') {
-    const beta = atom.appVersion.match(/-beta/);
-    const appName = beta ? 'Atom Beta Helper' : 'Atom Helper';
-    return path.resolve(process.resourcesPath, '..', 'Frameworks',
-     `${appName}.app`, 'Contents', 'MacOS', appName);
-  } else {
-    return process.execPath;
-  }
-}
-
 export default class GitPromptServer {
-  constructor() {
+  constructor(gitTempDir) {
     this.emitter = new Emitter();
+    this.gitTempDir = gitTempDir;
   }
 
   async start(promptForInput) {
-    // TODO: [mkt] Windows?? yes.
     this.promptForInput = promptForInput;
-    const windows = process.platform === 'win32';
-    this.tmpFolderPath = await getTempDir({
-      dir: windows ? os.tmpdir() : '/tmp',
-      prefix: 'github-',
-      symlinkOk: true,
-    });
 
-    const credentialHelper = {};
-    const askPass = {};
-    const sshWrapper = {};
-    const gpgWrapper = {};
-
-    const sourceFiles = {
-      'git-credential-atom.js': outfile => (credentialHelper.script = outfile),
-      'git-credential-atom.sh': outfile => (credentialHelper.launcher = outfile),
-      'git-askpass-atom.js': outfile => (askPass.script = outfile),
-      'git-askpass-atom.sh': outfile => (askPass.launcher = outfile),
-      'linux-ssh-wrapper.sh': outfile => (sshWrapper.script = outfile),
-      'gpg-wrapper.sh': outfile => (gpgWrapper.launcher = outfile),
-    };
-
-    await Promise.all(
-      Object.keys(sourceFiles).map(async filename => {
-        const destPath = path.join(this.tmpFolderPath, filename);
-
-        await copyFile(
-          path.resolve(getPackageRoot(), 'bin', filename),
-          destPath,
-        );
-
-        if (path.extname(filename) === '.sh') {
-          await chmodFile(destPath, 0o700);
-        }
-
-        sourceFiles[filename](destPath);
-      }),
-    );
-
-    const socketPath = path.join(this.tmpFolderPath, 'helper.sock');
-    const namedPipePath = path.join(
-      '\\\\?\\pipe\\', 'gh-' + require('crypto').randomBytes(8).toString('hex'),
-      'helper.sock',
-    );
-    this.server = await this.startListening(windows ? namedPipePath : socketPath);
-
-    return {
-      socket: windows ? namedPipePath : socketPath,
-      tmpdir: this.tmpFolderPath,
-      electron: getAtomHelperPath(),
-      credentialHelper,
-      askPass,
-      sshWrapper,
-      gpgWrapper,
-    };
+    await this.gitTempDir.ensure();
+    this.server = await this.startListening(this.gitTempDir.getSocketPath());
   }
 
   startListening(socketPath) {
@@ -122,7 +55,6 @@ export default class GitPromptServer {
 
   async terminate() {
     await new Promise(resolve => this.server.close(resolve));
-    await deleteFileOrFolder(this.tmpFolderPath);
     this.emitter.dispose();
   }
 }

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -9,9 +9,10 @@ import {parse as parseDiff} from 'what-the-diff';
 import {parse as parseStatus} from 'what-the-status';
 
 import GitPromptServer from './git-prompt-server';
+import GitTempDir from './git-temp-dir';
 import AsyncQueue from './async-queue';
 import {
-  getDugitePath,
+  getDugitePath, getAtomHelperPath,
   readFile, fileExists, fsStat, writeFile, isFileExecutable, isBinary,
   normalizeGitHelperPath, toNativePathSep, toGitPathSep,
 } from './helpers';
@@ -32,7 +33,13 @@ export class GitError extends Error {
 }
 
 export default class GitShellOutStrategy {
-  static defaultExecArgs = {stdin: null, useGitPromptServer: false, useGpgWrapper: false, writeOperation: false}
+  static defaultExecArgs = {
+    stdin: null,
+    useGitPromptServer: false,
+    useGpgWrapper: false,
+    useGpgAtomPrompt: false,
+    writeOperation: false,
+  }
 
   constructor(workingDir, options = {}) {
     this.workingDir = workingDir;
@@ -62,8 +69,9 @@ export default class GitShellOutStrategy {
   }
 
   // Execute a command and read the output using the embedded Git environment
-  async exec(args, {stdin, useGitPromptServer, useGpgWrapper, writeOperation} = GitShellOutStrategy.defaultExecArgs) {
+  async exec(args, options = GitShellOutStrategy.defaultExecArgs) {
     /* eslint-disable no-console */
+    const {stdin, useGitPromptServer, useGpgWrapper, useGpgAtomPrompt, writeOperation} = options;
     const subscriptions = new CompositeDisposable();
     const diagnosticsEnabled = process.env.ATOM_GITHUB_GIT_DIAGNOSTICS || atom.config.get('github.gitDiagnostics');
 
@@ -105,17 +113,22 @@ export default class GitShellOutStrategy {
         PATH: pathParts.join(path.delimiter),
       };
 
-      if (useGitPromptServer) {
-        gitPromptServer = new GitPromptServer();
-        const {
-          socket, tmpdir, electron, credentialHelper, askPass, sshWrapper, gpgWrapper,
-        } = await gitPromptServer.start(this.prompt);
+      const gitTempDir = new GitTempDir();
 
-        env.ATOM_GITHUB_TMP = tmpdir;
-        env.ATOM_GITHUB_ASKPASS_PATH = normalizeGitHelperPath(askPass.script);
-        env.ATOM_GITHUB_CREDENTIAL_PATH = normalizeGitHelperPath(credentialHelper.script);
-        env.ATOM_GITHUB_ELECTRON_PATH = normalizeGitHelperPath(electron);
-        env.ATOM_GITHUB_SOCK_PATH = normalizeGitHelperPath(socket);
+      if (useGpgWrapper) {
+        await gitTempDir.ensure();
+        args.unshift('-c', `gpg.program=${gitTempDir.getGpgWrapperSh()}`);
+      }
+
+      if (useGitPromptServer) {
+        gitPromptServer = new GitPromptServer(gitTempDir);
+        await gitPromptServer.start(this.prompt);
+
+        env.ATOM_GITHUB_TMP = gitTempDir.getRootPath();
+        env.ATOM_GITHUB_ASKPASS_PATH = normalizeGitHelperPath(gitTempDir.getAskPassJs());
+        env.ATOM_GITHUB_CREDENTIAL_PATH = normalizeGitHelperPath(gitTempDir.getCredentialHelperJs());
+        env.ATOM_GITHUB_ELECTRON_PATH = normalizeGitHelperPath(getAtomHelperPath());
+        env.ATOM_GITHUB_SOCK_PATH = normalizeGitHelperPath(gitTempDir.getSocketPath());
 
         env.ATOM_GITHUB_WORKDIR_PATH = this.workingDir;
         env.ATOM_GITHUB_DUGITE_PATH = getDugitePath();
@@ -134,20 +147,21 @@ export default class GitShellOutStrategy {
         env.ATOM_GITHUB_ORIGINAL_GIT_SSH_COMMAND = process.env.GIT_SSH_COMMAND || '';
         env.ATOM_GITHUB_SPEC_MODE = atom.inSpecMode() ? 'true' : 'false';
 
-        env.SSH_ASKPASS = normalizeGitHelperPath(askPass.launcher);
-        env.GIT_ASKPASS = normalizeGitHelperPath(askPass.launcher);
+        env.SSH_ASKPASS = normalizeGitHelperPath(gitTempDir.getAskPassSh());
+        env.GIT_ASKPASS = normalizeGitHelperPath(gitTempDir.getAskPassSh());
 
         if (process.platform === 'linux') {
-          env.GIT_SSH_COMMAND = sshWrapper.script;
+          env.GIT_SSH_COMMAND = gitTempDir.getSshWrapperSh();
         } else {
           env.GIT_SSH_COMMAND = process.env.GIT_SSH_COMMAND;
         }
 
-        if (useGpgWrapper) {
-          args.unshift('-c', `gpg.program=${gpgWrapper.launcher}`);
-        }
+        const credentialHelperJs = normalizeGitHelperPath(gitTempDir.getCredentialHelperJs());
+        args.unshift('-c', `credential.helper=${credentialHelperJs}`);
+      }
 
-        args.unshift('-c', `credential.helper=${normalizeGitHelperPath(credentialHelper.launcher)}`);
+      if (useGpgWrapper && useGitPromptServer && useGpgAtomPrompt) {
+        env.ATOM_GITHUB_GPG_PROMPT = 'true';
       }
 
       if (diagnosticsEnabled) {
@@ -155,18 +169,18 @@ export default class GitShellOutStrategy {
         env.GIT_TRACE_CURL = 'true';
       }
 
-      const options = {env};
+      const opts = {env};
 
       if (stdin) {
-        options.stdin = stdin;
-        options.stdinEncoding = 'utf8';
+        opts.stdin = stdin;
+        opts.stdinEncoding = 'utf8';
       }
 
       if (process.env.PRINT_GIT_TIMES) {
         console.time(`git:${formattedArgs}`);
       }
       return new Promise(async (resolve, reject) => {
-        const {promise, cancel} = this.executeGitCommand(args, options, timingMarker);
+        const {promise, cancel} = this.executeGitCommand(args, opts, timingMarker);
         let expectCancel = false;
         if (gitPromptServer) {
           subscriptions.add(gitPromptServer.onDidCancel(async ({handlerPid}) => {
@@ -248,10 +262,19 @@ export default class GitShellOutStrategy {
 
   async gpgExec(args, options) {
     try {
-      return await this.exec(args, options);
+      return await this.exec(args.slice(), {
+        useGpgWrapper: true,
+        useGpgAtomPrompt: false,
+        ...options,
+      });
     } catch (e) {
       if (/gpg failed/.test(e.stdErr)) {
-        return await this.exec(args, {useGitPromptServer: true, useGpgWrapper: true, ...options});
+        return await this.exec(args, {
+          useGitPromptServer: true,
+          useGpgWrapper: true,
+          useGpgAtomPrompt: true,
+          ...options,
+        });
       } else {
         throw e;
       }

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -156,7 +156,7 @@ export default class GitShellOutStrategy {
           env.GIT_SSH_COMMAND = process.env.GIT_SSH_COMMAND;
         }
 
-        const credentialHelperSh = normalizeGitHelperPath(gitTempDir.getCredentialHelperSh());
+        const credentialHelperSh = gitTempDir.getCredentialHelperSh();
         args.unshift('-c', `credential.helper=${credentialHelperSh}`);
       }
 

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -156,7 +156,7 @@ export default class GitShellOutStrategy {
           env.GIT_SSH_COMMAND = process.env.GIT_SSH_COMMAND;
         }
 
-        const credentialHelperSh = gitTempDir.getCredentialHelperSh();
+        const credentialHelperSh = normalizeGitHelperPath(gitTempDir.getCredentialHelperSh());
         args.unshift('-c', `credential.helper=${credentialHelperSh}`);
       }
 

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -156,8 +156,8 @@ export default class GitShellOutStrategy {
           env.GIT_SSH_COMMAND = process.env.GIT_SSH_COMMAND;
         }
 
-        const credentialHelperJs = normalizeGitHelperPath(gitTempDir.getCredentialHelperJs());
-        args.unshift('-c', `credential.helper=${credentialHelperJs}`);
+        const credentialHelperSh = normalizeGitHelperPath(gitTempDir.getCredentialHelperSh());
+        args.unshift('-c', `credential.helper=${credentialHelperSh}`);
       }
 
       if (useGpgWrapper && useGitPromptServer && useGpgAtomPrompt) {

--- a/lib/git-temp-dir.js
+++ b/lib/git-temp-dir.js
@@ -1,0 +1,84 @@
+import os from 'os';
+import path from 'path';
+import {getPackageRoot, deleteFileOrFolder, getTempDir, copyFile, chmodFile} from './helpers';
+
+export const BIN_SCRIPTS = {
+  getCredentialHelperJs: 'git-credential-atom.js',
+  getCredentialHelperSh: 'git-credential-atom.sh',
+  getAskPassJs: 'git-askpass-atom.js',
+  getAskPassSh: 'git-askpass-atom.sh',
+  getSshWrapperSh: 'linux-ssh-wrapper.sh',
+  getGpgWrapperSh: 'gpg-wrapper.sh',
+};
+
+export default class GitTempDir {
+  constructor() {
+    this.created = false;
+  }
+
+  async ensure() {
+    if (this.created) {
+      return;
+    }
+
+    this.root = await getTempDir({
+      dir: process.platform === 'win32' ? os.tmpdir() : '/tmp',
+      prefix: 'github-',
+      symlinkOk: true,
+    });
+
+    await Promise.all(
+      Object.values(BIN_SCRIPTS).map(async filename => {
+        await copyFile(
+          path.resolve(getPackageRoot(), 'bin', filename),
+          path.join(this.root, filename),
+        );
+
+        if (path.extname(filename) === '.sh') {
+          await chmodFile(path.join(this.root, filename), 0o700);
+        }
+      }),
+    );
+
+    this.created = true;
+  }
+
+  getRootPath() {
+    return this.root;
+  }
+
+  getScriptPath(filename) {
+    if (!this.created) {
+      throw new Error(`Attempt to access filename ${filename} in uninitialized GitTempDir`);
+    }
+
+    return path.join(this.root, filename);
+  }
+
+  getSocketPath() {
+    if (process.platform === 'win32') {
+      return path.join(
+        '\\\\?\\pipe\\',
+        'gh-' + require('crypto').randomBytes(8).toString('hex'),
+        'helper.sock',
+      );
+    } else {
+      return this.getScriptPath('helper.sock');
+    }
+  }
+
+  dispose() {
+    return deleteFileOrFolder(this.root);
+  }
+}
+
+function createGetter(key) {
+  const filename = BIN_SCRIPTS[key];
+  return function() {
+    return this.getScriptPath(filename);
+  };
+}
+
+for (const key in BIN_SCRIPTS) {
+  GitTempDir.prototype[key] = createGetter(key);
+}

--- a/lib/git-temp-dir.js
+++ b/lib/git-temp-dir.js
@@ -57,11 +57,14 @@ export default class GitTempDir {
 
   getSocketPath() {
     if (process.platform === 'win32') {
-      return path.join(
-        '\\\\?\\pipe\\',
-        'gh-' + require('crypto').randomBytes(8).toString('hex'),
-        'helper.sock',
-      );
+      if (!this.socketPath) {
+        this.socketPath = path.join(
+          '\\\\?\\pipe\\',
+          'gh-' + require('crypto').randomBytes(8).toString('hex'),
+          'helper.sock',
+        );
+      }
+      return this.socketPath;
     } else {
       return this.getScriptPath('helper.sock');
     }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -19,6 +19,17 @@ export function getPackageRoot() {
   }
 }
 
+export function getAtomHelperPath() {
+  if (process.platform === 'darwin') {
+    const beta = atom.appVersion.match(/-beta/);
+    const appName = beta ? 'Atom Beta Helper' : 'Atom Helper';
+    return path.resolve(process.resourcesPath, '..', 'Frameworks',
+     `${appName}.app`, 'Contents', 'MacOS', appName);
+  } else {
+    return process.execPath;
+  }
+}
+
 let DUGITE_PATH;
 export function getDugitePath() {
   if (!DUGITE_PATH) {

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -12,6 +12,7 @@ describe('GitPromptServer', function() {
     ATOM_GITHUB_DUGITE_PATH: require.resolve('dugite'),
     ATOM_GITHUB_ORIGINAL_PATH: process.env.PATH,
     ATOM_GITHUB_WORKDIR_PATH: path.join(__dirname, '..'),
+    ATOM_GITHUB_SPEC_MODE: 'true',
     GIT_TRACE: 'true',
     GIT_TERMINAL_PROMPT: '0',
   };

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -559,7 +559,7 @@ import {fsStat, normalizeGitHelperPath, writeFile, getTempDir} from '../lib/help
       const notCancelled = () => assert.fail('', '', 'Unexpected operation cancel');
 
       operations.forEach(op => {
-        it(`tries a ${op.command} without the gpg.program override first`, async function() {
+        it(`tries a ${op.command} without a GPG prompt first`, async function() {
           const execStub = sinon.stub(git, 'executeGitCommand');
           execStub.returns({
             promise: Promise.resolve({stdout: '', stderr: '', exitCode: 0}),
@@ -569,8 +569,8 @@ import {fsStat, normalizeGitHelperPath, writeFile, getTempDir} from '../lib/help
           await op.action();
 
           const [args, options] = execStub.getCall(0).args;
-          assertNoGitConfigSetting(args, op.command, 'gpg.program', '.*gpg-wrapper\\.sh$');
-          assert.equal(options.env.ATOM_GITHUB_SOCK_PATH !== undefined, op.usesPromptServerAlready);
+          assertGitConfigSetting(args, op.command, 'gpg.program', '.*gpg-wrapper\\.sh$');
+          assert.isUndefined(options.env.ATOM_GITHUB_GPG_PROMPT);
         });
 
         it(`retries and overrides gpg.program when ${op.progressiveTense}`, async function() {
@@ -593,6 +593,7 @@ import {fsStat, normalizeGitHelperPath, writeFile, getTempDir} from '../lib/help
           const [args, options] = execStub.getCall(1).args;
           assertGitConfigSetting(args, op.command, 'gpg.program', '.*gpg-wrapper\\.sh$');
           assert.isDefined(options.env.ATOM_GITHUB_SOCK_PATH);
+          assert.isDefined(options.env.ATOM_GITHUB_GPG_PROMPT);
         });
 
         if (!op.usesPromptServerAlready) {
@@ -617,11 +618,13 @@ import {fsStat, normalizeGitHelperPath, writeFile, getTempDir} from '../lib/help
 
             const [args0, options0] = execStub.getCall(0).args;
             assertGitConfigSetting(args0, op.command, 'gpg.program', '.*gpg-wrapper\\.sh$');
-            assert.equal(options0.env.ATOM_GITHUB_SOCK_PATH === undefined, !op.usesPromptServerAlready);
+            assert.isUndefined(options0.env.ATOM_GITHUB_SOCK_PATH);
+            assert.isUndefined(options0.env.ATOM_GITHUB_GPG_PROMPT);
 
             const [args1, options1] = execStub.getCall(1).args;
             assertGitConfigSetting(args1, op.command, 'gpg.program', '.*gpg-wrapper\\.sh$');
             assert.isDefined(options1.env.ATOM_GITHUB_SOCK_PATH);
+            assert.isDefined(options1.env.ATOM_GITHUB_GPG_PROMPT);
           });
         }
       });

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -1216,17 +1216,3 @@ function assertGitConfigSetting(args, command, settingName, valuePattern = '.*$'
 
   assert.fail('', '', `Setting ${settingName} not found in exec arguments ${args.join(' ')}`);
 }
-
-function assertNoGitConfigSetting(args, command, settingName) {
-  const commandIndex = args.indexOf(command);
-  assert.notEqual(commandIndex, -1, `${command} not found in exec arguments ${args.join(' ')}`);
-
-  const settingNamePattern = settingName.replace(/[.\\()[\]{}+*^$]/, '\\$&');
-  const valueRx = new RegExp(`^${settingNamePattern}=.*$`);
-
-  for (let i = 0; i < commandIndex; i++) {
-    if (args[i] === '-c' && valueRx.test(args[i + 1] || '')) {
-      assert.fail('', '', `Setting ${settingName} was found in exec arguments ${args.join(' ')}`);
-    }
-  }
-}


### PR DESCRIPTION
Without the `--batch --no-tty` arguments, gpg 2.0.x will attempt to perform tty-specific operations on stdin even if the gpg-agent has a passphrase cached. This causes git to assume that signing has failed and triggers an extra prompt through Atom.

To provide the `-c gpg.program` argument to git correctly, we also need the ability to create our auxiliary helper script directory for git operations even when no `GitPromptServer` is running. I've extracted the temporary directory management to a `GitTempDir` object.

Fixes #1127.