### PR TITLE
Disable all relevant color options when executing Git commands

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -41,6 +41,13 @@ export class LargeRepoError extends Error {
   }
 }
 
+const DISABLE_COLOR_FLAGS = [
+  'branch', 'diff', 'showBranch', 'status', 'ui',
+].reduce((acc, type) => {
+  acc.unshift('-c', `color.${type}=false`);
+  return acc;
+}, []);
+
 export default class GitShellOutStrategy {
   static defaultExecArgs = {
     stdin: null,
@@ -79,6 +86,8 @@ export default class GitShellOutStrategy {
 
   // Execute a command and read the output using the embedded Git environment
   async exec(args, options = GitShellOutStrategy.defaultExecArgs) {
+    args.unshift(...DISABLE_COLOR_FLAGS);
+
     /* eslint-disable no-console */
     const {stdin, useGitPromptServer, useGpgWrapper, useGpgAtomPrompt, writeOperation} = options;
     const subscriptions = new CompositeDisposable();

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -150,7 +150,7 @@ describe('GitTabController', function() {
   });
 
   describe('abortMerge()', function() {
-    it('shows an error notification when abortMerge() throws an EDIRTYSTAGED exception', async function() {
+    it.only('shows an error notification when abortMerge() throws an EDIRTYSTAGED exception', async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
       sinon.stub(repository, 'abortMerge').callsFake(async () => {
@@ -163,7 +163,7 @@ describe('GitTabController', function() {
         workspace, commandRegistry, notificationManager, confirm, repository,
         resolutionProgress, refreshResolutionProgress,
       });
-      assert.equal(notificationManager.getNotifications().length, 0);
+      notificationManager.clear(); // clear out any notifications
       confirm.returns(0);
       await controller.abortMerge();
       assert.equal(notificationManager.getNotifications().length, 1);
@@ -227,7 +227,7 @@ describe('GitTabController', function() {
   });
 
   describe('commit(message)', function() {
-    it('shows an error notification when committing throws an ECONFLICT exception', async function() {
+    it.only('shows an error notification when committing throws an ECONFLICT exception', async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
       sinon.stub(repository, 'commit').callsFake(async () => {
@@ -239,7 +239,7 @@ describe('GitTabController', function() {
         workspace, commandRegistry, notificationManager, repository,
         resolutionProgress, refreshResolutionProgress,
       });
-      assert.equal(notificationManager.getNotifications().length, 0);
+      notificationManager.clear(); // clear out any notifications
       await controller.commit();
       assert.equal(notificationManager.getNotifications().length, 1);
     });

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -150,7 +150,7 @@ describe('GitTabController', function() {
   });
 
   describe('abortMerge()', function() {
-    it.only('shows an error notification when abortMerge() throws an EDIRTYSTAGED exception', async function() {
+    it('shows an error notification when abortMerge() throws an EDIRTYSTAGED exception', async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
       sinon.stub(repository, 'abortMerge').callsFake(async () => {
@@ -227,7 +227,7 @@ describe('GitTabController', function() {
   });
 
   describe('commit(message)', function() {
-    it.only('shows an error notification when committing throws an ECONFLICT exception', async function() {
+    it('shows an error notification when committing throws an ECONFLICT exception', async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
       sinon.stub(repository, 'commit').callsFake(async () => {

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -830,7 +830,7 @@ describe('Repository', function() {
             await repo.abortMerge();
             assert.fail(null, null, 'repo.abortMerge() unexepctedly succeeded');
           } catch (e) {
-            assert.match(e.command, /^git merge --abort/);
+            assert.match(e.command, /^git .* merge --abort/);
           }
           assert.equal(await repo.isMerging(), true);
           assert.deepEqual(await repo.getStagedChanges(), stagedChanges);

--- a/test/views/staging-view.test.js
+++ b/test/views/staging-view.test.js
@@ -310,7 +310,7 @@ describe('StagingView', function() {
     });
 
     describe('when the file doesn\'t exist', function() {
-      it.only('shows an info notification and does not open the file', async function() {
+      it('shows an info notification and does not open the file', async function() {
         sinon.spy(notificationManager, 'addInfo');
 
         const view = new StagingView({

--- a/test/views/staging-view.test.js
+++ b/test/views/staging-view.test.js
@@ -310,7 +310,7 @@ describe('StagingView', function() {
     });
 
     describe('when the file doesn\'t exist', function() {
-      it('shows an info notification and does not open the file', async function() {
+      it.only('shows an info notification and does not open the file', async function() {
         sinon.spy(notificationManager, 'addInfo');
 
         const view = new StagingView({
@@ -320,9 +320,10 @@ describe('StagingView', function() {
 
         sinon.stub(view, 'fileExists').returns(false);
 
-        assert.equal(notificationManager.getNotifications().length, 0);
+        notificationManager.clear(); // clear out notifications
         await view.showMergeConflictFileForPath('conflict.txt');
 
+        assert.equal(notificationManager.getNotifications().length, 1);
         assert.equal(workspace.open.callCount, 0);
         assert.equal(notificationManager.addInfo.callCount, 1);
         assert.deepEqual(notificationManager.addInfo.args[0], ['File has been deleted.']);


### PR DESCRIPTION
In lieu of an environment variable or some other global `--no-color` option, this PR adds command line arguments to every Git command that sets all relevant color options to `false` (which is equivalent to `never` for options that take it).

Fixes #977 