### PR TITLE
Make "Stage/Unstage All" buttons actually stage/unstage everything

### DIFF
--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -65,6 +65,7 @@ export default class GitTabController {
         openFiles={this.props.openFiles}
         discardWorkDirChangesForPaths={this.props.discardWorkDirChangesForPaths}
         attemptFileStageOperation={this.attemptFileStageOperation}
+        attemptStageAllOperation={this.attemptStageAllOperation}
         prepareToCommit={this.prepareToCommit}
         commit={this.commit}
         setAmending={this.setAmending}
@@ -209,6 +210,11 @@ export default class GitTabController {
 
   unstageFilePatch(filePatch) {
     return this.getActiveRepository().applyPatchToIndex(filePatch.getUnstagePatch());
+  }
+
+  @autobind
+  attemptStageAllOperation(stageStatus) {
+    return this.attemptFileStageOperation(['.'], stageStatus);
   }
 
   @autobind

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -105,6 +105,7 @@ export default class GitTabView {
             openFiles={this.props.openFiles}
             discardWorkDirChangesForPaths={this.props.discardWorkDirChangesForPaths}
             attemptFileStageOperation={this.props.attemptFileStageOperation}
+            attemptStageAllOperation={this.props.attemptStageAllOperation}
             undoLastDiscard={this.props.undoLastDiscard}
             abortMerge={this.props.abortMerge}
             resolveAsOurs={this.props.resolveAsOurs}

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -211,15 +211,13 @@ export default class StagingView {
   @autobind
   stageAll() {
     if (this.props.unstagedChanges.length === 0) { return null; }
-    const filePaths = this.props.unstagedChanges.map(filePatch => filePatch.filePath);
-    return this.props.attemptFileStageOperation(filePaths, 'unstaged');
+    return this.props.attemptFileStageOperation(['.'], 'unstaged');
   }
 
   @autobind
   unstageAll() {
     if (this.props.stagedChanges.length === 0) { return null; }
-    const filePaths = this.props.stagedChanges.map(filePatch => filePatch.filePath);
-    return this.props.attemptFileStageOperation(filePaths, 'staged');
+    return this.props.attemptFileStageOperation(['.'], 'staged');
   }
 
   @autobind

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -211,13 +211,13 @@ export default class StagingView {
   @autobind
   stageAll() {
     if (this.props.unstagedChanges.length === 0) { return null; }
-    return this.props.attemptFileStageOperation(['.'], 'unstaged');
+    return this.props.attemptStageAllOperation('unstaged');
   }
 
   @autobind
   unstageAll() {
     if (this.props.stagedChanges.length === 0) { return null; }
-    return this.props.attemptFileStageOperation(['.'], 'staged');
+    return this.props.attemptStageAllOperation('staged');
   }
 
   @autobind

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -150,7 +150,7 @@ describe('GitTabController', function() {
   });
 
   describe('abortMerge()', function() {
-    it('shows an error notification when abortMerge() throws an EDIRTYSTAGED exception', async function() {
+    it.only('shows an error notification when abortMerge() throws an EDIRTYSTAGED exception', async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
       sinon.stub(repository, 'abortMerge').callsFake(async () => {
@@ -163,7 +163,7 @@ describe('GitTabController', function() {
         workspace, commandRegistry, notificationManager, confirm, repository,
         resolutionProgress, refreshResolutionProgress,
       });
-      assert.equal(notificationManager.getNotifications().length, 0);
+      notificationManager.clear(); // clear out any notifications
       confirm.returns(0);
       await controller.abortMerge();
       assert.equal(notificationManager.getNotifications().length, 1);
@@ -227,7 +227,7 @@ describe('GitTabController', function() {
   });
 
   describe('commit(message)', function() {
-    it('shows an error notification when committing throws an ECONFLICT exception', async function() {
+    it.only('shows an error notification when committing throws an ECONFLICT exception', async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
       sinon.stub(repository, 'commit').callsFake(async () => {
@@ -239,7 +239,7 @@ describe('GitTabController', function() {
         workspace, commandRegistry, notificationManager, repository,
         resolutionProgress, refreshResolutionProgress,
       });
-      assert.equal(notificationManager.getNotifications().length, 0);
+      notificationManager.clear(); // clear out any notifications
       await controller.commit();
       assert.equal(notificationManager.getNotifications().length, 1);
     });

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -150,7 +150,7 @@ describe('GitTabController', function() {
   });
 
   describe('abortMerge()', function() {
-    it.only('shows an error notification when abortMerge() throws an EDIRTYSTAGED exception', async function() {
+    it('shows an error notification when abortMerge() throws an EDIRTYSTAGED exception', async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
       sinon.stub(repository, 'abortMerge').callsFake(async () => {
@@ -227,7 +227,7 @@ describe('GitTabController', function() {
   });
 
   describe('commit(message)', function() {
-    it.only('shows an error notification when committing throws an ECONFLICT exception', async function() {
+    it('shows an error notification when committing throws an ECONFLICT exception', async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
       sinon.stub(repository, 'commit').callsFake(async () => {

--- a/test/views/staging-view.test.js
+++ b/test/views/staging-view.test.js
@@ -310,7 +310,7 @@ describe('StagingView', function() {
     });
 
     describe('when the file doesn\'t exist', function() {
-      it.only('shows an info notification and does not open the file', async function() {
+      it('shows an info notification and does not open the file', async function() {
         sinon.spy(notificationManager, 'addInfo');
 
         const view = new StagingView({

--- a/test/views/staging-view.test.js
+++ b/test/views/staging-view.test.js
@@ -310,7 +310,7 @@ describe('StagingView', function() {
     });
 
     describe('when the file doesn\'t exist', function() {
-      it('shows an info notification and does not open the file', async function() {
+      it.only('shows an info notification and does not open the file', async function() {
         sinon.spy(notificationManager, 'addInfo');
 
         const view = new StagingView({
@@ -320,9 +320,10 @@ describe('StagingView', function() {
 
         sinon.stub(view, 'fileExists').returns(false);
 
-        assert.equal(notificationManager.getNotifications().length, 0);
+        notificationManager.clear(); // clear out notifications
         await view.showMergeConflictFileForPath('conflict.txt');
 
+        assert.equal(notificationManager.getNotifications().length, 1);
         assert.equal(workspace.open.callCount, 0);
         assert.equal(notificationManager.addInfo.callCount, 1);
         assert.deepEqual(notificationManager.addInfo.args[0], ['File has been deleted.']);


### PR DESCRIPTION
This works even if the list of files is too large to execute on one command line invocation or if some files are not shown in the list because it's truncated.

Fixes #960 

/cc @kuychaco 