### PR TITLE
No-op on untitled buffers

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -501,6 +501,8 @@ export default class RootController extends React.Component {
 
   async viewChangesForCurrentFile(stagingStatus) {
     const editor = this.props.workspace.getActiveTextEditor();
+    if (!editor.getPath()) { return; }
+
     const absFilePath = await fs.realpath(editor.getPath());
     const repoPath = this.props.repository.getWorkingDirectoryPath();
     if (repoPath === null) {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -551,12 +551,12 @@ export default class RootController extends React.Component {
 
   @autobind
   viewUnstagedChangesForCurrentFile() {
-    this.viewChangesForCurrentFile('unstaged');
+    return this.viewChangesForCurrentFile('unstaged');
   }
 
   @autobind
   viewStagedChangesForCurrentFile() {
-    this.viewChangesForCurrentFile('staged');
+    return this.viewChangesForCurrentFile('staged');
   }
 
   @autobind

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -1052,6 +1052,18 @@ describe('RootController', function() {
         assert.deepEqual(filePatchItem.goToDiffLine.args[0], [8]);
         assert.equal(filePatchItem.focus.callCount, 1);
       });
+
+      it('does nothing on an untitled buffer', async function() {
+        const workdirPath = await cloneRepository('three-files');
+        const repository = await buildRepository(workdirPath);
+        const wrapper = mount(React.cloneElement(app, {repository}));
+
+        await workspace.open();
+
+        sinon.spy(workspace, 'open');
+        await wrapper.instance().viewUnstagedChangesForCurrentFile();
+        assert.isFalse(workspace.open.called);
+      });
     });
 
     describe('viewStagedChangesForCurrentFile()', function() {
@@ -1084,6 +1096,18 @@ describe('RootController', function() {
         await assert.async.equal(filePatchItem.goToDiffLine.callCount, 1);
         assert.deepEqual(filePatchItem.goToDiffLine.args[0], [8]);
         assert.equal(filePatchItem.focus.callCount, 1);
+      });
+
+      it('does nothing on an untitled buffer', async function() {
+        const workdirPath = await cloneRepository('three-files');
+        const repository = await buildRepository(workdirPath);
+        const wrapper = mount(React.cloneElement(app, {repository}));
+
+        await workspace.open();
+
+        sinon.spy(workspace, 'open');
+        await wrapper.instance().viewStagedChangesForCurrentFile();
+        assert.isFalse(workspace.open.called);
       });
     });
   });


### PR DESCRIPTION
Opening staged or unstaged changes on an untitled buffer should be a no-op, not throw an exception.

Fixes #951.