### PR TITLE
Add priority to stylesheet

### DIFF
--- a/lib/models/style-calculator.js
+++ b/lib/models/style-calculator.js
@@ -25,6 +25,6 @@ export default class StyleCalculator {
   @autobind
   updateStyles(sourcePath, getStylesheetFn) {
     const stylesheet = getStylesheetFn(this.config);
-    this.styles.addStyleSheet(stylesheet, {sourcePath});
+    this.styles.addStyleSheet(stylesheet, {sourcePath, priority: 0});
   }
 }

--- a/test/models/style-calculator.test.js
+++ b/test/models/style-calculator.test.js
@@ -44,19 +44,19 @@ describe('StyleCalculator', function(done) {
     assert.deepEqual(Object.keys(configChangeCallbacks), ['config1', 'config2']);
     assert.equal(stylesMock.addStyleSheet.callCount, 1);
     assert.deepEqual(stylesMock.addStyleSheet.getCall(0).args, [
-      expectedCss, {sourcePath: 'my-source-path'},
+      expectedCss, {sourcePath: 'my-source-path', priority: 0},
     ]);
 
     configChangeCallbacks.config1();
     assert.equal(stylesMock.addStyleSheet.callCount, 2);
     assert.deepEqual(stylesMock.addStyleSheet.getCall(1).args, [
-      expectedCss, {sourcePath: 'my-source-path'},
+      expectedCss, {sourcePath: 'my-source-path', priority: 0},
     ]);
 
     configChangeCallbacks.config2();
     assert.equal(stylesMock.addStyleSheet.callCount, 3);
     assert.deepEqual(stylesMock.addStyleSheet.getCall(2).args, [
-      expectedCss, {sourcePath: 'my-source-path'},
+      expectedCss, {sourcePath: 'my-source-path', priority: 0},
     ]);
   });
 });


### PR DESCRIPTION
### Description of the Change

This adds a `priority="0"` attribute to `github-package-styles` styles. So that themes and user’s styles.less come after.

![screen shot 2018-01-19 at 4 58 54 pm](https://user-images.githubusercontent.com/378023/35140649-6041c7f6-fd3b-11e7-96d3-e07065d61c5d.png)

### Benefits

Themes and users can override the styles easier. Without `!important` or so.

### Possible Drawbacks

None

### Applicable Issues

Closes #1292
