### PR TITLE
Call FilePatchController methods on the "real item"

### DIFF
--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -436,11 +436,12 @@ export default class StagingView {
     // due to changes being fully staged/unstaged/stashed/deleted/etc
     return this.props.workspace.getPanes().filter(pane => {
       const pendingItem = pane.getPendingItem();
-      if (!pendingItem) { return false; }
-      const isDiffViewItem = pendingItem.getRealItem && pendingItem.getRealItem() instanceof FilePatchController;
+      if (!pendingItem || !pendingItem.getRealItem) { return false; }
+      const realItem = pendingItem.getRealItem();
+      const isDiffViewItem = realItem instanceof FilePatchController;
       // We only want to update pending diff views for currently active repo
-      const isInActiveRepo = pendingItem.getWorkingDirectory() === this.props.workingDirectoryPath;
-      const isStale = !this.changedFileExists(pendingItem.getFilePath(), pendingItem.getStagingStatus());
+      const isInActiveRepo = realItem.getWorkingDirectory() === this.props.workingDirectoryPath;
+      const isStale = !this.changedFileExists(realItem.getFilePath(), realItem.getStagingStatus());
       return isDiffViewItem && isInActiveRepo && isStale;
     });
   }


### PR DESCRIPTION
We're using getRealItem() to identify pane items that are `FilePatchControllers`, but we're calling `FilePatchController` methods directly on the pane item even if it isn't a `FilePatchController`.

Not adding a regression test because StagingView is pending a React port and adding more tests would make it that much more painful 😅 

Fixes #1396.