### PR TITLE
Align changed file count in status bar

### DIFF
--- a/lib/views/changed-files-count-view.js
+++ b/lib/views/changed-files-count-view.js
@@ -23,8 +23,9 @@ export default class ChangedFilesCountView extends React.Component {
     return (
       <a
         ref="changedFiles"
-        className="github-ChangedFilesCount inline-block icon icon-diff"
+        className="github-ChangedFilesCount inline-block"
         onClick={this.props.didClick}>
+        <Octicon icon="diff" />
         {label}
         {this.props.mergeConflictsPresent && <Octicon icon="alert" />}
       </a>


### PR DESCRIPTION
No more misalignment, yay!
![status-bar-file-count](https://user-images.githubusercontent.com/2766036/36051480-490e40a4-0db8-11e8-8ded-0f60389dc114.png)

Same as sethlu/github#1 by @simurai but on master.

Fixes #1198
Supersedes and closes #1182