### PR TITLE
Move undo discard button

### DIFF
--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -515,8 +515,6 @@ export default class StagingView {
             <span className="github-StagingView-title">Unstaged Changes</span>
             {this.props.unstagedChanges.length ? this.renderStageAllButton() : null}
           </header>
-          {this.props.hasUndoHistory ? this.renderUndoButton() : null}
-
           <div ref="unstagedChanges" className="github-StagingView-list github-FilePatchListView">
             {
               this.truncatedLists.unstagedChanges.map(filePatch => (
@@ -534,6 +532,7 @@ export default class StagingView {
             }
           </div>
           {this.renderTruncatedMessage(this.props.unstagedChanges)}
+          {this.props.hasUndoHistory ? this.renderUndoButton() : null}
         </div>
         { this.renderMergeConflicts() }
         <div className={`github-StagingView-group github-StagedChanges ${this.getFocusClass('staged')}`} >
@@ -648,7 +647,7 @@ export default class StagingView {
 
   renderUndoButton() {
     return (
-      <button className="github-StagingView-headerButton github-StagingView-headerButton--fullWidth icon icon-history"
+      <button className="github-StagingView-headerButton github-StagingView-headerButton--fullWidth btn icon icon-history"
         onclick={this.undoLastDiscard}>Undo Discard</button>
     );
   }

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -646,8 +646,9 @@ export default class StagingView {
   }
 
   renderUndoButton() {
+    const classes = 'github-StagingView-headerButton github-StagingView-headerButton--fullWidth btn icon icon-history';
     return (
-      <button className="github-StagingView-headerButton github-StagingView-headerButton--fullWidth btn icon icon-history"
+      <button className={classes}
         onclick={this.undoLastDiscard}>Undo Discard</button>
     );
   }

--- a/styles/staging-view.less
+++ b/styles/staging-view.less
@@ -59,7 +59,11 @@
 
     &--fullWidth {
       border-left: none;
-      border-bottom: 1px solid @panel-heading-border-color;
+      background: none !important;
+      border: 1px solid @panel-heading-border-color;
+      border-radius: @component-border-radius;
+      margin: @component-padding;
+      cursor: pointer;
     }
   }
 


### PR DESCRIPTION
Fixes #605 

![undo-discard-button](https://user-images.githubusercontent.com/7910250/32357259-66ae35be-bff8-11e7-9358-51d1b01624e6.gif)

For now I'm simply going to move the button down. Still open for consideration is removing the button from the UI under certain circumstances, but then the question is when do we remove it? After a certain amount of time? If so, how long? After committing? @BinaryMuse has noted that sometimes she uses this feature for quick stashing (discarding changes, making a commit, then restoring the changes). 

As a first step we'll move the button so it's harder to accidentally push it since it's clear that this is causing some pain. If there's still lingering discontentment we can discuss when it is reasonable to remove the button. 