### PR TITLE
Scroll to selected diff line only if head of selection changes

### DIFF
--- a/lib/views/hunk-view.js
+++ b/lib/views/hunk-view.js
@@ -94,18 +94,17 @@ export default class HunkView extends React.Component {
     this.lineElements.set(line, element);
   }
 
-  componentDidUpdate() {
-    const selectedLine = Array.from(this.props.selectedLines)[0];
-    if (selectedLine && this.lineElements.get(selectedLine)) {
-      // QUESTION: why is this setTimeout needed?
-      const element = this.lineElements.get(selectedLine);
-      setTimeout(() => {
-        element.scrollIntoViewIfNeeded();
-      }, 0);
-    } else if (this.props.headHunk === this.props.hunk) {
-      this.element.scrollIntoViewIfNeeded();
-    } else if (this.props.headLine && this.lineElements.has(this.props.headLine)) {
-      this.lineElements.get(this.props.headLine).scrollIntoViewIfNeeded();
+  componentDidUpdate(prevProps) {
+    if (prevProps.headLine !== this.props.headLine) {
+      if (this.props.headLine && this.lineElements.has(this.props.headLine)) {
+        this.lineElements.get(this.props.headLine).scrollIntoViewIfNeeded();
+      }
+    }
+
+    if (prevProps.headHunk !== this.props.headHunk) {
+      if (this.props.headHunk === this.props.hunk) {
+        this.element.scrollIntoViewIfNeeded();
+      }
     }
   }
 }


### PR DESCRIPTION
Previously, `componentDidUpdate` was being called when anonymous
function props were updated, triggering scrolling at undesired times.
Instead, now we specifically check to see if the relevant props have
changed before scrolling.

Fixes #1226 
Fixes #884