### PR TITLE
Fix so dialogs are canceled when pressing escape/closing them

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -648,7 +648,7 @@ export default class RootController extends React.Component {
       detailedMessage: `for the following files:\n${conflictedFiles}\n` +
         'Would you like to apply the changes with merge conflict markers, ' +
         'or open the text with merge conflict markers in a new file?',
-      buttons: ['Merge with conflict markers', 'Open in new file', 'Cancel undo'],
+      buttons: ['Merge with conflict markers', 'Open in new file', 'Cancel'],
     });
     if (choice === 0) {
       await this.proceedWithLastDiscardUndo(results, partialDiscardFilePath);

--- a/lib/get-repo-pipeline-manager.js
+++ b/lib/get-repo-pipeline-manager.js
@@ -19,7 +19,7 @@ export default function({confirm, notificationManager, workspace}) {
       const choice = confirm({
         message: 'Are you sure you want to force push?',
         detailedMessage: 'This operation could result in losing data on the remote.',
-        buttons: ['Force Push', 'Cancel Push'],
+        buttons: ['Force Push', 'Cancel'],
       });
       if (choice !== 0) { /* do nothing */ } else { await next(); }
     } else {


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The label for canceling a dialog needs to be "Cancel" or "No" so that when canceling the dialog either by pressing escape or by closing the dialog cancels the dialog. Otherwise these actions default to the first item. This can be a bad default choice for the force push dialog which would force push when you close the dialog.

![image](https://user-images.githubusercontent.com/1058982/39743989-02605f5e-52a3-11e8-9ce5-2445a2f65534.png)

### Alternate Designs

There is a cancelId option [according to the electron documentation](https://electronjs.org/docs/api/dialog) but this is not supported on Windows.

### Benefits

* Don't accidentally force push or merge with conflict markers when the user intended to cancel the dialog
* Moves the cancel button to where it should be

### Possible Drawbacks

* Someone relies on pressing escape to execute a force push? :sweat_smile: 

### Applicable Issues

Fixes https://github.com/atom/github/issues/1368