### PR TITLE
Shorter time ago in recent commits

### DIFF
--- a/lib/views/recent-commits-view.js
+++ b/lib/views/recent-commits-view.js
@@ -4,25 +4,6 @@ import moment from 'moment';
 
 import Timeago from './timeago';
 
-moment.updateLocale('en', {
-  relativeTime : {
-    future: "%s",
-    past:   "%s",
-    s  : 'Now',
-    ss : '<1m',
-    m:  "1m",
-    mm: "%dm",
-    h:  "1h",
-    hh: "%dh",
-    d:  "1d",
-    dd: "%dd",
-    M:  "1M",
-    MM: "%dM",
-    y:  "1y",
-    yy: "%d y"
-  }
-});
-
 class RecentCommitView extends React.Component {
   static propTypes = {
     commit: PropTypes.object.isRequired,

--- a/lib/views/recent-commits-view.js
+++ b/lib/views/recent-commits-view.js
@@ -4,6 +4,25 @@ import moment from 'moment';
 
 import Timeago from './timeago';
 
+moment.updateLocale('en', {
+  relativeTime : {
+    future: "%s",
+    past:   "%s",
+    s  : 'Now',
+    ss : '<1m',
+    m:  "1m",
+    mm: "%dm",
+    h:  "1h",
+    hh: "%dh",
+    d:  "1d",
+    dd: "%dd",
+    M:  "1M",
+    MM: "%dM",
+    y:  "1y",
+    yy: "%d y"
+  }
+});
+
 class RecentCommitView extends React.Component {
   static propTypes = {
     commit: PropTypes.object.isRequired,

--- a/lib/views/recent-commits-view.js
+++ b/lib/views/recent-commits-view.js
@@ -26,6 +26,7 @@ class RecentCommitView extends React.Component {
         <Timeago
           className="github-RecentCommit-time"
           type="time"
+          displayStyle="short"
           time={authorMoment}
           title={authorMoment.format('MMM Do, YYYY')}
         />

--- a/lib/views/timeago.js
+++ b/lib/views/timeago.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import cx from 'classnames';
 
-moment.updateLocale('en', {
+moment.defineLocale('en-shortdiff', {
+  parentLocale: 'en',
   relativeTime: {
     future: 'in %s',
     past: '%s ago',
@@ -18,7 +19,7 @@ moment.updateLocale('en', {
     M: '1M',
     MM: '%dM',
     y: '1y',
-    yy: '%d y',
+    yy: '%dy',
   },
 });
 
@@ -35,9 +36,21 @@ export default class Timeago extends React.Component {
     type: 'span',
   }
 
-  static getTimeDisplay(time, now = moment()) {
+  static getTimeDisplay(time, now = moment(), style = 'long') {
     const m = moment(time);
-    return m.from(now, true);
+    if (style === 'short') {
+      m.locale('en-shortdiff');
+      return m.from(now, true);
+    } else {
+      const diff = m.diff(now, 'months', true);
+      if (Math.abs(diff) <= 1) {
+        m.locale('en');
+        return m.from(now);
+      } else {
+        const format = m.format('MMM Do, YYYY');
+        return `on ${format}`;
+      }
+    }
   }
 
   componentDidMount() {

--- a/lib/views/timeago.js
+++ b/lib/views/timeago.js
@@ -65,8 +65,8 @@ export default class Timeago extends React.Component {
   }
 
   render() {
-    const {type, time, ...others} = this.props;
-    const display = Timeago.getTimeDisplay(time, moment(), this.props.displayStyle);
+    const {type, time, displayStyle, ...others} = this.props;
+    const display = Timeago.getTimeDisplay(time, moment(), displayStyle);
     const Type = type;
     const className = cx('timeago', others.className);
     return (

--- a/lib/views/timeago.js
+++ b/lib/views/timeago.js
@@ -18,13 +18,7 @@ export default class Timeago extends React.Component {
 
   static getTimeDisplay(time, now = moment()) {
     const m = moment(time);
-    const diff = m.diff(now, 'months', true);
-    if (Math.abs(diff) <= 1) {
-      return m.from(now);
-    } else {
-      const format = m.format('MMM Do, YYYY');
-      return `on ${format}`;
-    }
+    return m.from(now, true);
   }
 
   componentDidMount() {

--- a/lib/views/timeago.js
+++ b/lib/views/timeago.js
@@ -22,6 +22,7 @@ moment.defineLocale('en-shortdiff', {
     yy: '%dy',
   },
 });
+moment.locale('en');
 
 export default class Timeago extends React.Component {
   static propTypes = {
@@ -30,12 +31,12 @@ export default class Timeago extends React.Component {
       PropTypes.string,
       PropTypes.func,
     ]),
-    style: PropTypes.oneOf(['short', 'long']),
+    displayStyle: PropTypes.oneOf(['short', 'long']),
   }
 
   static defaultProps = {
     type: 'span',
-    style: 'long',
+    displayStyle: 'long',
   }
 
   static getTimeDisplay(time, now, style) {
@@ -65,7 +66,7 @@ export default class Timeago extends React.Component {
 
   render() {
     const {type, time, ...others} = this.props;
-    const display = Timeago.getTimeDisplay(time, moment(), this.props.style);
+    const display = Timeago.getTimeDisplay(time, moment(), this.props.displayStyle);
     const Type = type;
     const className = cx('timeago', others.className);
     return (

--- a/lib/views/timeago.js
+++ b/lib/views/timeago.js
@@ -4,22 +4,22 @@ import moment from 'moment';
 import cx from 'classnames';
 
 moment.updateLocale('en', {
-  relativeTime : {
-    future: "in %s",
-    past:   "%s ago",
-    s  : 'Now',
-    ss : '<1m',
-    m:  "1m",
-    mm: "%dm",
-    h:  "1h",
-    hh: "%dh",
-    d:  "1d",
-    dd: "%dd",
-    M:  "1M",
-    MM: "%dM",
-    y:  "1y",
-    yy: "%d y"
-  }
+  relativeTime: {
+    future: 'in %s',
+    past: '%s ago',
+    s: 'Now',
+    ss: '<1m',
+    m: '1m',
+    mm: '%dm',
+    h: '1h',
+    hh: '%dh',
+    d: '1d',
+    dd: '%dd',
+    M: '1M',
+    MM: '%dM',
+    y: '1y',
+    yy: '%d y',
+  },
 });
 
 export default class Timeago extends React.Component {

--- a/lib/views/timeago.js
+++ b/lib/views/timeago.js
@@ -3,6 +3,25 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import cx from 'classnames';
 
+moment.updateLocale('en', {
+  relativeTime : {
+    future: "in %s",
+    past:   "%s ago",
+    s  : 'Now',
+    ss : '<1m',
+    m:  "1m",
+    mm: "%dm",
+    h:  "1h",
+    hh: "%dh",
+    d:  "1d",
+    dd: "%dd",
+    M:  "1M",
+    MM: "%dM",
+    y:  "1y",
+    yy: "%d y"
+  }
+});
+
 export default class Timeago extends React.Component {
   static propTypes = {
     time: PropTypes.any.isRequired,

--- a/lib/views/timeago.js
+++ b/lib/views/timeago.js
@@ -30,13 +30,15 @@ export default class Timeago extends React.Component {
       PropTypes.string,
       PropTypes.func,
     ]),
+    style: PropTypes.oneOf(['short', 'long']),
   }
 
   static defaultProps = {
     type: 'span',
+    style: 'long',
   }
 
-  static getTimeDisplay(time, now = moment(), style = 'long') {
+  static getTimeDisplay(time, now, style) {
     const m = moment(time);
     if (style === 'short') {
       m.locale('en-shortdiff');
@@ -63,7 +65,7 @@ export default class Timeago extends React.Component {
 
   render() {
     const {type, time, ...others} = this.props;
-    const display = Timeago.getTimeDisplay(time);
+    const display = Timeago.getTimeDisplay(time, moment(), this.props.style);
     const Type = type;
     const className = cx('timeago', others.className);
     return (

--- a/test/views/timeago.test.js
+++ b/test/views/timeago.test.js
@@ -2,28 +2,44 @@ import moment from 'moment';
 
 import Timeago from '../../lib/views/timeago';
 
-function test(kindOfDisplay, modifier, expectation) {
+function test(kindOfDisplay, style, modifier, expectation) {
   it(`displays correctly for ${kindOfDisplay}`, function() {
     const base = moment('May 6 1987', 'MMMM D YYYY');
     const m = modifier(moment(base)); // copy `base` since `modifier` mutates
-    assert.equal(Timeago.getTimeDisplay(m, base), expectation);
+    assert.equal(Timeago.getTimeDisplay(m, base, style), expectation);
   });
 }
 
 describe('Timeago component', function() {
-  describe('time display calcuation', function() {
-    test('recent items', m => m, 'a few seconds ago');
-    test('items within a minute', m => m.subtract(45, 'seconds'), 'a minute ago');
-    test('items within two minutes', m => m.subtract(2, 'minutes'), '2 minutes ago');
-    test('items within five minutes', m => m.subtract(5, 'minutes'), '5 minutes ago');
-    test('items within thirty minutes', m => m.subtract(30, 'minutes'), '30 minutes ago');
-    test('items within an hour', m => m.subtract(1, 'hours'), 'an hour ago');
-    test('items within the same day', m => m.subtract(20, 'hours'), '20 hours ago');
-    test('items within a day', m => m.subtract(1, 'day'), 'a day ago');
-    test('items within the same week', m => m.subtract(4, 'days'), '4 days ago');
-    test('items within the same month', m => m.subtract(20, 'days'), '20 days ago');
-    test('items within a month', m => m.subtract(1, 'month'), 'a month ago');
-    test('items beyond a month', m => m.subtract(31, 'days'), 'on Apr 5th, 1987');
-    test('items way beyond a month', m => m.subtract(2, 'years'), 'on May 6th, 1985');
+  describe('long time display calcuation', function() {
+    test('recent items', 'long', m => m, 'a few seconds ago');
+    test('items within a minute', 'long', m => m.subtract(45, 'seconds'), 'a minute ago');
+    test('items within two minutes', 'long', m => m.subtract(2, 'minutes'), '2 minutes ago');
+    test('items within five minutes', 'long', m => m.subtract(5, 'minutes'), '5 minutes ago');
+    test('items within thirty minutes', 'long', m => m.subtract(30, 'minutes'), '30 minutes ago');
+    test('items within an hour', 'long', m => m.subtract(1, 'hours'), 'an hour ago');
+    test('items within the same day', 'long', m => m.subtract(20, 'hours'), '20 hours ago');
+    test('items within a day', 'long', m => m.subtract(1, 'day'), 'a day ago');
+    test('items within the same week', 'long', m => m.subtract(4, 'days'), '4 days ago');
+    test('items within the same month', 'long', m => m.subtract(20, 'days'), '20 days ago');
+    test('items within a month', 'long', m => m.subtract(1, 'month'), 'a month ago');
+    test('items beyond a month', 'long', m => m.subtract(31, 'days'), 'on Apr 5th, 1987');
+    test('items way beyond a month', 'long', m => m.subtract(2, 'years'), 'on May 6th, 1985');
+  });
+
+  describe('short time display calcuation', function() {
+    test('recent items', 'short', m => m, 'Now');
+    test('items within a minute', 'short', m => m.subtract(45, 'seconds'), '1m');
+    test('items within two minutes', 'short', m => m.subtract(2, 'minutes'), '2m');
+    test('items within five minutes', 'short', m => m.subtract(5, 'minutes'), '5m');
+    test('items within thirty minutes', 'short', m => m.subtract(30, 'minutes'), '30m');
+    test('items within an hour', 'short', m => m.subtract(1, 'hours'), '1h');
+    test('items within the same day', 'short', m => m.subtract(20, 'hours'), '20h');
+    test('items within a day', 'short', m => m.subtract(1, 'day'), '1d');
+    test('items within the same week', 'short', m => m.subtract(4, 'days'), '4d');
+    test('items within the same month', 'short', m => m.subtract(20, 'days'), '20d');
+    test('items within a month', 'short', m => m.subtract(1, 'month'), '1M');
+    test('items beyond a month', 'short', m => m.subtract(31, 'days'), '1M');
+    test('items way beyond a month', 'short', m => m.subtract(2, 'years'), '2y');
   });
 });


### PR DESCRIPTION
### Description of the Change

This shortens the "time ago". E.g. `2 hours ago` to just `2h`.

Before | After
--- | ---
![screen shot 2018-03-01 at 2 30 59 pm](https://user-images.githubusercontent.com/378023/36828498-8ad8ea66-1d5d-11e8-9392-66e536a1c1a7.png) | ![screen shot 2018-03-01 at 2 29 47 pm](https://user-images.githubusercontent.com/378023/36828496-88568104-1d5d-11e8-9a02-b0231d8f2adf.png)

- For "a few seconds" it says "Now".
- For months an uppercase `M` is used to differentiate from minutes.

### Alternate Designs

We could also use [twitter](https://momentjs.com/docs/#/plugins/twitter/) or [short date formatter](https://momentjs.com/docs/#/plugins/shortformat/) plugin. These only have a short form under 1 week.

### Benefits

Less space for the time ago, more space for the message + status icon or maybe refs.

### Possible Drawbacks

Might not be too obvious what the short form means. But maybe still fine, Twitter and other apps use it too.

### Applicable Issues

This PR is on top of #1322.
