### PR TITLE
Configuration option to disable merge conflict resolution

### DIFF
--- a/lib/controllers/repository-conflict-controller.js
+++ b/lib/controllers/repository-conflict-controller.js
@@ -25,6 +25,7 @@ export default class RepositoryConflictController extends React.Component {
   static propTypes = {
     workspace: PropTypes.object.isRequired,
     commandRegistry: PropTypes.object.isRequired,
+    config: PropTypes.object.isRequired,
     resolutionProgress: PropTypes.object.isRequired,
     repository: PropTypes.object.isRequired,
     mergeConflictPaths: PropTypes.arrayOf(PropTypes.string),
@@ -81,7 +82,8 @@ export default class RepositoryConflictController extends React.Component {
   getConflictingEditors() {
     if (
       this.props.mergeConflictPaths.length === 0 ||
-      this.state.openEditors.length === 0
+      this.state.openEditors.length === 0 ||
+      !this.props.config.get('github.graphicalConflictResolution')
     ) {
       return [];
     }

--- a/lib/controllers/repository-conflict-controller.js
+++ b/lib/controllers/repository-conflict-controller.js
@@ -57,6 +57,7 @@ export default class RepositoryConflictController extends React.Component {
     this.subscriptions.add(
       this.props.workspace.observeTextEditors(updateState),
       this.props.workspace.onDidDestroyPaneItem(updateState),
+      this.props.config.observe('github.graphicalConflictResolution', () => this.forceUpdate()),
     );
   }
 

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -291,6 +291,7 @@ export default class RootController extends React.Component {
     return (
       <RepositoryConflictController
         workspace={this.props.workspace}
+        config={this.props.config}
         repository={this.props.repository}
         resolutionProgress={this.props.resolutionProgress}
         refreshResolutionProgress={this.refreshResolutionProgress}

--- a/package.json
+++ b/package.json
@@ -166,6 +166,11 @@
       "type": "boolean",
       "default": true,
       "description": "Hard wrap commit message body in commit box to 72 characters. Does not apply to expanded commit editors, where message formatting is preserved."
+    },
+    "graphicalConflictResolution": {
+      "type": "boolean",
+      "default": true,
+      "description": "Resolve merge conflicts with in-editor controls"
     }
   },
   "deserializers": {

--- a/test/controllers/repository-conflict-controller.test.js
+++ b/test/controllers/repository-conflict-controller.test.js
@@ -67,4 +67,26 @@ describe('RepositoryConflictController', () => {
       await assert.async.equal(wrapper.find(EditorConflictController).length, 2);
     });
   });
+
+  describe('with the configuration option disabled', function() {
+    beforeEach(function() {
+      atomEnv.config.set('github.graphicalConflictResolution', false);
+    });
+
+    it('renders no children', async function() {
+      const workdirPath = await cloneRepository('merge-conflict');
+      const repository = await buildRepository(workdirPath);
+
+      await assert.isRejected(repository.git.merge('origin/branch'));
+
+      await Promise.all(['modified-on-both-ours.txt', 'modified-on-both-theirs.txt'].map(basename => {
+        return workspace.open(path.join(workdirPath, basename));
+      }));
+
+      app = React.cloneElement(app, {repository});
+      const wrapper = mount(app);
+
+      await assert.async.lengthOf(wrapper.find(EditorConflictController), 0);
+    });
+  });
 });

--- a/test/controllers/repository-conflict-controller.test.js
+++ b/test/controllers/repository-conflict-controller.test.js
@@ -12,10 +12,11 @@ describe('RepositoryConflictController', () => {
 
   beforeEach(() => {
     atomEnv = global.buildAtomEnvironment();
+    atomEnv.config.set('github.graphicalConflictResolution', true);
     workspace = atomEnv.workspace;
     const commandRegistry = atomEnv.commands;
 
-    app = <RepositoryConflictController workspace={workspace} commandRegistry={commandRegistry} />;
+    app = <RepositoryConflictController workspace={workspace} config={atomEnv.config} commandRegistry={commandRegistry} />;
   });
 
   afterEach(() => atomEnv.destroy());


### PR DESCRIPTION
Introduce a `github.graphicalConflictResolution` setting that can be set to `false` to disable in-editor conflict resolution.

Fixes #1078.