### PR TITLE
Stop propagation of handled focus events in tab view

### DIFF
--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -217,9 +217,8 @@ export default class GitTabView {
         evt.stopPropagation();
       }
     } else {
-      if (stagingView.activatePreviousList()) {
-        evt.stopPropagation();
-      }
+      stagingView.activatePreviousList();
+      evt.stopPropagation();
     }
   }
 


### PR DESCRIPTION
Fixes #1245.

Prior to this PR, `core:focus-next` and `core:focus-previous` while in the Git panel would focus the Diagnostics panel, causing it to open if it was closed. This PR stops event propagation once they are handled by the Git panel and ensures that focus remains within the Git panel.

Supersedes #1255. Thanks @xdissent for doing all of the heavy-lifting :)