### PR TITLE
Only register "github:co-author:..." commands on co-author editor

### DIFF
--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -111,7 +111,8 @@ export default class CommitView extends React.Component {
         'github:commit': this.commit,
         'github:amend-last-commit': this.amendLastCommit,
         'github:toggle-expanded-commit-message-editor': this.toggleExpandedCommitMessageEditor,
-
+      }),
+      this.props.commandRegistry.add('.github-CommitView-coAuthorEditor', {
         'github:co-author:down': this.proxyKeyCode(40),
         'github:co-author:up': this.proxyKeyCode(38),
         'github:co-author:enter': this.proxyKeyCode(13),


### PR DESCRIPTION
It looks like the command palette doesn't like the `github:co-author:...`-style commands, but we don't really want these to be user-visible anyway. Let's only register them on the co-author text field to keep them from appearing. They will still appear if you open the command palette with the co-author text field focused, though.

Fixes #1407.