### PR TITLE
Restore missing RefHolder

### DIFF
--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -69,6 +69,7 @@ export default class CommitView extends React.Component {
     this.refAbortMergeButton = new RefHolder();
     this.refCoAuthorToggle = new RefHolder();
     this.refCoAuthorSelect = new RefHolder();
+    this.refCoAuthorForm = new RefHolder();
     this.refEditor = new RefHolder();
     this.editor = null;
 


### PR DESCRIPTION
This fixes a "Cannot read setter of undefined" stacktrace.