### PR TITLE
Require confirmation on undo discard  - Fix #1260

### DIFF
--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -93,6 +93,7 @@ export default class GitTabView {
         <div className={cx('github-Panel', {'is-loading': isLoading})} tabIndex="-1">
           <StagingView
             ref="stagingView"
+            confirm={this.props.confirm}
             commandRegistry={this.props.commandRegistry}
             notificationManager={this.props.notificationManager}
             workspace={this.props.workspace}

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -667,7 +667,7 @@ export default class StagingView {
   undoLastDiscardWithConfirmation() {
     const choice = this.props.confirm({
       message: 'Undo Discard',
-      detailedMessage: 'Are you sure you want to undo last discarded changes?',
+      detailedMessage: 'Are you sure you want to undo the last discarded changes?',
       buttons: ['Undo Discard', 'Cancel'],
     });
     if (choice === 0) {

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -647,7 +647,7 @@ export default class StagingView {
   renderUndoButton() {
     return (
       <button className="github-StagingView-headerButton github-StagingView-headerButton--fullWidth icon icon-history"
-        onclick={this.undoLastDiscard}>Undo Discard</button>
+        onclick={this.undoLastDiscardWithConfirmation}>Undo Discard</button>
     );
   }
 
@@ -660,6 +660,18 @@ export default class StagingView {
       );
     } else {
       return null;
+    }
+  }
+
+  @autobind
+  undoLastDiscardWithConfirmation() {
+    const choice = this.props.confirm({
+      message: 'Undo Discard',
+      detailedMessage: 'Are you sure you want to undo last discarded changes?',
+      buttons: ['Undo Discard', 'Cancel'],
+    });
+    if (choice === 0) {
+      this.undoLastDiscard();
     }
   }
 


### PR DESCRIPTION
Description from #1260:

> The package should confirm the user if they really want to undo discarded changes. There's no spacing between that button and the first diff item so I accidentally press it often and have to manually search through the diff to see what it restored and undo that

Interested in ideas about the confirmation messages