### PR TITLE
Only call scrollIntoViewIfNeeded() on elements that are still present

### DIFF
--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -357,7 +357,12 @@ export default class StagingView {
 
   writeAfterUpdate() {
     const headItem = this.selection.getHeadItem();
-    if (headItem) { this.listElementsByItem.get(headItem).scrollIntoViewIfNeeded(); }
+    if (headItem) {
+      const element = this.listElementsByItem.get(headItem);
+      if (element) {
+        element.scrollIntoViewIfNeeded();
+      }
+    }
   }
 
   // Directly modify the selection to include only the item identified by the file path and stagingStatus tuple.


### PR DESCRIPTION
Addresses #935 on `0.14-releases` (Atom 1.27 beta line).