### PR TITLE
Remove One theme hacks

### DIFF
--- a/styles/commit-view.less
+++ b/styles/commit-view.less
@@ -268,35 +268,3 @@
     fill: @text-color
   }
 }
-
-
-
-
-
-
-// Hacks ---------------------------------------------------
-// TODO: Unhack if possible
-
-
-// Fix focus styles
-// Since it's not possible to add a padding to <atom-text-editor>
-// a pseudo element is used to add the border when focused.
-
-.theme-one-dark-ui,
-.theme-one-light-ui {
-  .github-CommitView-editor atom-text-editor.is-focused,
-  .github-CommitView-coAuthorEditor.is-focused {
-    box-shadow: none;
-    &:before {
-      content: "";
-      position: absolute;
-      top: -2px;
-      left: -2px;
-      right: -2px;
-      bottom: -2px;
-      border: 2px solid;
-      border-color: inherit;
-      border-radius: @component-border-radius;
-    }
-  }
-}


### PR DESCRIPTION
### Description of the Change

This removes the overrides for the One themes.

### Benefits

Less hacks!

### Applicable Issues

Added back here https://github.com/atom/one-light-ui/pull/131
