### PR TITLE
Clear the branch name after a successful checkout

### DIFF
--- a/lib/views/branch-menu-view.js
+++ b/lib/views/branch-menu-view.js
@@ -120,15 +120,20 @@ export default class BranchMenuView extends React.Component {
       const branchName = this.editorElement.getModel().getText().trim();
       await this.checkout(branchName, {createNew: true});
     } else {
-      this.setState({createNew: true}, () => {
-        this.editorElement.focus();
+      await new Promise(resolve => {
+        this.setState({createNew: true}, () => {
+          this.editorElement.focus();
+          resolve();
+        });
       });
     }
   }
 
   async checkout(branchName, options) {
     this.editorElement.classList.remove('is-focused');
-    this.setState({checkedOutBranch: branchName});
+    await new Promise(resolve => {
+      this.setState({checkedOutBranch: branchName}, resolve);
+    });
     try {
       await this.props.checkout(branchName, options);
     } catch (error) {

--- a/lib/views/branch-menu-view.js
+++ b/lib/views/branch-menu-view.js
@@ -117,7 +117,7 @@ export default class BranchMenuView extends React.Component {
 
   async createBranch() {
     if (this.state.createNew) {
-      const branchName = this.editorElement.innerText.trim();
+      const branchName = this.editorElement.getModel().getText().trim();
       await this.checkout(branchName, {createNew: true});
     } else {
       this.setState({createNew: true}, () => {

--- a/lib/views/branch-menu-view.js
+++ b/lib/views/branch-menu-view.js
@@ -100,16 +100,6 @@ export default class BranchMenuView extends React.Component {
     );
   }
 
-  componentDidUpdate() {
-    const currentBranch = this.props.currentBranch.getName();
-    const branchNames = this.props.branches.getNames();
-    const hasNewBranch = branchNames.includes(this.state.checkedOutBranch);
-    if (currentBranch === this.state.checkedOutBranch && hasNewBranch) {
-      this.editorElement.classList.add('is-focused');
-      this.setState({checkedOutBranch: null, createNew: false});
-    }
-  }
-
   async didSelectItem(event) {
     const branchName = event.target.value;
     await this.checkout(branchName);
@@ -136,13 +126,16 @@ export default class BranchMenuView extends React.Component {
     });
     try {
       await this.props.checkout(branchName, options);
+      await new Promise(resolve => {
+        this.setState({checkedOutBranch: null, createNew: false}, resolve);
+      });
+      this.editorElement.getModel().setText('');
     } catch (error) {
       this.editorElement.classList.add('is-focused');
-      this.setState({checkedOutBranch: null});
-      if (error instanceof GitError) {
-        // eslint-disable-next-line no-console
-        console.warn('Non-fatal', error);
-      } else {
+      await new Promise(resolve => {
+        this.setState({checkedOutBranch: null}, resolve);
+      });
+      if (!(error instanceof GitError)) {
         throw error;
       }
     }

--- a/test/controllers/status-bar-tile-controller.test.js
+++ b/test/controllers/status-bar-tile-controller.test.js
@@ -197,7 +197,7 @@ describe('StatusBarTileController', function() {
           assert.isTrue(selectList.className.includes('hidden'));
           assert.isFalse(tip.querySelector('.github-BranchMenuView-editor').className.includes('hidden'));
 
-          tip.querySelector('atom-text-editor').innerText = 'new-branch';
+          tip.querySelector('atom-text-editor').getModel().setText('new-branch');
           tip.querySelector('button').click();
           assert.isTrue(editor.hasAttribute('readonly'));
 
@@ -231,7 +231,7 @@ describe('StatusBarTileController', function() {
           assert.equal(tip.querySelector('select').value, 'branch');
 
           createNewButton.click();
-          tip.querySelector('atom-text-editor').innerText = 'master';
+          tip.querySelector('atom-text-editor').getModel().setText('master');
           createNewButton.click();
           assert.isTrue(createNewButton.hasAttribute('disabled'));
 
@@ -245,7 +245,7 @@ describe('StatusBarTileController', function() {
           assert.isFalse(branch1.isDetached());
 
           assert.lengthOf(tip.querySelectorAll('.github-BranchMenuView-editor'), 1);
-          assert.equal(tip.querySelector('atom-text-editor').innerText, 'master');
+          assert.equal(tip.querySelector('atom-text-editor').getModel().getText(), 'master');
           assert.isFalse(createNewButton.hasAttribute('disabled'));
         });
       });


### PR DESCRIPTION
Fixing a minor bug that I've noticed. When you create a new branch with the BranchMenuView, the branch's name is still there the next time that you start creating a new branch.