### PR TITLE
getWrappedComponent() calls on things that are no longer EtchWrappers

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -447,7 +447,7 @@ export default class RootController extends React.Component {
   @autobind
   surfaceFromFileAtPath(filePath, stagingStatus) {
     if (this.gitTabController) {
-      this.gitTabController.getWrappedComponent().focusAndSelectStagingItem(filePath, stagingStatus);
+      this.gitTabController.focusAndSelectStagingItem(filePath, stagingStatus);
     }
   }
 

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -469,7 +469,7 @@ export default class RootController extends React.Component {
   @autobind
   quietlySelectItem(filePath, stagingStatus) {
     if (this.gitTabController) {
-      return this.gitTabController.getWrappedComponent().quietlySelectItem(filePath, stagingStatus);
+      return this.gitTabController.getWrappedComponentInstance().quietlySelectItem(filePath, stagingStatus);
     } else {
       return null;
     }

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -447,7 +447,7 @@ export default class RootController extends React.Component {
   @autobind
   surfaceFromFileAtPath(filePath, stagingStatus) {
     if (this.gitTabController) {
-      this.gitTabController.focusAndSelectStagingItem(filePath, stagingStatus);
+      this.gitTabController.getWrappedComponentInstance().focusAndSelectStagingItem(filePath, stagingStatus);
     }
   }
 


### PR DESCRIPTION
There were a few places where we were still calling `.getWrappedComponent()` on components that used to be `EtchWrappers`, but now aren't.

Fixes #1337.