### PR TITLE
Don't retry prompt server tests

### DIFF
--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -5,7 +5,7 @@ import GitPromptServer from '../lib/git-prompt-server';
 import GitTempDir from '../lib/git-temp-dir';
 import {fileExists, writeFile, readFile, getAtomHelperPath} from '../lib/helpers';
 
-describe('GitPromptServer', function() {
+describe.stress(50, 'GitPromptServer', function() {
   const electronEnv = {
     ELECTRON_RUN_AS_NODE: '1',
     ELECTRON_NO_ATTACH_CONSOLE: '1',

--- a/test/git-prompt-server.test.js
+++ b/test/git-prompt-server.test.js
@@ -71,9 +71,6 @@ describe('GitPromptServer', function() {
     });
 
     it('prompts for user input and writes collected credentials to stdout', async function() {
-      this.retries(5); // Known Flake
-      this.timeout(10000);
-
       let queried = null;
 
       function queryHandler(query) {
@@ -106,9 +103,6 @@ describe('GitPromptServer', function() {
     });
 
     it('preserves a provided username', async function() {
-      this.timeout(10000);
-      this.retries(5);
-
       let queried = null;
 
       function queryHandler(query) {
@@ -140,9 +134,6 @@ describe('GitPromptServer', function() {
     });
 
     it('parses input without the terminating blank line', async function() {
-      this.timeout(10000);
-      this.retries(5);
-
       function queryHandler(query) {
         return {
           username: 'old-man-from-scene-24',
@@ -167,9 +158,6 @@ describe('GitPromptServer', function() {
     });
 
     it('creates a flag file if remember is set to true', async function() {
-      this.timeout(10000);
-      this.retries(5);
-
       function queryHandler(query) {
         return {
           username: 'old-man-from-scene-24',
@@ -190,9 +178,6 @@ describe('GitPromptServer', function() {
     });
 
     it('uses matching credentials from keytar if available without prompting', async function() {
-      this.timeout(10000);
-      this.retries(5);
-
       let called = false;
       function queryHandler() {
         called = true;
@@ -228,9 +213,6 @@ describe('GitPromptServer', function() {
     });
 
     it('uses a default username for the appropriate host if one is available', async function() {
-      this.timeout(10000);
-      this.retries(5);
-
       let called = false;
       function queryHandler() {
         called = true;
@@ -271,9 +253,6 @@ describe('GitPromptServer', function() {
     });
 
     it('uses credentials from the GitHub tab if available', async function() {
-      this.timeout(10000);
-      this.retries(5);
-
       let called = false;
       function queryHandler() {
         called = true;
@@ -305,9 +284,6 @@ describe('GitPromptServer', function() {
     });
 
     it('stores credentials in keytar if a flag file is present', async function() {
-      this.timeout(10000);
-      this.retries(5);
-
       let called = false;
       function queryHandler() {
         called = true;
@@ -339,9 +315,6 @@ describe('GitPromptServer', function() {
     });
 
     it('forgets stored credentials from keytar if authentication fails', async function() {
-      this.timeout(10000);
-      this.retries(5);
-
       function queryHandler() {
         return {};
       }
@@ -385,9 +358,6 @@ describe('GitPromptServer', function() {
 
   describe('askpass helper', function() {
     it('prompts for user input and writes the response to stdout', async function() {
-      this.timeout(10000);
-      this.retries(5);
-
       let queried = null;
 
       const server = new GitPromptServer(tempDir);


### PR DESCRIPTION
I _think_ the root cause of our intermittent GitPromptServer test failures was a buffering issue: in some cases, the credential helper script was not flushing its output to stdout before terminating, which caused the test to fail.

Waiting for the stdout write to flush should have addressed this:

https://github.com/atom/github/blob/39817fd9fad45139fc89d4e1b6aff514609ab7d3/bin/git-credential-atom.js#L388-L392

If we can get rid of the `this.retries()` settings for these tests, it'll:

1. Make our test suite somewhat faster
2. Avoid messing up stack traces appearing in the mocha test runner
3. Be slightly tidier