### PR TITLE
Trick electron-link

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -334,7 +334,10 @@ export default class RootController extends React.Component {
 
   @autobind
   installReactDevTools() {
-    const devTools = require('electron-devtools-installer');
+    // Prevent electron-link from attempting to descend into electron-devtools-installer, which is not available
+    // when we're bundled in Atom.
+    const devToolsName = 'electron-devtools-installer';
+    const devTools = require(devToolsName);
     devTools.default(devTools.REACT_DEVELOPER_TOOLS);
   }
 


### PR DESCRIPTION
Fool electron-link into skipping the `require()` for electron-devtools-installer, which is installed as a dev dependency and unavailable when we're bundled.

`installReactDevTools()` is only called in dev mode, so this should be fine. If we do care about being able to install devtools while we're bundled we'd have to move electron-devtools-installer to be a non-dev dependency.