### PR TITLE
Use unambiguous branch name when pushing

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -658,7 +658,7 @@ export default class GitShellOutStrategy {
   }
 
   push(remoteName, branchName, options = {}) {
-    const args = ['push', remoteName || 'origin', branchName];
+    const args = ['push', remoteName || 'origin', `refs/heads/${branchName}`];
     if (options.setUpstream) { args.push('--set-upstream'); }
     if (options.force) { args.push('--force'); }
     return this.exec(args, {useGitPromptServer: true, writeOperation: true});


### PR DESCRIPTION
### Description of the Change

When pushing, use unambiguous "refs/heads/branch_name" instead of "branch_name"

### Benefits

Avoids ambiguity with other kinds of git refs like tags. git push will fail if a ref string refers to more than one thing. Fixes #1358

### Applicable Issues

#1358