### PR TITLE
Fix #1067: Bypass external diff tools

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -461,7 +461,7 @@ export default class GitShellOutStrategy {
   }
 
   async getDiffForFilePath(filePath, {staged, baseCommit} = {}) {
-    let args = ['diff', '--no-prefix', '--no-renames', '--diff-filter=u'];
+    let args = ['diff', '--no-prefix', '--no-ext-diff', '--no-renames', '--diff-filter=u'];
     if (staged) { args.push('--staged'); }
     if (baseCommit) { args.push(baseCommit); }
     args = args.concat(['--', toGitPathSep(filePath)]);

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -203,6 +203,18 @@ import {fsStat, normalizeGitHelperPath, writeFile, getTempDir} from '../lib/help
         assert.isUndefined(diffOutput);
       });
 
+      it('bypasses external diff tools', async function() {
+        const workingDirPath = await cloneRepository('three-files');
+        const git = createTestStrategy(workingDirPath);
+
+        fs.writeFileSync(path.join(workingDirPath, 'a.txt'), 'qux\nfoo\nbar\n', 'utf8');
+        process.env.GIT_EXTERNAL_DIFF = 'bogus_app_name';
+        const diffOutput = await git.getDiffForFilePath('a.txt');
+        delete process.env.GIT_EXTERNAL_DIFF;
+
+        assert.isDefined(diffOutput);
+      });
+
       describe('when the file is unstaged', function() {
         it('returns a diff comparing the working directory copy of the file and the version on the index', async function() {
           const workingDirPath = await cloneRepository('three-files');


### PR DESCRIPTION
This change fixes issue #1067 which states that a user-configured external diff tool will cause the "View [Un]Staged Changes" commands to return empty diff views because `git diff` launches an external viewer.  The fix is to add the `--no-ext-diff` parameter to the `git diff` call in `getDiffForFilePath` as this bypasses any user-configured external diff tool.

I double-checked the `diffFileStatus` path since that's another call to `git diff`, it does not seem to be affected by user configuration.

Since this is my first PR to this repo, please let me know if I'm not following the guidelines correctly!  :smile: 
 
Fixes #1067 