### PR TITLE
URIPatterns never match undefined or null

### DIFF
--- a/lib/atom/uri-pattern.js
+++ b/lib/atom/uri-pattern.js
@@ -58,6 +58,10 @@ export default class URIPattern {
   }
 
   matches(string) {
+    if (string === undefined || string === null) {
+      return false;
+    }
+
     const other = url.parse(string, true);
     const params = {};
 

--- a/test/atom/uri-pattern.test.js
+++ b/test/atom/uri-pattern.test.js
@@ -18,6 +18,11 @@ describe('URIPattern', function() {
       assert.isFalse(exact.matches('atom-github://exact/but/not').ok());
       assert.isFalse(exact.matches('atom-github://exact?no=no').ok());
     });
+
+    it('does not match undefined or null', function() {
+      assert.isFalse(exact.matches(undefined));
+      assert.isFalse(exact.matches(null));
+    });
   });
 
   describe('parameter placeholders', function() {


### PR DESCRIPTION
Untitled pane items respond to `getURI` but return `undefined`, which breaks `url.parse()`. I'm fixing this by making `URIPattern` always return false for undefined or null URIs.

Fixes #1443.