### PR TITLE
URIPattern.match() returns a URIMatch

### DIFF
--- a/lib/atom/uri-pattern.js
+++ b/lib/atom/uri-pattern.js
@@ -59,7 +59,7 @@ export default class URIPattern {
 
   matches(string) {
     if (string === undefined || string === null) {
-      return false;
+      return nonURIMatch;
     }
 
     const other = url.parse(string, true);

--- a/test/atom/uri-pattern.test.js
+++ b/test/atom/uri-pattern.test.js
@@ -20,8 +20,8 @@ describe('URIPattern', function() {
     });
 
     it('does not match undefined or null', function() {
-      assert.isFalse(exact.matches(undefined));
-      assert.isFalse(exact.matches(null));
+      assert.isFalse(exact.matches(undefined).ok());
+      assert.isFalse(exact.matches(null).ok());
     });
   });
 


### PR DESCRIPTION
Oops. This should actually fix #1443.