### PR TITLE
Respect `editor.tabLength` setting in diff view

### DIFF
--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -141,7 +141,7 @@ export default class GithubPackage {
       this.workspace.getCenter().onDidChangeActivePaneItem(this.scheduleActiveContextUpdate),
       this.styleCalculator.startWatching(
         'github-package-styles',
-        ['editor.fontSize', 'editor.fontFamily', 'editor.lineHeight'],
+        ['editor.fontSize', 'editor.fontFamily', 'editor.lineHeight', 'editor.tabLength'],
         config => `
           .github-FilePatchView {
             font-size: 1.1em;
@@ -151,6 +151,7 @@ export default class GithubPackage {
             font-size: ${config.get('editor.fontSize')}px;
             font-family: ${config.get('editor.fontFamily')};
             line-height: ${config.get('editor.lineHeight')};
+            tab-size: ${config.get('editor.tabLength')}
           }
         `,
       ),

--- a/lib/views/hunk-view.js
+++ b/lib/views/hunk-view.js
@@ -137,7 +137,7 @@ class LineView extends React.Component {
           <div className="github-HunkView-lineNumber is-new">{newLineNumber}</div>
           <div className="github-HunkView-lineContent">
             <span className="github-HunkView-plusMinus">{line.getOrigin()}</span>
-            <span>{line.getText()}</span>
+            <span className="github-HunkView-lineText">{line.getText()}</span>
           </div>
         </div>
       </ContextMenuInterceptor>

--- a/styles/hunk-view.less
+++ b/styles/hunk-view.less
@@ -69,6 +69,7 @@
   &-plusMinus {
     margin-right: 1ch;
     color: fade(@text-color, 50%);
+    vertical-align: top;
   }
 
   &-lineContent {
@@ -78,7 +79,13 @@
     white-space: pre-wrap;
     word-break: break-word;
     width: 100%;
+    vertical-align: top;
   }
+
+  &-lineText {
+     display: inline-block;
+     text-indent: 0;
+ }
 }
 
 


### PR DESCRIPTION
This PR uses the `tab-size` CSS property to update the diff view tab length based on the editor settings. Previously this value would simply default to 8 spaces. 

Fixes #939 