### PR TITLE
Remember Me?

### DIFF
--- a/bin/git-credential-atom.js
+++ b/bin/git-credential-atom.js
@@ -285,11 +285,16 @@ async function toKeytar(query) {
 }
 
 /*
- *
+ * Remove credentials that failed authentication.
  */
-// async function deleteFromKeytar(query) {
-//   //
-// }
+async function deleteFromKeytar(query) {
+  const strategy = await createStrategy();
+
+  const gitService = `atom-github-git @ ${query.host}`;
+  log(`removing account "${query.username}" from service "${gitService}"`);
+  await strategy.deletePassword(gitService, query.username, query.password);
+  log('success');
+}
 
 async function get() {
   const query = await parse();
@@ -329,6 +334,7 @@ async function erase() {
   try {
     const query = await parse();
     await withAllHelpers(query, 'reject');
+    await deleteFromKeytar(query);
     log('success');
     process.exit(0);
   } catch (e) {

--- a/bin/git-credential-atom.js
+++ b/bin/git-credential-atom.js
@@ -180,11 +180,13 @@ async function fromKeytar(query) {
     log(`reading username from service "${metaService}" and account "username"`);
     const u = await strategy.getPassword(metaService, 'username');
     if (u !== UNAUTHENTICATED) {
+      log('username found in keychain');
       query.username = u;
     }
   }
 
   if (query.username) {
+    // Read git entry from OS keychain
     const gitService = `atom-github-git @ ${query.protocol}://${query.host}`;
     log(`reading service "${gitService}" and account "${query.username}"`);
     const gitPassword = await strategy.getPassword(gitService, query.username);

--- a/bin/git-credential-atom.js
+++ b/bin/git-credential-atom.js
@@ -296,6 +296,11 @@ async function toKeytar(query) {
   const gitService = `atom-github-git @ ${query.host}`;
   log(`writing service "${gitService}" and account "${query.username}"`);
   await strategy.replacePassword(gitService, query.username, query.password);
+
+  const metaService = `atom-github-git-meta @ ${query.host}`;
+  log(`writing service "${metaService}" and account "username"`);
+  await strategy.replacePassword(metaService, 'username', query.username);
+
   log('success');
 }
 

--- a/bin/git-credential-atom.js
+++ b/bin/git-credential-atom.js
@@ -250,7 +250,7 @@ function dialog(query) {
   const prompt = 'Please enter your credentials for ' + url.format(query);
   const includeUsername = !query.username;
 
-  const payload = {prompt, includeUsername, pid: process.pid};
+  const payload = {prompt, includeUsername, includeRemember: true, pid: process.pid};
 
   return new Promise((resolve, reject) => {
     log('requesting dialog through Atom socket');

--- a/bin/git-credential-atom.js
+++ b/bin/git-credential-atom.js
@@ -254,6 +254,13 @@ async function fromKeytar(query) {
       }
 
       password = githubPassword;
+
+      // Always remember credentials we had to go to GraphQL to get
+      await new Promise((resolve, reject) => {
+        fs.writeFile(rememberFile, err => {
+          if (err) { reject(err); } else { resolve(); }
+        });
+      });
     }
   }
 

--- a/bin/git-credential-atom.js
+++ b/bin/git-credential-atom.js
@@ -169,14 +169,14 @@ async function fromKeytar(query) {
   log('reading credentials stored in your OS keychain');
   let password = UNAUTHENTICATED;
 
-  if (!query.host) {
-    throw new Error('Host unavailable');
+  if (!query.host && !query.protocol) {
+    throw new Error('Host or protocol unavailable');
   }
 
   const strategy = await createStrategy();
 
   if (!query.username) {
-    const metaService = `atom-github-git-meta @ ${query.host}`;
+    const metaService = `atom-github-git-meta @ ${query.protocol}://${query.host}`;
     log(`reading username from service "${metaService}" and account "username"`);
     const u = await strategy.getPassword(metaService, 'username');
     if (u !== UNAUTHENTICATED) {
@@ -185,7 +185,7 @@ async function fromKeytar(query) {
   }
 
   if (query.username) {
-    const gitService = `atom-github-git @ ${query.host}`;
+    const gitService = `atom-github-git @ ${query.protocol}://${query.host}`;
     log(`reading service "${gitService}" and account "${query.username}"`);
     const gitPassword = await strategy.getPassword(gitService, query.username);
     if (gitPassword !== UNAUTHENTICATED) {
@@ -310,11 +310,11 @@ async function toKeytar(query) {
 
   const strategy = await createStrategy();
 
-  const gitService = `atom-github-git @ ${query.host}`;
+  const gitService = `atom-github-git @ ${query.protocol}://${query.host}`;
   log(`writing service "${gitService}" and account "${query.username}"`);
   await strategy.replacePassword(gitService, query.username, query.password);
 
-  const metaService = `atom-github-git-meta @ ${query.host}`;
+  const metaService = `atom-github-git-meta @ ${query.protocol}://${query.host}`;
   log(`writing service "${metaService}" and account "username"`);
   await strategy.replacePassword(metaService, 'username', query.username);
 
@@ -327,7 +327,7 @@ async function toKeytar(query) {
 async function deleteFromKeytar(query) {
   const strategy = await createStrategy();
 
-  const gitService = `atom-github-git @ ${query.host}`;
+  const gitService = `atom-github-git @ ${query.protocol}://${query.host}`;
   log(`removing account "${query.username}" from service "${gitService}"`);
   await strategy.deletePassword(gitService, query.username, query.password);
   log('success');

--- a/lib/controllers/issueish-pane-item-controller.js
+++ b/lib/controllers/issueish-pane-item-controller.js
@@ -5,7 +5,8 @@ import {autobind} from 'core-decorators';
 import {QueryRenderer, graphql} from 'react-relay';
 
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
-import GithubLoginModel, {UNAUTHENTICATED} from '../models/github-login-model';
+import GithubLoginModel from '../models/github-login-model';
+import {UNAUTHENTICATED} from '../models/keytar-strategy';
 import GithubLoginView from '../views/github-login-view';
 import ObserveModel from '../views/observe-model';
 import IssueishLookupByNumberContainer from '../containers/issueish-lookup-by-number-container';

--- a/lib/controllers/issueish-pane-item-controller.js
+++ b/lib/controllers/issueish-pane-item-controller.js
@@ -6,7 +6,7 @@ import {QueryRenderer, graphql} from 'react-relay';
 
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
 import GithubLoginModel from '../models/github-login-model';
-import {UNAUTHENTICATED} from '../models/keytar-strategy';
+import {UNAUTHENTICATED} from '../shared/keytar-strategy';
 import GithubLoginView from '../views/github-login-view';
 import ObserveModel from '../views/observe-model';
 import IssueishLookupByNumberContainer from '../containers/issueish-lookup-by-number-container';

--- a/lib/controllers/pr-info-controller.js
+++ b/lib/controllers/pr-info-controller.js
@@ -8,7 +8,7 @@ import PrSelectionByUrlContainer from '../containers/pr-selection-by-url-contain
 import PrSelectionByBranchContainer from '../containers/pr-selection-by-branch-container';
 import GithubLoginView from '../views/github-login-view';
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
-import {UNAUTHENTICATED} from '../models/keytar-strategy';
+import {UNAUTHENTICATED} from '../shared/keytar-strategy';
 
 export default class PrInfoController extends React.Component {
   static propTypes = {

--- a/lib/controllers/pr-info-controller.js
+++ b/lib/controllers/pr-info-controller.js
@@ -8,7 +8,7 @@ import PrSelectionByUrlContainer from '../containers/pr-selection-by-url-contain
 import PrSelectionByBranchContainer from '../containers/pr-selection-by-branch-container';
 import GithubLoginView from '../views/github-login-view';
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
-import {UNAUTHENTICATED} from '../models/github-login-model';
+import {UNAUTHENTICATED} from '../models/keytar-strategy';
 
 export default class PrInfoController extends React.Component {
   static propTypes = {

--- a/lib/controllers/remote-pr-controller.js
+++ b/lib/controllers/remote-pr-controller.js
@@ -6,7 +6,7 @@ import yubikiri from 'yubikiri';
 import {RemotePropType} from '../prop-types';
 import ObserveModelDecorator from '../decorators/observe-model';
 import GithubLoginView from '../views/github-login-view';
-import {UNAUTHENTICATED} from '../models/keytar-strategy';
+import {UNAUTHENTICATED} from '../shared/keytar-strategy';
 import {nullRemote} from '../models/remote';
 import PrInfoController from './pr-info-controller';
 

--- a/lib/controllers/remote-pr-controller.js
+++ b/lib/controllers/remote-pr-controller.js
@@ -6,7 +6,7 @@ import yubikiri from 'yubikiri';
 import {RemotePropType} from '../prop-types';
 import ObserveModelDecorator from '../decorators/observe-model';
 import GithubLoginView from '../views/github-login-view';
-import {UNAUTHENTICATED} from '../models/github-login-model';
+import {UNAUTHENTICATED} from '../models/keytar-strategy';
 import {nullRemote} from '../models/remote';
 import PrInfoController from './pr-info-controller';
 

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -12,7 +12,7 @@ import GitPromptServer from './git-prompt-server';
 import GitTempDir from './git-temp-dir';
 import AsyncQueue from './async-queue';
 import {
-  getDugitePath, getAtomHelperPath,
+  getDugitePath, getSharedModulePath, getAtomHelperPath,
   readFile, fileExists, fsStat, writeFile, isFileExecutable, isFileSymlink, isBinary, getRealPath,
   normalizeGitHelperPath, toNativePathSep, toGitPathSep,
 } from './helpers';
@@ -151,6 +151,7 @@ export default class GitShellOutStrategy {
 
         env.ATOM_GITHUB_WORKDIR_PATH = this.workingDir;
         env.ATOM_GITHUB_DUGITE_PATH = getDugitePath();
+        env.ATOM_GITHUB_KEYTAR_STRATEGY_PATH = getSharedModulePath('keytar-strategy');
 
         // "ssh" won't respect SSH_ASKPASS unless:
         // (a) it's running without a tty

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -51,6 +51,23 @@ export function getDugitePath() {
   return DUGITE_PATH;
 }
 
+const SHARED_MODULE_PATHS = new Map();
+export function getSharedModulePath(relPath) {
+  let modulePath = SHARED_MODULE_PATHS.get(relPath);
+  if (!modulePath) {
+    modulePath = require.resolve(path.join(__dirname, 'shared', relPath));
+    if (!path.isAbsolute(modulePath)) {
+      // Assume we're snapshotted
+      const {resourcePath} = atom.getLoadSettings();
+      modulePath = path.join(resourcePath, modulePath);
+    }
+
+    SHARED_MODULE_PATHS.set(relPath, modulePath);
+  }
+
+  return modulePath;
+}
+
 export function isBinary(data) {
   for (let i = 0; i < 50; i++) {
     const code = data.charCodeAt(i);

--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -1,6 +1,6 @@
 import {Emitter} from 'event-kit';
 
-import {UNAUTHENTICATED, createStrategy} from './keytar-strategy';
+import {UNAUTHENTICATED, createStrategy} from '../shared/keytar-strategy';
 
 let instance = null;
 

--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -1,117 +1,9 @@
-import {execFile} from 'child_process';
-
 import {Emitter} from 'event-kit';
 
-export const UNAUTHENTICATED = Symbol('UNAUTHENTICATED');
-
-export class KeytarStrategy {
-  static get keytar() {
-    return require('keytar');
-  }
-
-  static async isValid() {
-    // Allow for disabling Keytar on problematic CI environments
-    if (process.env.ATOM_GITHUB_DISABLE_KEYTAR) {
-      return false;
-    }
-
-    const keytar = this.keytar;
-
-    try {
-      const rand = Math.floor(Math.random() * 10e20).toString(16);
-      await keytar.setPassword('atom-test-service', rand, rand);
-      const pass = await keytar.getPassword('atom-test-service', rand);
-      const success = pass === rand;
-      keytar.deletePassword('atom-test-service', rand);
-      return success;
-    } catch (err) {
-      return false;
-    }
-  }
-
-  getPassword(service, account) {
-    return this.constructor.keytar.getPassword(service, account);
-  }
-
-  replacePassword(service, account, password) {
-    return this.constructor.keytar.setPassword(service, account, password);
-  }
-
-  deletePassword(service, account) {
-    return this.constructor.keytar.deletePassword(service, account);
-  }
-}
-
-export class SecurityBinaryStrategy {
-  static isValid() {
-    return process.platform === 'darwin';
-  }
-
-  async getPassword(service, account) {
-    try {
-      const password = await this.exec(['find-generic-password', '-s', service, '-a', account, '-w']);
-      return password.trim() || UNAUTHENTICATED;
-    } catch (err) {
-      return UNAUTHENTICATED;
-    }
-  }
-
-  replacePassword(service, account, newPassword) {
-    return this.exec(['add-generic-password', '-s', service, '-a', account, '-w', newPassword, '-U']);
-  }
-
-  deletePassword(service, account) {
-    return this.exec(['delete-generic-password', '-s', service, '-a', account]);
-  }
-
-  exec(securityArgs, {binary} = {binary: 'security'}) {
-    return new Promise((resolve, reject) => {
-      execFile(binary, securityArgs, (error, stdout) => {
-        if (error) { return reject(error); }
-        return resolve(stdout);
-      });
-    });
-  }
-}
-
-export class InMemoryStrategy {
-  static isValid() {
-    return true;
-  }
-
-  constructor() {
-    if (!atom.inSpecMode()) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Using an InMemoryStrategy strategy for storing tokens. ' +
-        'The tokens will only be stored for the current window.',
-      );
-    }
-    this.passwordsByService = new Map();
-  }
-
-  getPassword(service, account) {
-    const passwords = this.passwordsByService.get(service) || new Map();
-    const password = passwords.get(account);
-    return password || UNAUTHENTICATED;
-  }
-
-  replacePassword(service, account, newPassword) {
-    const passwords = this.passwordsByService.get(service) || new Map();
-    passwords.set(account, newPassword);
-    this.passwordsByService.set(service, passwords);
-  }
-
-  deletePassword(service, account) {
-    const passwords = this.passwordsByService.get(service);
-    if (passwords) {
-      passwords.delete(account);
-    }
-  }
-}
+import {UNAUTHENTICATED, createStrategy} from './keytar-strategy';
 
 let instance = null;
-const strategies = [KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy];
+
 export default class GithubLoginModel {
   static get() {
     if (!instance) {
@@ -136,20 +28,7 @@ export default class GithubLoginModel {
       return this._strategy;
     }
 
-    let Strategy;
-    for (let i = 0; i < strategies.length; i++) {
-      const strat = strategies[i];
-      const isValid = await strat.isValid();
-      if (isValid) {
-        Strategy = strat;
-        break;
-      }
-    }
-    // const Strategy = this._Strategy || strategies.find(strat => strat.isValid());
-    if (!Strategy) {
-      throw new Error('None of the listed GithubLoginModel strategies returned true for `isValid`');
-    }
-    this._strategy = new Strategy();
+    this._strategy = await createStrategy();
     return this._strategy;
   }
 

--- a/lib/models/keytar-strategy.js
+++ b/lib/models/keytar-strategy.js
@@ -1,4 +1,13 @@
 import {execFile} from 'child_process';
+import path from 'path';
+import fs from 'fs';
+
+if (typeof atom === 'undefined') {
+  global.atom = {
+    inSpecMode() { return !!process.env.ATOM_GITHUB_SPEC_MODE; },
+    inDevMode() { return false; },
+  };
+}
 
 export const UNAUTHENTICATED = Symbol('UNAUTHENTICATED');
 

--- a/lib/models/keytar-strategy.js
+++ b/lib/models/keytar-strategy.js
@@ -1,0 +1,127 @@
+import {execFile} from 'child_process';
+
+export const UNAUTHENTICATED = Symbol('UNAUTHENTICATED');
+
+export class KeytarStrategy {
+  static get keytar() {
+    return require('keytar');
+  }
+
+  static async isValid() {
+    // Allow for disabling Keytar on problematic CI environments
+    if (process.env.ATOM_GITHUB_DISABLE_KEYTAR) {
+      return false;
+    }
+
+    const keytar = this.keytar;
+
+    try {
+      const rand = Math.floor(Math.random() * 10e20).toString(16);
+      await keytar.setPassword('atom-test-service', rand, rand);
+      const pass = await keytar.getPassword('atom-test-service', rand);
+      const success = pass === rand;
+      keytar.deletePassword('atom-test-service', rand);
+      return success;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  getPassword(service, account) {
+    return this.constructor.keytar.getPassword(service, account);
+  }
+
+  replacePassword(service, account, password) {
+    return this.constructor.keytar.setPassword(service, account, password);
+  }
+
+  deletePassword(service, account) {
+    return this.constructor.keytar.deletePassword(service, account);
+  }
+}
+
+export class SecurityBinaryStrategy {
+  static isValid() {
+    return process.platform === 'darwin';
+  }
+
+  async getPassword(service, account) {
+    try {
+      const password = await this.exec(['find-generic-password', '-s', service, '-a', account, '-w']);
+      return password.trim() || UNAUTHENTICATED;
+    } catch (err) {
+      return UNAUTHENTICATED;
+    }
+  }
+
+  replacePassword(service, account, newPassword) {
+    return this.exec(['add-generic-password', '-s', service, '-a', account, '-w', newPassword, '-U']);
+  }
+
+  deletePassword(service, account) {
+    return this.exec(['delete-generic-password', '-s', service, '-a', account]);
+  }
+
+  exec(securityArgs, {binary} = {binary: 'security'}) {
+    return new Promise((resolve, reject) => {
+      execFile(binary, securityArgs, (error, stdout) => {
+        if (error) { return reject(error); }
+        return resolve(stdout);
+      });
+    });
+  }
+}
+
+export class InMemoryStrategy {
+  static isValid() {
+    return true;
+  }
+
+  constructor() {
+    if (!atom.inSpecMode()) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Using an InMemoryStrategy strategy for storing tokens. ' +
+        'The tokens will only be stored for the current window.',
+      );
+    }
+    this.passwordsByService = new Map();
+  }
+
+  getPassword(service, account) {
+    const passwords = this.passwordsByService.get(service) || new Map();
+    const password = passwords.get(account);
+    return password || UNAUTHENTICATED;
+  }
+
+  replacePassword(service, account, newPassword) {
+    const passwords = this.passwordsByService.get(service) || new Map();
+    passwords.set(account, newPassword);
+    this.passwordsByService.set(service, passwords);
+  }
+
+  deletePassword(service, account) {
+    const passwords = this.passwordsByService.get(service);
+    if (passwords) {
+      passwords.delete(account);
+    }
+  }
+}
+
+const strategies = [KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy];
+
+export async function createStrategy() {
+  let Strategy;
+  for (let i = 0; i < strategies.length; i++) {
+    const strat = strategies[i];
+    const isValid = await strat.isValid();
+    if (isValid) {
+      Strategy = strat;
+      break;
+    }
+  }
+  if (!Strategy) {
+    throw new Error('None of the listed keytar strategies returned true for `isValid`');
+  }
+  return Strategy;
+}

--- a/lib/models/keytar-strategy.js
+++ b/lib/models/keytar-strategy.js
@@ -144,9 +144,7 @@ export class FileStrategy {
   }
 
   async getPassword(service, account) {
-    process.stderr.write('getPassword()');
     const payload = await this.load();
-    process.stderr.write(`payload = ${require('util').inspect(payload)}\n`);
     const forService = payload[service];
     if (forService === undefined) {
       return UNAUTHENTICATED;

--- a/lib/models/keytar-strategy.js
+++ b/lib/models/keytar-strategy.js
@@ -123,5 +123,5 @@ export async function createStrategy() {
   if (!Strategy) {
     throw new Error('None of the listed keytar strategies returned true for `isValid`');
   }
-  return Strategy;
+  return new Strategy();
 }

--- a/lib/models/keytar-strategy.js
+++ b/lib/models/keytar-strategy.js
@@ -117,20 +117,122 @@ export class InMemoryStrategy {
   }
 }
 
-const strategies = [KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy];
+export class FileStrategy {
+  static isValid() {
+    if (!atom.inSpecMode() && !atom.inDevMode()) {
+      return false;
+    }
+
+    return Boolean(process.env.ATOM_GITHUB_KEYTAR_FILE);
+  }
+
+  constructor() {
+    this.filePath = process.env.ATOM_GITHUB_KEYTAR_FILE;
+
+    if (!atom.inSpecMode()) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Using a FileStrategy strategy for storing tokens. ' +
+        'The tokens will be stored %cin the clear%c in a file at %s. ' +
+        "You probably shouldn't use real credentials while this strategy is in use. " +
+        'Unset ATOM_GITHUB_KEYTAR_FILE_STRATEGY to disable it.',
+        'color: red; font-weight: bold; font-style: italic',
+        'color: black; font-weight: normal; font-style: normal',
+        this.filePath,
+      );
+    }
+  }
+
+  async getPassword(service, account) {
+    process.stderr.write('getPassword()');
+    const payload = await this.load();
+    process.stderr.write(`payload = ${require('util').inspect(payload)}\n`);
+    const forService = payload[service];
+    if (forService === undefined) {
+      return UNAUTHENTICATED;
+    }
+    const passwd = forService[account];
+    if (passwd === undefined) {
+      return UNAUTHENTICATED;
+    }
+    return passwd;
+  }
+
+  replacePassword(service, account, password) {
+    return this.modify(payload => {
+      let forService = payload[service];
+      if (forService === undefined) {
+        forService = {};
+        payload[service] = forService;
+      }
+      forService[account] = password;
+    });
+  }
+
+  deletePassword(service, account) {
+    return this.modify(payload => {
+      const forService = payload[service];
+      if (forService === undefined) {
+        return;
+      }
+      delete forService[account];
+      if (Object.keys(forService).length === 0) {
+        delete payload[service];
+      }
+    });
+  }
+
+  load() {
+    return new Promise((resolve, reject) => {
+      fs.readFile(this.filePath, 'utf8', (err, content) => {
+        if (err && err.code === 'ENOENT') {
+          return resolve({});
+        }
+        if (err) {
+          return reject(err);
+        }
+        return resolve(JSON.parse(content));
+      });
+    });
+  }
+
+  save(payload) {
+    return new Promise((resolve, reject) => {
+      fs.writeFile(this.filePath, JSON.stringify(payload), 'utf8', err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  async modify(callback) {
+    const payload = await this.load();
+    callback(payload);
+    await this.save(payload);
+  }
+}
+
+const strategies = [FileStrategy, KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy];
+let ValidStrategy = null;
 
 export async function createStrategy() {
-  let Strategy;
+  if (ValidStrategy) {
+    return new ValidStrategy();
+  }
+
   for (let i = 0; i < strategies.length; i++) {
     const strat = strategies[i];
     const isValid = await strat.isValid();
     if (isValid) {
-      Strategy = strat;
+      ValidStrategy = strat;
       break;
     }
   }
-  if (!Strategy) {
+  if (!ValidStrategy) {
     throw new Error('None of the listed keytar strategies returned true for `isValid`');
   }
-  return new Strategy();
+  return new ValidStrategy();
 }

--- a/lib/shared/README.md
+++ b/lib/shared/README.md
@@ -1,0 +1,3 @@
+# Shared code
+
+Modules in this folder are imported by both `bin/` and elsewhere in `lib/`. As a consequence, they can't use features provided by Babel transpilation or import files outside of those that do.

--- a/lib/shared/keytar-strategy.js
+++ b/lib/shared/keytar-strategy.js
@@ -1,6 +1,5 @@
-import {execFile} from 'child_process';
-import path from 'path';
-import fs from 'fs';
+const {execFile} = require('child_process');
+const fs = require('fs');
 
 if (typeof atom === 'undefined') {
   global.atom = {
@@ -9,9 +8,9 @@ if (typeof atom === 'undefined') {
   };
 }
 
-export const UNAUTHENTICATED = Symbol('UNAUTHENTICATED');
+const UNAUTHENTICATED = Symbol('UNAUTHENTICATED');
 
-export class KeytarStrategy {
+class KeytarStrategy {
   static get keytar() {
     return require('keytar');
   }
@@ -49,7 +48,7 @@ export class KeytarStrategy {
   }
 }
 
-export class SecurityBinaryStrategy {
+class SecurityBinaryStrategy {
   static isValid() {
     return process.platform === 'darwin';
   }
@@ -81,7 +80,7 @@ export class SecurityBinaryStrategy {
   }
 }
 
-export class InMemoryStrategy {
+class InMemoryStrategy {
   static isValid() {
     return true;
   }
@@ -117,7 +116,7 @@ export class InMemoryStrategy {
   }
 }
 
-export class FileStrategy {
+class FileStrategy {
   static isValid() {
     if (!atom.inSpecMode() && !atom.inDevMode()) {
       return false;
@@ -216,7 +215,7 @@ export class FileStrategy {
 const strategies = [FileStrategy, KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy];
 let ValidStrategy = null;
 
-export async function createStrategy() {
+async function createStrategy() {
   if (ValidStrategy) {
     return new ValidStrategy();
   }
@@ -234,3 +233,12 @@ export async function createStrategy() {
   }
   return new ValidStrategy();
 }
+
+module.exports = {
+  UNAUTHENTICATED,
+  KeytarStrategy,
+  SecurityBinaryStrategy,
+  InMemoryStrategy,
+  FileStrategy,
+  createStrategy,
+};

--- a/lib/shared/keytar-strategy.js
+++ b/lib/shared/keytar-strategy.js
@@ -35,8 +35,9 @@ class KeytarStrategy {
     }
   }
 
-  getPassword(service, account) {
-    return this.constructor.keytar.getPassword(service, account);
+  async getPassword(service, account) {
+    const password = await this.constructor.keytar.getPassword(service, account);
+    return password !== null ? password : UNAUTHENTICATED;
   }
 
   replacePassword(service, account, password) {

--- a/lib/shared/keytar-strategy.js
+++ b/lib/shared/keytar-strategy.js
@@ -1,10 +1,18 @@
+/* eslint comma-dangle: ["error", {
+    "arrays": "never",
+    "objects": "never",
+    "imports": "never",
+    "exports": "never",
+    "functions": "never"
+  }] */
+
 const {execFile} = require('child_process');
 const fs = require('fs');
 
 if (typeof atom === 'undefined') {
   global.atom = {
     inSpecMode() { return !!process.env.ATOM_GITHUB_SPEC_MODE; },
-    inDevMode() { return false; },
+    inDevMode() { return false; }
   };
 }
 
@@ -91,7 +99,7 @@ class InMemoryStrategy {
       // eslint-disable-next-line no-console
       console.warn(
         'Using an InMemoryStrategy strategy for storing tokens. ' +
-        'The tokens will only be stored for the current window.',
+        'The tokens will only be stored for the current window.'
       );
     }
     this.passwordsByService = new Map();
@@ -138,7 +146,7 @@ class FileStrategy {
         'Unset ATOM_GITHUB_KEYTAR_FILE_STRATEGY to disable it.',
         'color: red; font-weight: bold; font-style: italic',
         'color: black; font-weight: normal; font-style: normal',
-        this.filePath,
+        this.filePath
       );
     }
   }
@@ -241,5 +249,5 @@ module.exports = {
   SecurityBinaryStrategy,
   InMemoryStrategy,
   FileStrategy,
-  createStrategy,
+  createStrategy
 };

--- a/lib/views/credential-dialog.js
+++ b/lib/views/credential-dialog.js
@@ -9,12 +9,14 @@ export default class CredentialDialog extends React.Component {
     commandRegistry: PropTypes.object.isRequired,
     prompt: PropTypes.string.isRequired,
     includeUsername: PropTypes.bool,
+    includeRemember: PropTypes.bool,
     onSubmit: PropTypes.func,
     onCancel: PropTypes.func,
   }
 
   static defaultProps = {
     includeUsername: false,
+    includeRemember: false,
     onSubmit: () => {},
     onCancel: () => {},
   }
@@ -25,6 +27,7 @@ export default class CredentialDialog extends React.Component {
     this.state = {
       username: '',
       password: '',
+      remember: false,
     };
   }
 
@@ -67,6 +70,17 @@ export default class CredentialDialog extends React.Component {
           </label>
         </main>
         <footer className="github-DialogButtons">
+          {this.props.includeRemember ? (
+            <label className="github-DialogLabel">
+              <input
+                className="github-CredentialDialog-remember"
+                type="checkbox"
+                checked={this.state.remember}
+                onChange={this.onRememberChange}
+              />
+              Remember
+            </label>
+          ) : null}
           <button className="btn github-CancelButton" tabIndex="3" onClick={this.cancel}>Cancel</button>
           <button className="btn btn-primary" tabIndex="4" onClick={this.confirm}>Sign in</button>
         </footer>
@@ -80,6 +94,10 @@ export default class CredentialDialog extends React.Component {
 
     if (this.props.includeUsername) {
       payload.username = this.state.username;
+    }
+
+    if (this.props.includeRemember) {
+      payload.remember = this.state.remember;
     }
 
     this.props.onSubmit(payload);
@@ -98,6 +116,11 @@ export default class CredentialDialog extends React.Component {
   @autobind
   onPasswordChange(e) {
     this.setState({password: e.target.value});
+  }
+
+  @autobind
+  onRememberChange(e) {
+    this.setState({remember: e.target.checked});
   }
 
   @autobind

--- a/lib/views/credential-dialog.js
+++ b/lib/views/credential-dialog.js
@@ -71,9 +71,9 @@ export default class CredentialDialog extends React.Component {
         </main>
         <footer className="github-DialogButtons">
           {this.props.includeRemember ? (
-            <label className="github-DialogLabel">
+            <label className="github-DialogButtons-leftItem input-label">
               <input
-                className="github-CredentialDialog-remember"
+                className="github-CredentialDialog-remember input-checkbox"
                 type="checkbox"
                 checked={this.state.remember}
                 onChange={this.onRememberChange}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "main": "./lib/index",
-  "version": "0.10.1",
+  "version": "0.10.1-0",
   "description": "GitHub integration",
   "repository": "https://github.com/atom/github",
   "license": "MIT",

--- a/styles/dialog.less
+++ b/styles/dialog.less
@@ -24,6 +24,7 @@
 
   &Buttons {
     display: flex;
+    align-items: center;
     justify-content: flex-end;
     padding: @github-dialog-spacing;
 
@@ -35,6 +36,12 @@
 
     .btn {
       margin: @github-dialog-spacing;
+    }
+
+    &-leftItem,
+    &-leftItem.btn {
+      margin: @github-dialog-spacing;
+      margin-right: auto;
     }
   }
 

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 import GitPromptServer from '../lib/git-prompt-server';
 import GitTempDir from '../lib/git-temp-dir';
-import {fileExists, writeFile, readFile, deleteFileOrFolder, getAtomHelperPath} from '../lib/helpers';
+import {fileExists, writeFile, readFile, getAtomHelperPath} from '../lib/helpers';
 import {transpile} from './helpers';
 
 describe('GitPromptServer', function() {

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 import GitPromptServer from '../lib/git-prompt-server';
 import GitTempDir from '../lib/git-temp-dir';
-import {fileExists, writeFile, readFile, getAtomHelperPath} from '../lib/helpers';
+import {fileExists, writeFile, readFile, deleteFileOrFolder, getAtomHelperPath} from '../lib/helpers';
 import {transpile} from './helpers';
 
 describe('GitPromptServer', function() {
@@ -62,7 +62,7 @@ describe('GitPromptServer', function() {
       });
     }
 
-    afterEach(function() {
+    afterEach(async function() {
       if (this.currentTest.state === 'failed') {
         if (stderrData.length > 0) {
           /* eslint-disable no-console */
@@ -72,6 +72,8 @@ describe('GitPromptServer', function() {
           /* eslint-enable no-console */
         }
       }
+
+      await tempDir.dispose();
     });
 
     it('prompts for user input and writes collected credentials to stdout', async function() {
@@ -244,13 +246,14 @@ describe('GitPromptServer', function() {
       function processHandler(child) {
         child.stdin.write('protocol=https\n');
         child.stdin.write('host=what-is-your-favorite-color.com\n');
+        child.stdin.write('username=old-man-from-scene-24\n');
         child.stdin.end('\n');
       }
 
       await writeFile(tempDir.getScriptPath('fake-keytar'), `
       {
         "atom-github": {
-          "github.com": "swordfish"
+          "https://api.what-is-your-favorite-color.com": "swordfish"
         }
       }
       `);
@@ -277,7 +280,7 @@ describe('GitPromptServer', function() {
       function processHandler(child) {
         child.stdin.write('protocol=https\n');
         child.stdin.write('host=what-is-your-favorite-color.com\n');
-        child.stdin.write('username=old-man-from-scene-24');
+        child.stdin.write('username=old-man-from-scene-24\n');
         child.stdin.write('password=shhhh');
         child.stdin.end('\n');
       }

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -4,7 +4,6 @@ import path from 'path';
 import GitPromptServer from '../lib/git-prompt-server';
 import GitTempDir from '../lib/git-temp-dir';
 import {fileExists, writeFile, readFile, getAtomHelperPath} from '../lib/helpers';
-import {transpile} from './helpers';
 
 describe('GitPromptServer', function() {
   const electronEnv = {
@@ -12,7 +11,7 @@ describe('GitPromptServer', function() {
     ELECTRON_NO_ATTACH_CONSOLE: '1',
     ATOM_GITHUB_KEYTAR_FILE: null,
     ATOM_GITHUB_DUGITE_PATH: require.resolve('dugite'),
-    ATOM_GITHUB_KEYTAR_STRATEGY_PATH: null, // Computed lazily in beforeEach()
+    ATOM_GITHUB_KEYTAR_STRATEGY_PATH: require.resolve('../lib/shared/keytar-strategy'),
     ATOM_GITHUB_ORIGINAL_PATH: process.env.PATH,
     ATOM_GITHUB_WORKDIR_PATH: path.join(__dirname, '..'),
     ATOM_GITHUB_SPEC_MODE: 'true',
@@ -27,11 +26,6 @@ describe('GitPromptServer', function() {
     await tempDir.ensure();
 
     electronEnv.ATOM_GITHUB_KEYTAR_FILE = tempDir.getScriptPath('fake-keytar');
-
-    if (!electronEnv.ATOM_GITHUB_KEYTAR_STRATEGY_PATH) {
-      const [keytarStrategyPath] = await transpile(require.resolve('../lib/models/keytar-strategy'));
-      electronEnv.ATOM_GITHUB_KEYTAR_STRATEGY_PATH = keytarStrategyPath;
-    }
   });
 
   describe('credential helper', function() {

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -214,11 +214,11 @@ describe('GitPromptServer', function() {
 
       await writeFile(tempDir.getScriptPath('fake-keytar'), `
       {
-        "atom-github-git @ what-is-your-favorite-color.com": {
+        "atom-github-git @ https://what-is-your-favorite-color.com": {
           "old-man-from-scene-24": "swordfish",
           "github.com": "nope"
         },
-        "atom-github-git @ github.com": {
+        "atom-github-git @ https://github.com": {
           "old-man-from-scene-24": "nope"
         }
       }
@@ -251,17 +251,17 @@ describe('GitPromptServer', function() {
 
       await writeFile(tempDir.getScriptPath('fake-keytar'), `
       {
-        "atom-github-git-meta @ what-is-your-favorite-color.com": {
+        "atom-github-git-meta @ https://what-is-your-favorite-color.com": {
           "username": "old-man-from-scene-24"
         },
-        "atom-github-git @ what-is-your-favorite-color.com": {
+        "atom-github-git @ https://what-is-your-favorite-color.com": {
           "old-man-from-scene-24": "swordfish",
           "github.com": "nope"
         },
-        "atom-github-git-meta @ github.com": {
+        "atom-github-git-meta @ https://github.com": {
           "username": "nah"
         },
-        "atom-github-git @ github.com": {
+        "atom-github-git @ https://github.com": {
           "old-man-from-scene-24": "nope"
         }
       }
@@ -335,10 +335,10 @@ describe('GitPromptServer', function() {
 
       const stored = await readFile(tempDir.getScriptPath('fake-keytar'));
       assert.deepEqual(JSON.parse(stored), {
-        'atom-github-git-meta @ what-is-your-favorite-color.com': {
+        'atom-github-git-meta @ https://what-is-your-favorite-color.com': {
           username: 'old-man-from-scene-24',
         },
-        'atom-github-git @ what-is-your-favorite-color.com': {
+        'atom-github-git @ https://what-is-your-favorite-color.com': {
           'old-man-from-scene-24': 'shhhh',
         },
       });
@@ -361,11 +361,11 @@ describe('GitPromptServer', function() {
       }
 
       await writeFile(tempDir.getScriptPath('fake-keytar'), JSON.stringify({
-        'atom-github-git @ what-is-your-favorite-color.com': {
+        'atom-github-git @ https://what-is-your-favorite-color.com': {
           'old-man-from-scene-24': 'shhhh',
           'someone-else': 'untouched',
         },
-        'atom-github-git @ github.com': {
+        'atom-github-git @ https://github.com': {
           'old-man-from-scene-24': 'untouched',
         },
       }));
@@ -375,10 +375,10 @@ describe('GitPromptServer', function() {
 
       const stored = await readFile(tempDir.getScriptPath('fake-keytar'));
       assert.deepEqual(JSON.parse(stored), {
-        'atom-github-git @ what-is-your-favorite-color.com': {
+        'atom-github-git @ https://what-is-your-favorite-color.com': {
           'someone-else': 'untouched',
         },
-        'atom-github-git @ github.com': {
+        'atom-github-git @ https://github.com': {
           'old-man-from-scene-24': 'untouched',
         },
       });

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -290,7 +290,7 @@ describe('GitPromptServer', function() {
       await writeFile(tempDir.getScriptPath('fake-keytar'), `
       {
         "atom-github": {
-          "https://api.what-is-your-favorite-color.com": "swordfish"
+          "https://what-is-your-favorite-color.com": "swordfish"
         }
       }
       `);

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -57,6 +57,7 @@ describe.only('GitPromptServer', function() {
       if (this.currentTest.state === 'failed') {
         if (stderrData.length > 0) {
           /* eslint-disable no-console */
+          console.log(this.currentTest.fullTitle());
           console.log(`STDERR:\n${stderrData.join('')}\n`);
           console.log(`STDOUT:\n${stdoutData.join('')}\n`);
           /* eslint-enable no-console */

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -335,6 +335,9 @@ describe('GitPromptServer', function() {
 
       const stored = await readFile(tempDir.getScriptPath('fake-keytar'));
       assert.deepEqual(JSON.parse(stored), {
+        'atom-github-git-meta @ what-is-your-favorite-color.com': {
+          username: 'old-man-from-scene-24',
+        },
         'atom-github-git @ what-is-your-favorite-color.com': {
           'old-man-from-scene-24': 'shhhh',
         },

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -5,7 +5,7 @@ import GitPromptServer from '../lib/git-prompt-server';
 import GitTempDir from '../lib/git-temp-dir';
 import {fileExists, writeFile, readFile, getAtomHelperPath} from '../lib/helpers';
 
-describe.only('GitPromptServer', function() {
+describe('GitPromptServer', function() {
   const electronEnv = {
     ELECTRON_RUN_AS_NODE: '1',
     ELECTRON_NO_ATTACH_CONSOLE: '1',

--- a/test/models/file-patch.test.js
+++ b/test/models/file-patch.test.js
@@ -1,4 +1,5 @@
-import {cloneRepository, buildRepository, toGitPathSep} from '../helpers';
+import {cloneRepository, buildRepository} from '../helpers';
+import {toGitPathSep} from '../../lib/helpers';
 import path from 'path';
 import fs from 'fs';
 import dedent from 'dedent-js';

--- a/test/models/github-login-model.test.js
+++ b/test/models/github-login-model.test.js
@@ -1,5 +1,5 @@
 import GithubLoginModel from '../../lib/models/github-login-model';
-import {KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy, UNAUTHENTICATED} from '../../lib/models/keytar-strategy';
+import {KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy, UNAUTHENTICATED} from '../../lib/shared/keytar-strategy';
 
 describe('GithubLoginModel', function() {
   [null, KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy].forEach(function(Strategy) {

--- a/test/models/github-login-model.test.js
+++ b/test/models/github-login-model.test.js
@@ -1,4 +1,5 @@
-import GithubLoginModel, {KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy, UNAUTHENTICATED} from '../../lib/models/github-login-model';
+import GithubLoginModel from '../../lib/models/github-login-model';
+import {KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy, UNAUTHENTICATED} from '../../lib/models/keytar-strategy';
 
 describe('GithubLoginModel', function() {
   [null, KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy].forEach(function(Strategy) {

--- a/test/transpiled/.gitignore
+++ b/test/transpiled/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/test/views/credential-dialog.test.js
+++ b/test/views/credential-dialog.test.js
@@ -18,6 +18,7 @@ describe('CredentialDialog', function() {
         commandRegistry={atomEnv.commands}
         prompt="speak friend and enter"
         includeUsername={true}
+        includeRemember={false}
         onSubmit={didSubmit}
         onCancel={didCancel}
       />
@@ -58,6 +59,30 @@ describe('CredentialDialog', function() {
       assert.deepEqual(didSubmit.firstCall.args[0], {
         password: 'twowordsuppercase',
       });
+    });
+
+    it('includes a "remember me" checkbox', function() {
+      wrapper = mount(React.cloneElement(app, {includeRemember: true}));
+
+      const rememberBox = wrapper.find('.github-CredentialDialog-remember');
+      assert.isTrue(rememberBox.exists());
+      rememberBox.simulate('change', {target: {checked: true}});
+
+      setTextIn('.github-CredentialDialog-Username', 'someone');
+      setTextIn('.github-CredentialDialog-Password', 'letmein');
+
+      wrapper.find('.btn-primary').simulate('click');
+
+      assert.deepEqual(didSubmit.firstCall.args[0], {
+        username: 'someone',
+        password: 'letmein',
+        remember: true,
+      });
+    });
+
+    it('omits the "remember me" checkbox', function() {
+      wrapper = mount(app);
+      assert.isFalse(wrapper.find('.github-CredentialDialog-remember').exists());
     });
   });
 });


### PR DESCRIPTION
Add a "remember me" checkbox to the authentication dialog that's launched by the bundled git credential helper. When checked, if authentication is successful (as detected by git invoking `git credential approve`), store the provided credentials in your OS keychain by way of [keytar](https://www.npmjs.com/package/keytar). If authentication fails, delete them.

##### Remaining

- [x] Refactor the `KeytarStrategy` implementations out of `github-login-model` so I can reuse them from the credential helper.
- [x] Introduce a `FileStrategy` that fakes keytar by reading and writing a JSON file. This is insecure as hell, so put in extra guards against it handling actual credentials.
- [x] Pre-transpile `keytar-strategy.js` and get its transpiled path so that it can be executed from the credential helper subprocess (from specs).
- [x] Attempt to read credentials from keytar within the credential handler before prompting from the Atom dialog. If credentials are found, short-circuit and reply.
- [x] Store the username as a per-host default as well if it wasn't provided in the original query.
- [x] Store a successfully used credential pair on `git credential approve`.
- [x] Delete an unsuccessfully used credential pair on `git credential reject`.
- [x] Re-use the token from the GitHub panel if it's been set. The interesting wrinkle here is that we don't have a username, so we'll need to pull it from the GitHub API.
- [x] Add the actual "remember me" text to the authentication dialog.
- [x] Test the pre-transpiled `keytar-strategy.js` in (a) dev mode and (b) when bundled within an Atom build. Find an alternative if it doesn't work.
- [x] Investigate and correct test failures
- [x] Give it a spin on Windows
- [x] Give it a spin on Linux

Fixes #861.