### PR TITLE
Fix incorrect file paths in transpiled files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "@binarymuse/relay-compiler": "^1.2.0",
-    "atom-babel6-transpiler": "1.1.1",
+    "atom-babel6-transpiler": "1.1.3",
     "babel-generator": "^6.25.0",
     "babel-plugin-chai-assert-async": "^0.1.0",
     "babel-plugin-relay": "^1.2.0-rc.1",


### PR DESCRIPTION
This PR updates `atom-babel6-transpiler` to 1.1.3, which fixes an issue with relative filenames during transpilation. As a result, clicking links in the `atom-mocha-test-runner` output will now lead to the correct file.

<img width="1534" alt="etch-wrapper_test_js_ ___github_github_and_github_package_tests_-_pid_16952_and_1__mtilley_c02r312bg8wm____github_github__zsh_" src="https://user-images.githubusercontent.com/189606/35006082-71d56e84-faaa-11e7-9be0-67a07ff9eb8c.png">
