### PR TITLE
GitTabItem is the root of the git tab subtree

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -18,7 +18,7 @@ import GitTimingsView from '../views/git-timings-view';
 import GithubTabController from './github-tab-controller';
 import FilePatchController from './file-patch-controller';
 import IssueishPaneItem from '../items/issueish-pane-item';
-import GitTabController from './git-tab-controller';
+import GitTabItem from '../items/git-tab-item';
 import StatusBarTileController from './status-bar-tile-controller';
 import RepositoryConflictController from './repository-conflict-controller';
 import GithubLoginModel from '../models/github-login-model';
@@ -182,7 +182,7 @@ export default class RootController extends React.Component {
             stubItem={this.props.gitTabStubItem}
             itemHolder={this.refGitTabController}
             activate={this.props.startOpen}>
-            <GitTabController
+            <GitTabItem
               ref={this.refGitTabController.setter}
               workspace={this.props.workspace}
               commandRegistry={this.props.commandRegistry}


### PR DESCRIPTION
Er. So when I _thought_ I was testing #1458 out in Atom in dev mode, I'd unlinked atom/github, so I wasn't actually testing anything and I broke the world.

Fortunately the fix is pretty easy.