### PR TITLE
Stop propagation of handled focus events in tab view

### DIFF
--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -197,22 +197,29 @@ export default class GitTabView {
   }
 
   @autobind
-  advanceFocus() {
+  advanceFocus(evt) {
     if (!this.refs.stagingView.activateNextList()) {
-      this.refs.commitViewController.setFocus(GitTabView.focus.EDITOR);
+      if (this.refs.commitViewController.setFocus(GitTabView.focus.EDITOR)) {
+        evt.stopPropagation();
+      }
+    } else {
+      evt.stopPropagation();
     }
   }
 
   @autobind
-  retreatFocus() {
+  retreatFocus(evt) {
     const {stagingView, commitViewController} = this.refs;
 
     if (commitViewController.hasFocus()) {
       if (stagingView.activateLastList()) {
         this.setFocus(GitTabView.focus.STAGING);
+        evt.stopPropagation();
       }
     } else {
-      stagingView.activatePreviousList();
+      if (stagingView.activatePreviousList()) {
+        evt.stopPropagation();
+      }
     }
   }
 


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Fixes #1245 by stopping the propagation of tab/focus events that are reported as handled by the git tab view's children. Just a note: I believe the problem is exacerbated by *debouncing* the keyboard events in the staging view. If I disabled that, it would sometimes focus correctly. But this patch fixes both cases for me.

### Alternate Designs

I tried messing with keymaps and selector specificity but couldn't get it to work.

### Benefits

Fixes #1245

### Possible Drawbacks

I don't *really* understand how global focus events work in atom, this could be the wrong approach. (But it seems to jive with documentation)

### Applicable Issues

#1245