### PR TITLE
Improve git log readability

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -87,7 +87,7 @@ export default class GitShellOutStrategy {
 
   // Execute a command and read the output using the embedded Git environment
   async exec(args, options = GitShellOutStrategy.defaultExecArgs) {
-    /* eslint-disable no-console */
+    /* eslint-disable no-console,no-control-regex */
     const {stdin, useGitPromptServer, useGpgWrapper, useGpgAtomPrompt, writeOperation} = options;
     const subscriptions = new CompositeDisposable();
     const diagnosticsEnabled = process.env.ATOM_GITHUB_GIT_DIAGNOSTICS || atom.config.get('github.gitDiagnostics');
@@ -243,6 +243,12 @@ export default class GitShellOutStrategy {
         subscriptions.dispose();
 
         if (diagnosticsEnabled) {
+          const exposeControlCharacters = raw => {
+            return raw
+              .replace(/\u0000/ug, '<NUL>\n')
+              .replace(/\u001F/ug, '<SEP>');
+          };
+
           if (headless) {
             let summary = `git:${formattedArgs}\n`;
             summary += `exit status: ${exitCode}\n`;
@@ -250,13 +256,13 @@ export default class GitShellOutStrategy {
             if (stdout.length === 0) {
               summary += ' <empty>\n';
             } else {
-              summary += `\n${stdout}\n`;
+              summary += `\n${exposeControlCharacters(stdout)}\n`;
             }
             summary += 'stderr:';
             if (stderr.length === 0) {
               summary += ' <empty>\n';
             } else {
-              summary += `\n${stderr}\n`;
+              summary += `\n${exposeControlCharacters(stderr)}\n`;
             }
 
             console.log(summary);
@@ -271,9 +277,9 @@ export default class GitShellOutStrategy {
               util.inspect(args, {breakLength: Infinity}),
             );
             console.log('%cstdout', headerStyle);
-            console.log(stdout);
+            console.log(exposeControlCharacters(stdout));
             console.log('%cstderr', headerStyle);
-            console.log(stderr);
+            console.log(exposeControlCharacters(stderr));
             console.groupEnd();
           }
         }
@@ -291,7 +297,7 @@ export default class GitShellOutStrategy {
         resolve(stdout);
       });
     }, {parallel: !writeOperation});
-    /* eslint-enable no-console */
+    /* eslint-enable no-console,no-control-regex */
   }
 
   async gpgExec(args, options) {

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -2,6 +2,7 @@ import path from 'path';
 import os from 'os';
 import childProcess from 'child_process';
 import fs from 'fs-extra';
+import util from 'util';
 import {remote} from 'electron';
 
 import {CompositeDisposable} from 'event-kit';
@@ -264,6 +265,11 @@ export default class GitShellOutStrategy {
 
             console.groupCollapsed(`git:${formattedArgs}`);
             console.log('%cexit status%c %d', headerStyle, 'font-weight: normal; color: black;', exitCode);
+            console.log(
+              '%cfull arguments%c %s',
+              headerStyle, 'font-weight: normal; color: black;',
+              util.inspect(args, {breakLength: Infinity}),
+            );
             console.log('%cstdout', headerStyle);
             console.log(stdout);
             console.log('%cstderr', headerStyle);

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -86,8 +86,6 @@ export default class GitShellOutStrategy {
 
   // Execute a command and read the output using the embedded Git environment
   async exec(args, options = GitShellOutStrategy.defaultExecArgs) {
-    args.unshift(...DISABLE_COLOR_FLAGS);
-
     /* eslint-disable no-console */
     const {stdin, useGitPromptServer, useGpgWrapper, useGpgAtomPrompt, writeOperation} = options;
     const subscriptions = new CompositeDisposable();
@@ -96,6 +94,8 @@ export default class GitShellOutStrategy {
     const formattedArgs = `git ${args.join(' ')} in ${this.workingDir}`;
     const timingMarker = GitTimingsView.generateMarker(`git ${args.join(' ')}`);
     timingMarker.mark('queued');
+
+    args.unshift(...DISABLE_COLOR_FLAGS);
 
     if (execPathPromise === null) {
       // Attempt to collect the --exec-path from a native git installation.

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -838,7 +838,7 @@ describe('Repository', function() {
             await repo.abortMerge();
             assert.fail(null, null, 'repo.abortMerge() unexepctedly succeeded');
           } catch (e) {
-            assert.match(e.command, /^git .* merge --abort/);
+            assert.match(e.command, /^git merge --abort/);
           }
           assert.equal(await repo.isMerging(), true);
           assert.deepEqual(await repo.getStagedChanges(), stagedChanges);


### PR DESCRIPTION
The console output created by enabling `github.gitDiagnostics` isn't very readable. The actual git command is obfuscated by all of the `-c` arguments that we add to improve parseability.

<img width="500" alt="before" src="https://user-images.githubusercontent.com/17565/39635874-b23e18b8-4f8c-11e8-88f7-966f307a2d4c.png">

I've improved its legibility by generating the formattedArgs string _before_ we manipulate the `args` object:

<img width="500" alt="after" src="https://user-images.githubusercontent.com/17565/39635956-e633c500-4f8c-11e8-9402-247a58fa2564.png">

I've also added some post-processing on the commands' stdout and stderr, to reveal hidden characters that we use like null bytes and unicode field separator characters:

<img width="500" alt="details" src="https://user-images.githubusercontent.com/17565/39636007-01bf8ad4-4f8d-11e8-9f80-38e5a5af3e3c.png">
