### PR TITLE
Fix freezing when dragging pane/dock items

### DIFF
--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -370,8 +370,10 @@ export default class FilePatchController extends React.Component {
     }
   }
 
-  wasActivated() {
-    process.nextTick(() => this.focus());
+  wasActivated(isStillActive) {
+    process.nextTick(() => {
+      isStillActive() && this.focus();
+    });
   }
 
   @autobind

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -355,8 +355,10 @@ export default class GitTabController {
     return this.element.contains(document.activeElement);
   }
 
-  wasActivated() {
-    process.nextTick(() => this.restoreFocus());
+  wasActivated(isStillActive) {
+    process.nextTick(() => {
+      isStillActive() && this.restoreFocus();
+    });
   }
 
   focusAndSelectStagingItem(filePath, stagingStatus) {

--- a/lib/views/dock-item.js
+++ b/lib/views/dock-item.js
@@ -72,7 +72,9 @@ export default class DockItem extends React.Component {
       this.subscriptions.add(
         this.props.workspace.onDidChangeActivePaneItem(activeItem => {
           if (activeItem === this.dockItem) {
-            itemToAdd.wasActivated();
+            itemToAdd.wasActivated(() => {
+              return this.props.workspace.getActivePaneItem() === this.dockItem;
+            });
           }
         }),
       );

--- a/lib/views/pane-item.js
+++ b/lib/views/pane-item.js
@@ -62,7 +62,9 @@ export default class PaneItem extends React.Component {
       this.subscriptions.add(
         this.props.workspace.onDidChangeActivePaneItem(activeItem => {
           if (activeItem === this.paneItem) {
-            itemToAdd.wasActivated();
+            itemToAdd.wasActivated(() => {
+              return this.props.workspace.getActivePaneItem() === this.paneItem;
+            });
           }
         }),
       );


### PR DESCRIPTION
There was some strange emergent behavior where moving a file patch view out of the dock into the center when the Git tab was present in the dock would bounce the focus back and forth between the two items, essentially freezing Atom and causing a crash. This avoids the issue by preventing each component from stealing focus in its `nextTick` callback unless the item is *still* the active item.

Fixes https://github.com/atom/github/issues/1112