### PR TITLE
Update test for async confirm

### DIFF
--- a/lib/controllers/issueish-pane-item-controller.js
+++ b/lib/controllers/issueish-pane-item-controller.js
@@ -82,8 +82,8 @@ export default class IssueishPaneItemController extends React.Component {
                   <div className="github-GithubLoginView-Container">
                     <GithubLoginView onLogin={this.handleLogin}>
                       <p>
-                      The API endpoint returned a unauthorized error. Please try to re-authenticate with the endpoint.
-                    </p>
+                        The API endpoint returned a unauthorized error. Please try to re-authenticate with the endpoint.
+                      </p>
                     </GithubLoginView>
                   </div>
                 );
@@ -118,8 +118,8 @@ export default class IssueishPaneItemController extends React.Component {
         <div className="github-Message-wrapper">
           <h1 className="github-Message-title">Error</h1>
           <p className="github-Message-description">
-              An unknown error occurred
-            </p>
+            An unknown error occurred
+          </p>
           <div className="github-Message-action">
             <button className="github-Message-button btn btn-primary" onClick={retry}>Try Again</button>
             <button className="github-Message-button btn" onClick={this.handleLogout}>Logout</button>

--- a/test/controllers/commit-view-controller.test.js
+++ b/test/controllers/commit-view-controller.test.js
@@ -232,7 +232,7 @@ describe('CommitViewController', function() {
 
         // atom internals calls `confirm` on the ApplicationDelegate instead of the atom environment
         sinon.stub(atomEnvironment.applicationDelegate, 'confirm').callsFake((options, callback) => {
-          if (callback typeof 'function') {
+          if (typeof callback === 'function') {
             callback(0); // Save
           }
           return 0; // TODO: Remove this return and typeof check once https://github.com/atom/atom/pull/16229 is on stable

--- a/test/controllers/commit-view-controller.test.js
+++ b/test/controllers/commit-view-controller.test.js
@@ -231,7 +231,12 @@ describe('CommitViewController', function() {
         editor.setText('make some new changes');
 
         // atom internals calls `confirm` on the ApplicationDelegate instead of the atom environment
-        sinon.stub(atomEnvironment.applicationDelegate, 'confirm').returns(0); // Save
+        sinon.stub(atomEnvironment.applicationDelegate, 'confirm').callsFake((options, callback) => {
+          if (callback typeof 'function') {
+            callback(0); // Save
+          }
+          return 0; // TODO: Remove this return and typeof check once https://github.com/atom/atom/pull/16229 is on stable
+        });
         commandRegistry.dispatch(atomEnvironment.views.getView(workspace), 'github:toggle-expanded-commit-message-editor');
         await assert.async.equal(controller.getCommitMessageEditors().length, 0);
         assert.isTrue(atomEnvironment.applicationDelegate.confirm.called);

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -150,7 +150,7 @@ describe('GitTabController', function() {
   });
 
   describe('abortMerge()', function() {
-    it('shows an error notification when abortMerge() throws an EDIRTYSTAGED exception', async function() {
+    it.only('shows an error notification when abortMerge() throws an EDIRTYSTAGED exception', async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
       sinon.stub(repository, 'abortMerge').callsFake(async () => {
@@ -163,7 +163,7 @@ describe('GitTabController', function() {
         workspace, commandRegistry, notificationManager, confirm, repository,
         resolutionProgress, refreshResolutionProgress,
       });
-      assert.equal(notificationManager.getNotifications().length, 0);
+      notificationManager.clear(); // clear out any notifications
       confirm.returns(0);
       await controller.abortMerge();
       assert.equal(notificationManager.getNotifications().length, 1);
@@ -227,7 +227,7 @@ describe('GitTabController', function() {
   });
 
   describe('commit(message)', function() {
-    it('shows an error notification when committing throws an ECONFLICT exception', async function() {
+    it.only('shows an error notification when committing throws an ECONFLICT exception', async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
       sinon.stub(repository, 'commit').callsFake(async () => {
@@ -239,7 +239,7 @@ describe('GitTabController', function() {
         workspace, commandRegistry, notificationManager, repository,
         resolutionProgress, refreshResolutionProgress,
       });
-      assert.equal(notificationManager.getNotifications().length, 0);
+      notificationManager.clear(); // clear out any notifications
       await controller.commit();
       assert.equal(notificationManager.getNotifications().length, 1);
     });

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -150,7 +150,7 @@ describe('GitTabController', function() {
   });
 
   describe('abortMerge()', function() {
-    it.only('shows an error notification when abortMerge() throws an EDIRTYSTAGED exception', async function() {
+    it('shows an error notification when abortMerge() throws an EDIRTYSTAGED exception', async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
       sinon.stub(repository, 'abortMerge').callsFake(async () => {
@@ -227,7 +227,7 @@ describe('GitTabController', function() {
   });
 
   describe('commit(message)', function() {
-    it.only('shows an error notification when committing throws an ECONFLICT exception', async function() {
+    it('shows an error notification when committing throws an ECONFLICT exception', async function() {
       const workdirPath = await cloneRepository('three-files');
       const repository = await buildRepository(workdirPath);
       sinon.stub(repository, 'commit').callsFake(async () => {

--- a/test/views/staging-view.test.js
+++ b/test/views/staging-view.test.js
@@ -310,7 +310,7 @@ describe('StagingView', function() {
     });
 
     describe('when the file doesn\'t exist', function() {
-      it.only('shows an info notification and does not open the file', async function() {
+      it('shows an info notification and does not open the file', async function() {
         sinon.spy(notificationManager, 'addInfo');
 
         const view = new StagingView({

--- a/test/views/staging-view.test.js
+++ b/test/views/staging-view.test.js
@@ -310,7 +310,7 @@ describe('StagingView', function() {
     });
 
     describe('when the file doesn\'t exist', function() {
-      it('shows an info notification and does not open the file', async function() {
+      it.only('shows an info notification and does not open the file', async function() {
         sinon.spy(notificationManager, 'addInfo');
 
         const view = new StagingView({
@@ -320,9 +320,10 @@ describe('StagingView', function() {
 
         sinon.stub(view, 'fileExists').returns(false);
 
-        assert.equal(notificationManager.getNotifications().length, 0);
+        notificationManager.clear(); // clear out notifications
         await view.showMergeConflictFileForPath('conflict.txt');
 
+        assert.equal(notificationManager.getNotifications().length, 1);
         assert.equal(workspace.open.callCount, 0);
         assert.equal(notificationManager.addInfo.callCount, 1);
         assert.deepEqual(notificationManager.addInfo.args[0], ['File has been deleted.']);


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Needed for atom/atom#16229, in which the unsaved changes dialog has been changed to be async.

### Alternate Designs

None.

### Benefits

Keep specs passing.

### Possible Drawbacks

None.

### Applicable Issues

atom/atom#16229