### PR TITLE
Avoid rerendering the FilePatchView on every tiny update

### DIFF
--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -97,7 +97,7 @@ export default class FilePatchView extends React.Component {
       symlinkChange: ['oldSymlink', 'newSymlink', 'typechange', 'filePatchStatus'],
     };
 
-    for (const propKey in constructor.propTypes) {
+    for (const propKey in this.constructor.propTypes) {
       const subKeys = deepProps[propKey];
       if (subKeys) {
         if (subKeys.some(subKey => this.props[propKey][subKey] !== nextProps[propKey][subKey])) {

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -99,12 +99,26 @@ export default class FilePatchView extends React.Component {
 
     for (const propKey in this.constructor.propTypes) {
       const subKeys = deepProps[propKey];
+      const oldProp = this.props[propKey];
+      const newProp = nextProps[propKey];
+
       if (subKeys) {
+        const oldExists = (oldProp !== null && oldProp !== undefined);
+        const newExists = (newProp !== null && newProp !== undefined);
+
+        if (oldExists !== newExists) {
+          return true;
+        }
+
+        if (!oldExists && !newExists) {
+          continue;
+        }
+
         if (subKeys.some(subKey => this.props[propKey][subKey] !== nextProps[propKey][subKey])) {
           return true;
         }
       } else {
-        if (this.props[propKey] !== nextProps[propKey]) {
+        if (oldProp !== newProp) {
           return true;
         }
       }

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -91,6 +91,36 @@ export default class FilePatchView extends React.Component {
     }
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    const deepProps = {
+      executableModeChange: ['oldMode', 'newMode'],
+      symlinkChange: ['oldSymlink', 'newSymlink', 'typechange', 'filePatchStatus'],
+    };
+
+    for (const propKey in constructor.propTypes) {
+      const subKeys = deepProps[propKey];
+      if (subKeys) {
+        if (subKeys.some(subKey => this.props[propKey][subKey] !== nextProps[propKey][subKey])) {
+          return true;
+        }
+      } else {
+        if (this.props[propKey] !== nextProps[propKey]) {
+          return true;
+        }
+      }
+    }
+
+    if (this.state.selection !== nextState.selection) {
+      return true;
+    }
+
+    if (this.state.domNode !== nextState.domNode) {
+      return true;
+    }
+
+    return false;
+  }
+
   renderEmptyDiffMessage() {
     return (
       <div className="is-blank">
@@ -163,6 +193,7 @@ export default class FilePatchView extends React.Component {
   }
 
   render() {
+    console.log('FilePatchView - render');
     const unstaged = this.props.stagingStatus === 'unstaged';
     return (
       <div

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -207,7 +207,6 @@ export default class FilePatchView extends React.Component {
   }
 
   render() {
-    console.log('FilePatchView - render');
     const unstaged = this.props.stagingStatus === 'unstaged';
     return (
       <div


### PR DESCRIPTION
Use a `shouldComponentUpdate()` method to prevent the FilePatchView from re-rendering every time a change is triggered. This is especially egregrious now that the CommitView's editor triggers a Repository update event on each keystroke by way of `setRegularCommitMessage()`.

Fixes #1338.