### PR TITLE
Throw error when pane is not found for dock item only if it exists and is not destroyed

### DIFF
--- a/lib/views/dock-item.js
+++ b/lib/views/dock-item.js
@@ -126,8 +126,8 @@ export default class DockItem extends React.Component {
         if (dock && dock.show) {
           dock.show();
         }
-      } else {
-        throw new Error('Cannot find pane for item in `DockItem#activate`');
+      } else if (this.dockItem && !this.didCloseItem) {
+        throw new Error('Could not find pane for a non-destroyed DockItem');
       }
     });
   }

--- a/lib/views/dock-item.js
+++ b/lib/views/dock-item.js
@@ -34,14 +34,6 @@ export default class DockItem extends React.Component {
     onDidCloseItem: dockItem => {},
   }
 
-  constructor(props, context) {
-    super(props, context);
-
-    this.dockItemPromise = new Promise(resolve => {
-      this.resolveDockItemPromise = resolve;
-    });
-  }
-
   componentDidMount() {
     this.setupDockItem();
   }
@@ -84,7 +76,6 @@ export default class DockItem extends React.Component {
     if (stub) {
       stub.setRealItem(itemToAdd);
       this.dockItem = stub;
-      this.resolveDockItemPromise(this.dockItem);
       if (this.props.activate) {
         this.activate();
       }
@@ -92,7 +83,6 @@ export default class DockItem extends React.Component {
       Promise.resolve(this.props.workspace.open(itemToAdd, {activatePane: false}))
         .then(item => {
           this.dockItem = item;
-          this.resolveDockItemPromise(this.dockItem);
           if (this.props.activate) { this.activate(); }
         });
     }
@@ -120,10 +110,6 @@ export default class DockItem extends React.Component {
 
   getDockItem() {
     return this.dockItem;
-  }
-
-  getDockItemPromise() {
-    return this.dockItemPromise;
   }
 
   activate() {

--- a/lib/views/pane-item.js
+++ b/lib/views/pane-item.js
@@ -97,17 +97,4 @@ export default class PaneItem extends React.Component {
       this.paneItem.destroy();
     }
   }
-
-  activate() {
-    setTimeout(() => {
-      if (!this.paneItem) { return; }
-
-      const pane = this.props.workspace.paneForItem(this.paneItem);
-      if (pane) {
-        pane.activateItem(this.paneItem);
-      } else {
-        throw new Error('Cannot find pane for item in `PaneItem#activate`');
-      }
-    });
-  }
 }


### PR DESCRIPTION
Fixes #1150

We were unable to reproduce the error mentioned in #1150. After examining the code for `DockItem#activate` it looks like this error is thrown because the dock item was not present in a pane, either because it was not yet set (unlikely as we only call `activate` after we've set it) or because the dock item was closed by the time the asynchronous `setTimeout` callback is run. In either case, we don't need to throw this error, we simply do not activate the item or show the dock. 

We'll close the issue now with a fix that simply checks if the dock item exists and is not destroyed before throwing an error. If this doesn't address the issue then we'll have at least narrowed down the root cause and we can do further, more informed investigation once we get more reports in. 