### PR TITLE
DOMPurify is done within the notifications package

### DIFF
--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -3,7 +3,6 @@ import path from 'path';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {autobind} from 'core-decorators';
-import createDOMPurify from 'dompurify';
 
 import yubikiri from 'yubikiri';
 
@@ -12,8 +11,6 @@ import ObserveModel from '../views/observe-model';
 import UserStore from '../models/user-store';
 import {nullBranch} from '../models/branch';
 import {nullCommit} from '../models/commit';
-
-const DOMPurify = createDOMPurify();
 
 const DEFAULT_REPO_DATA = {
   lastCommit: nullCommit,
@@ -363,7 +360,7 @@ export default class GitTabController extends React.Component {
     } catch (e) {
       if (e.code === 'EDIRTYSTAGED') {
         this.props.notificationManager.addError(
-          DOMPurify.sanitize(`Cannot abort because ${e.path} is both dirty and staged.`),
+          `Cannot abort because ${e.path} is both dirty and staged.`,
           {dismissable: true},
         );
       } else {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -6,7 +6,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {autobind} from 'core-decorators';
 import {CompositeDisposable} from 'event-kit';
-import createDOMPurify from 'dompurify';
 
 import StatusBar from '../views/status-bar';
 import Panel from '../views/panel';
@@ -28,8 +27,6 @@ import RefHolder from '../models/ref-holder';
 import Switchboard from '../switchboard';
 import {toNativePathSep, destroyFilePatchPaneItems, destroyEmptyFilePatchPaneItems} from '../helpers';
 import {GitError} from '../git-shell-out-strategy';
-
-const DOMPurify = createDOMPurify();
 
 function getPropsFromUri(uri) {
   // atom-github://file-patch/file.txt?workdir=/foo/bar/baz&stagingStatus=staged
@@ -424,7 +421,7 @@ export default class RootController extends React.Component {
       await this.props.cloneRepositoryForProjectPath(remoteUrl, projectPath);
     } catch (e) {
       this.props.notificationManager.addError(
-        DOMPurify.sanitize(`Unable to clone ${remoteUrl}`),
+        `Unable to clone ${remoteUrl}`,
         {detail: e.stdErr, dismissable: true},
       );
     } finally {
@@ -444,7 +441,7 @@ export default class RootController extends React.Component {
       if (this.state.initDialogResolve) { this.state.initDialogResolve(projectPath); }
     } catch (e) {
       this.props.notificationManager.addError(
-        DOMPurify.sanitize(`Unable to initialize git repository in ${projectPath}`),
+        `Unable to initialize git repository in ${projectPath}`,
         {detail: e.stdErr, dismissable: true},
       );
     } finally {
@@ -586,7 +583,7 @@ export default class RootController extends React.Component {
       this.props.notificationManager.addError(
         message,
         {
-          description: DOMPurify.sanitize(`You have unsaved changes in:<br>${unsavedFiles}.`),
+          description: `You have unsaved changes in:<br>${unsavedFiles}.`,
           dismissable: true,
         },
       );
@@ -682,9 +679,7 @@ export default class RootController extends React.Component {
     this.props.notificationManager.addError(
       'Discard history has expired.',
       {
-        description: DOMPurify.sanitize(
-          `Cannot undo discard for<br>${filePathsStr}<br>Stale discard history has been deleted.`,
-        ),
+        description: `Cannot undo discard for<br>${filePathsStr}<br>Stale discard history has been deleted.`,
         dismissable: true,
       },
     );

--- a/lib/get-repo-pipeline-manager.js
+++ b/lib/get-repo-pipeline-manager.js
@@ -1,11 +1,8 @@
 import fs from 'fs-extra';
-import createDOMPurify from 'dompurify';
 
 import ActionPipelineManager from './action-pipeline';
 import {GitError} from './git-shell-out-strategy';
 import {getCommitMessagePath, getCommitMessageEditors, destroyFilePatchPaneItems} from './helpers';
-
-const DOMPurify = createDOMPurify();
 
 // Note: Middleware that catches errors should re-throw the errors so that they propogate
 // and other middleware in the pipeline can be made aware of the errors.
@@ -79,10 +76,9 @@ export default function({confirm, notificationManager, workspace}) {
           const lines = error.stdErr.split('\n');
           const files = lines.slice(3, lines.length - 3).map(l => `\`${l.trim()}\``).join('\n');
           notificationManager.addError('Pull aborted', {
-            description: DOMPurify.sanitize(
+            description:
               'Local changes to the following would be overwritten by merge:<br/>' + files +
               '<br/>Please commit your changes or stash them before you merge.',
-            ),
             dismissable: true,
           });
         } else if (/Automatic merge failed; fix conflicts and then commit the result./.test(error.stdOut)) {
@@ -149,12 +145,11 @@ export default function({confirm, notificationManager, workspace}) {
         if (error.stdErr.match(/local changes.*would be overwritten/)) {
           const files = error.stdErr.split(/\r?\n/).filter(l => l.startsWith('\t'))
             .map(l => `\`${l.trim()}\``).join('<br/>');
-          description = DOMPurify.sanitize(
+          description =
              'Local changes to the following would be overwritten:<br/>' + files +
-             '<br/>Please commit your changes or stash them.',
-          );
+             '<br/>Please commit your changes or stash them.';
         } else if (error.stdErr.match(/branch.*already exists/)) {
-          description = DOMPurify.sanitize(`\`${branchName}\` already exists. Choose another branch name.`);
+          description = `\`${branchName}\` already exists. Choose another branch name.`;
         } else if (error.stdErr.match(/error: you need to resolve your current index first/)) {
           description = 'You must first resolve merge conflicts.';
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2120,11 +2120,6 @@
         "domelementtype": "1.3.0"
       }
     },
-    "dompurify": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.3.tgz",
-      "integrity": "sha1-Py9uy27NJ1maUGtBD/R9brkP0F0="
-    },
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
@@ -2204,19 +2199,6 @@
         "object.values": "1.0.4",
         "raf": "3.4.0",
         "rst-selector-parser": "2.2.3"
-      }
-    },
-    "enzyme-adapter-react-15": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-15/-/enzyme-adapter-react-15-1.0.5.tgz",
-      "integrity": "sha1-mfmgP/LCMD5Rc0KTV5imvfu3X6w=",
-      "dev": true,
-      "requires": {
-        "enzyme-adapter-utils": "1.3.0",
-        "lodash": "4.17.5",
-        "object.assign": "4.1.0",
-        "object.values": "1.0.4",
-        "prop-types": "15.6.1"
       }
     },
     "enzyme-adapter-react-16": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "compare-sets": "^1.0.1",
     "core-decorators": "^0.19.0",
     "diff": "3.2.0",
-    "dompurify": "^1.0.3",
     "dugite": "^1.60.0",
     "etch": "^0.12.4",
     "event-kit": "^2.3.0",


### PR DESCRIPTION
atom/notifications#187, atom/notifications#188, and atom/notifications#189 use DOMPurify on _all_ notification descriptions. Because we were only using DOMPurify to sanitize stderr before sending it to the notifications package, it's no longer necessary (and I've confirmed that I still can't create a branch called `<iframe src="file:///etc/passwd" />`).

This saves us from needing to address some of the DOMPurify/snapshotting problems that we already solved in atom/notifications.

Fixes #1397.