### PR TITLE
lazy load `CustomEvent` to fix snapshotting

### DIFF
--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -13,12 +13,17 @@ import {AuthorPropType} from '../prop-types';
 
 const TOOLTIP_DELAY = 200;
 
-class FakeKeyDownEvent extends CustomEvent {
-  constructor(keyCode) {
-    super('keydown');
-    this.keyCode = keyCode;
+// CustomEvent is a DOM primitive, which v8 can't access
+// so we're essentially lazy loading to keep snapshotting from breaking.
+const getFakeKeyDownEvent = function(keyCode) {
+  class FakeKeyDownEvent extends CustomEvent {
+    constructor(kCode) {
+      super('keydown');
+      this.keyCode = kCode;
+    }
   }
-}
+  return new FakeKeyDownEvent(keyCode);
+};
 
 export default class CommitView extends React.Component {
   static focus = {
@@ -78,7 +83,7 @@ export default class CommitView extends React.Component {
         return;
       }
 
-      const fakeEvent = new FakeKeyDownEvent(keyCode);
+      const fakeEvent = getFakeKeyDownEvent(keyCode);
       this.refCoAuthorSelect.handleKeyDown(fakeEvent);
 
       if (!fakeEvent.defaultPrevented) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "main": "./lib/index",
-  "version": "0.13.0-0",
+  "version": "0.13.0",
   "description": "GitHub integration",
   "repository": "https://github.com/atom/github",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "main": "./lib/index",
-  "version": "0.13.0",
+  "version": "0.13.0-0",
   "description": "GitHub integration",
   "repository": "https://github.com/atom/github",
   "license": "MIT",


### PR DESCRIPTION
Problem: When I went to prepare the `0.13.0` release, snapshotting failed with the following output:

```
Generating snapshot script at "/Users/distiller/atom/out/startup.js" (483)
Verifying if snapshot can be executed via `mksnapshot`
/Users/distiller/atom/out/startup.js:294944
      let FakeKeyDownEvent = class FakeKeyDownEvent extends CustomEvent {
                                                            ^
ReferenceError: CustomEvent is not defined
    at Object.../node_modules/github/lib/views/commit-view.js (/Users/distiller/atom/out/startup.js:294944:61)
    at customRequire (/Users/distiller/atom/out/startup.js:94:47)
    at Object.../node_modules/github/lib/controllers/commit-controller.js (/Users/distiller/atom/out/startup.js:279080:25)
    at customRequire (/Users/distiller/atom/out/startup.js:94:47)
    at Object.../node_modules/github/lib/views/git-tab-view.js (/Users/distiller/atom/out/startup.js:232123:31)
    at customRequire (/Users/distiller/atom/out/startup.js:94:47)
    at Object.../node_modules/github/lib/controllers/git-tab-controller.js (/Users/distiller/atom/out/startup.js:189673:25)
    at customRequire (/Users/distiller/atom/out/startup.js:94:47)
    at Object.../node_modules/github/lib/controllers/root-controller.js (/Users/distiller/atom/out/startup.js:104740:31)
    at customRequire (/Users/distiller/atom/out/startup.js:94:47)
Error: Command failed: /Users/distiller/atom/out/Atom.app/Contents/MacOS/Atom /Users/distiller/atom/script/verify-snapshot-script /Users/distiller/atom/out/startup.js
/Users/distiller/atom/out/startup.js:294944
      let FakeKeyDownEvent = class FakeKeyDownEvent extends CustomEvent {
```

`CustomEvent` is a DOM primitive that is not available in the v8 context.  Solution is to make the code that needs `CustomEvent` not execute while snapshotting.

Test plan:
 - Ran unit tests for `atom/github`
 - Manually tested adding a co author and clearing the co author suggested inputs with `esc` key, which uses the `FakeKeyDown` functionality.
- Published a pre release version of `atom/github`, and then built `atom/atom` locally with my pre release version.  Build output successfully executed snapshotting.
