### PR TITLE
Add text clipping for 'Create Repo' button

### DIFF
--- a/styles/git-panel.less
+++ b/styles/git-panel.less
@@ -43,6 +43,11 @@
     .git-logo-path {
       fill: mix(@base-background-color, @text-color, 66%); // 2/3 of bg color
     }
+
+    .btn.btn-primary {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 }
 


### PR DESCRIPTION
### Description of the Change

Hi there! First time contributing to Atom :)

The `Create repository` button on the Github panel when there is no repository open allows for the text inside to leak out when the panel is resized to small dimensions. It could be improved by adding two rules for the button element's style: `overflow: hidden` and `text-overflow: ellipses`. This will replace the overflown text with ellipses when horizontally shrunk and will clip the text when vertically shrunk.

### Alternate Designs

Before: | After: 
--- | ---
![](https://media.giphy.com/media/xT9IgA0uVbjJXKC7fO/giphy.gif) | ![](https://media.giphy.com/media/3o7aCS5QIUIj8NkWkg/giphy.gif)
![](https://media.giphy.com/media/l1J9vSeeOsmULPTlS/giphy.gif) | ![](https://media.giphy.com/media/3ov9jYxs5pTwZY1tVC/giphy.gif)

### Benefits

No more text leaking from the button :)

### Possible Drawbacks

There should not be any other side-effects; the rule is specific to this one element.

Thank you, Atom team, for all your hard work!