### PR TITLE
Reset mouseSelectionInProgress synchronously on mouseUp

### DIFF
--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -778,15 +778,17 @@ export default class StagingView extends React.Component {
   }
 
   async mouseup() {
+    const hadSelectionInProgress = this.mouseSelectionInProgress;
+    this.mouseSelectionInProgress = false;
+
     await new Promise(resolve => {
       this.setState(prevState => ({
         selection: prevState.selection.coalesce(),
       }), resolve);
     });
-    if (this.mouseSelectionInProgress) {
+    if (hadSelectionInProgress) {
       this.debouncedDidChangeSelectedItem(true);
     }
-    this.mouseSelectionInProgress = false;
   }
 
   undoLastDiscard() {


### PR DESCRIPTION
This is a speculative fix for an issue where FilePatch items will pop open unpredictably on `mouseup` even while no StagingView mouse selection is in progress. It's difficult to reproduce or test because it relies on internal React rendering pipeline behavior.

If the `setState()` call within the `mouseup` handler is batched with other state transitions by React, a race condition could prevent `this.mouseSelectionInProgress` from being set to `false` correctly. Toggling off `this.mouseSelectionInProgress` before the first "await" should prevent this from triggering.