### PR TITLE
Restore missing .get() call

### DIFF
--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -550,7 +550,7 @@ export default class CommitView extends React.Component {
 
     if (focus === CommitView.focus.COMMIT_BUTTON) {
       if (!this.refCommitButton.isEmpty()) {
-        this.refCommitButton.focus();
+        this.refCommitButton.get().focus();
         return true;
       } else {
         fallback = true;

--- a/test/views/commit-view.test.js
+++ b/test/views/commit-view.test.js
@@ -247,4 +247,14 @@ describe('CommitView', function() {
     wrapper.find('.github-CommitView-abortMerge').simulate('click');
     assert.isTrue(abortMerge.calledOnce);
   });
+
+  describe('restoring focus', function() {
+    it('to the commit button', function() {
+      const wrapper = mount(app);
+      sinon.spy(wrapper.instance().refCommitButton.get(), 'focus');
+
+      wrapper.instance().setFocus(CommitView.focus.COMMIT_BUTTON);
+      assert.isTrue(wrapper.instance().refCommitButton.get().focus.called);
+    });
+  });
 });


### PR DESCRIPTION
`refCommitButton` is stored within a `RefHolder`, so the focus manipulation methods need to call `.get()` to access the actual element.

Fixes #1416.