### PR TITLE
More prominent commit button 

### DIFF
--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -143,7 +143,7 @@ export default class CommitView extends React.Component {
           }
           <button
             ref={c => { this.refCommitButton = c; }}
-            className="btn github-CommitView-button github-CommitView-commit"
+            className="github-CommitView-button github-CommitView-commit btn btn-primary"
             onClick={this.commit}
             disabled={!this.isCommitButtonEnabled()}>{this.commitButtonText()}</button>
           <div className={`github-CommitView-remaining-characters ${remainingCharsClassName}`}>


### PR DESCRIPTION
### Description of the Change

This makes the commit button look more prominent (`btn-primary`).

Before | After
--- | ---
![screen shot 2018-03-13 at 9 18 12 am](https://user-images.githubusercontent.com/378023/37315912-8609faa2-269f-11e8-8b06-fda050a282d7.png) | ![screen shot 2018-03-13 at 9 05 39 am](https://user-images.githubusercontent.com/378023/37315812-ef10d562-269e-11e8-94ab-0901572fc191.png)

### Benefits

- Guides the user more towards the main action on the panel -> committing.
- Also adds more contrast to the otherwise somewhat "flat" UI.
- More aligned with GitHub Desktop. /cc @donokuda

### Possible Drawbacks

None I can think of.
