### PR TITLE
stop calling `repository.didUpdate` when commit message changes.

### DIFF
--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -45,11 +45,7 @@ export default class Present extends State {
   }
 
   setCommitMessage(message) {
-    const oldMessage = this.commitMessage;
     this.commitMessage = message;
-    if (oldMessage !== message) {
-      this.didUpdate();
-    }
   }
 
   getCommitMessage() {

--- a/test/controllers/commit-controller.test.js
+++ b/test/controllers/commit-controller.test.js
@@ -87,6 +87,16 @@ describe('CommitController', function() {
       assert.strictEqual(wrapper.find('CommitView').prop('message'), 'some message');
     });
 
+    it('repository.didUpdate is not called when commit message changes', function() {
+      repository.setCommitMessage('some message');
+      const wrapper = shallow(app, {disableLifecycleMethods: true}).instance();
+      sinon.spy(wrapper.props.repository.state, 'didUpdate');
+      assert.strictEqual(wrapper.getCommitMessage(), 'some message');
+      wrapper.handleMessageChange('new message');
+      assert.strictEqual(wrapper.getCommitMessage(), 'new message');
+      assert.isFalse(wrapper.props.repository.state.didUpdate.called);
+    });
+
     describe('when a merge message is defined', function() {
       it('is set to the merge message when merging', function() {
         app = React.cloneElement(app, {isMerging: true, mergeMessage: 'merge conflict!'});

--- a/test/controllers/commit-controller.test.js
+++ b/test/controllers/commit-controller.test.js
@@ -87,7 +87,7 @@ describe('CommitController', function() {
       assert.strictEqual(wrapper.find('CommitView').prop('message'), 'some message');
     });
 
-    it('repository.didUpdate is not called when commit message changes', function() {
+    it('changing commit message does not cause the repository to update', function() {
       repository.setCommitMessage('some message');
       const wrapper = shallow(app, {disableLifecycleMethods: true}).instance();
       sinon.spy(wrapper.props.repository.state, 'didUpdate');

--- a/test/controllers/commit-controller.test.js
+++ b/test/controllers/commit-controller.test.js
@@ -87,7 +87,7 @@ describe('CommitController', function() {
       assert.strictEqual(wrapper.find('CommitView').prop('message'), 'some message');
     });
 
-    it('changing commit message does not cause the repository to update', function() {
+    it('does not cause the repository to update when commit message changes', function() {
       repository.setCommitMessage('some message');
       const wrapper = shallow(app, {disableLifecycleMethods: true}).instance();
       sinon.spy(wrapper.props.repository.state, 'didUpdate');


### PR DESCRIPTION
We are performing a bunch of unnecessary operations when the commit message changes.  It's causing some slowness.  

See https://github.com/atom/github/issues/1463 for details.

As far as I can tell, updating the repository when the commit message changes may have been necessary at some point in the past (like for the old way amending used to work, perhaps?) But it doesn't seem to be useful now.  Nevertheless, it's important to test carefully here to make sure removing this won't cause any surprise regressions.

**Test Plan**

manually tested the following flows:
- make a commit from Git pane, with and without co authors
- undo a commit, with and without co authors
- make a commit with expanded editor
- toggle back and forth between expanded editor and commit editor in Git pane
- make a commit from the command line.  Verify that commit shows up in recent commit history.

unit tests
- added a test that spies on the function we don't want to be called.  Negated assertions to prove that it's actually testing the thing we care about.