### PR TITLE
Check for deep equality of selected items after update

### DIFF
--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -143,9 +143,7 @@ export default class StagingView {
       await this.resolutionProgressObserver.setActiveModel(this.props.resolutionProgress);
     }
 
-    const previousSelection = Array.from(previouslySelectedItems).sort();
-    const newSelection = Array.from(this.selection.getSelectedItems()).sort();
-    const selectionChanged = !isEqual(previousSelection, newSelection);
+    const selectionChanged = !isEqual(previouslySelectedItems, this.selection.getSelectedItems());
     if (selectionChanged) {
       this.debouncedDidChangeSelectedItem();
     }

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -9,7 +9,7 @@ import {File} from 'atom';
 import path from 'path';
 import etch from 'etch';
 import {autobind} from 'core-decorators';
-import compareSets from 'compare-sets';
+import isEqual from 'lodash.isequal';
 
 import FilePatchListItemView from './file-patch-list-item-view';
 import MergeConflictListItemView from './merge-conflict-list-item-view';
@@ -143,8 +143,10 @@ export default class StagingView {
       await this.resolutionProgressObserver.setActiveModel(this.props.resolutionProgress);
     }
 
-    const {added, removed} = compareSets(previouslySelectedItems, this.selection.getSelectedItems());
-    if (added.size > 0 || removed.size > 0) {
+    const previousSelection = Array.from(previouslySelectedItems).sort();
+    const newSelection = Array.from(this.selection.getSelectedItems()).sort();
+    const selectionChanged = !isEqual(previousSelection, newSelection);
+    if (selectionChanged) {
       this.debouncedDidChangeSelectedItem();
     }
 


### PR DESCRIPTION
When there is a file system change, the repo emits a change event which results in a an update to `StagingView`. As part of this, the changed file information is fetched from git and updated in the UI. We check to see if the changed files selection has changed, and if it has, we call `didChangeSelectedItems` which opens the diff view associated with the newly selected file.

Previously we were checking for object reference equality to see if the selection had changed, but we need to be checking for deep equality since we're fetching new changed file objects. This was causing funky behavior described in #1163. This PR uses `lodash`'s `isEqual` to check for deep equality before calling `didChangeSelectedItems`.

Fixes #1163