### PR TITLE
Add linter-config.md

### DIFF
--- a/docs/linter-config.md
+++ b/docs/linter-config.md
@@ -1,0 +1,5 @@
+Recommended linter configuration is to use the `linter-eslint` and `atom-ide-ui` packages.  `linter-eslint` will prompt you to download `linter-ui-default` and other "dependencies." Don't believe their lies, use atom-ide-ui instead.  These packages don't need ay special configuration to work together - it should just happen automagically.
+
+Recommended linter configuration settings:
+- uncheck "use global eslint configuration" since the linter configuration lives in the project.
+- check "fix errors on save"

--- a/docs/linter-config.md
+++ b/docs/linter-config.md
@@ -1,4 +1,4 @@
-Recommended linter configuration is to use the `linter-eslint` and `atom-ide-ui` packages.  `linter-eslint` will prompt you to download `linter-ui-default` and other "dependencies." Don't believe their lies, use atom-ide-ui instead.  These packages don't need ay special configuration to work together - it should just happen automagically.
+Recommended linter configuration is to use the `linter-eslint` and `atom-ide-ui` packages.  `linter-eslint` will prompt you to download `linter-ui-default` and other "dependencies." Don't believe their lies, use atom-ide-ui instead.  These packages don't need any special configuration to work together - it should just happen automagically.
 
 Recommended linter configuration settings:
 - uncheck "use global eslint configuration" since the linter configuration lives in the project.

--- a/docs/linter-config.md
+++ b/docs/linter-config.md
@@ -1,4 +1,4 @@
-Recommended linter configuration is to use the `linter-eslint` and `atom-ide-ui` packages.  `linter-eslint` will prompt you to download `linter-ui-default` and other "dependencies." Don't believe their lies, use atom-ide-ui instead.  These packages don't need any special configuration to work together - it should just happen automagically.
+Recommended linter configuration is to use the `linter-eslint` and `atom-ide-ui` packages.  `linter-eslint` will prompt you to download `linter-ui-default` and other "dependencies" but that's not necessary if you're using `atom-ide-ui`.  These packages don't need any special configuration to work together - it should just happen automagically.
 
 Recommended linter configuration settings:
 - uncheck "use global eslint configuration" since the linter configuration lives in the project.


### PR DESCRIPTION
Documentation only change.  This pr adds a note about how to configure linters to work on the github package.  If we onboard folks in the future, this might be useful.

I'm not sure if this is the best place for this documentation to live.  Maybe it belongs on the team onboarding checklist instead (especially if the linter configuration is common across all core Atom packages.) . Suggestions welcome.