### PR TITLE
Restore ability to commit when using Atom with Electron 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "compare-sets": "1.0.1",
     "dugite": "1.63.0",
     "event-kit": "2.4.0",
-    "fs-extra": "6.0.0",
+    "fs-extra": "4.0.3",
     "graphql": "0.13.2",
     "keytar": "4.2.1",
     "lodash.memoize": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "main": "./lib/index",
-  "version": "0.14.0-3",
+  "version": "0.14.0-4",
   "description": "GitHub integration",
   "repository": "https://github.com/atom/github",
   "license": "MIT",


### PR DESCRIPTION
### Motivation

With the current version of the GitHub package, it's not possible to create a commit on macOS when using an Electron 2.0 build of Atom:

1. Install Atom built with Electron 2.0 and github package 0.14.0-3 [[atom-mac.zip](https://7476-3228505-gh.circle-artifacts.com/0/Users/distiller/atom/out/atom-mac.zip)]
2. Open any git repository in Atom
3. Change a file and save it
4. Open the git tab and stage the changes
5. Click the "commit" button
6. Observe that the change was not committed
7. Open the console and observe the following error:
    > Uncaught (in promise) Error: ENOTDIR: not a directory, copyfile '/Applications/Atom.app/Contents/Resources/app.asar/node_modules/github/bin/git-askpass-atom.sh' -> '/tmp/github-11848-53871-116kyba.1tjh/git-askpass-atom.sh'

### Suspected cause

In https://github.com/atom/atom/pull/17273#issuecomment-387496222, @smashwilson noted:

> here's the failing `fs.copy` call:
>
> https://github.com/atom/github/blob/8dedd1c857a265a2794a65efb5d9aa341466aba8/lib/git-temp-dir.js#L33-L36
>
> We're using the [fs-extra](https://www.npmjs.com/package/fs-extra) module for extra filesystem operations (and promisification).

And in chat, @smashwilson commented:

> I suspect the problem is a regression in Electron's asar integration - the fs-extra (or fs) module is no longer able to see directories within `~/src/atom/atom/out/Atom.app/Contents/Resources/app.asar/`.

It looks like other projects are seeing similar issues with fs-extra 5.0 and newer:

> We almost completely rewrote copySync in v5, so it doesn't surprise me that there's a few bugs here and there. -- https://github.com/jprichardson/node-fs-extra/issues/546

### Proposed remedy

Since the GitHub package only recently upgraded from fs-extra 2.1.2 to 6.0.0 two months ago in https://github.com/atom/github/pull/1350 and https://github.com/atom/github/pull/1427, it seems like the most expedient remedy is to drop back down to a pre-5.0 version for the time being. This pull request uses fs-extra 4.0.3, which is the highest version in the 4.x series.

This change restores the ability to commit with the GitHub package on Electron 2.0, and it unblocks https://github.com/atom/atom/pull/17273. :sweat_smile: