### PR TITLE
Log WorkdirCache errors to the console

### DIFF
--- a/lib/models/workdir-cache.js
+++ b/lib/models/workdir-cache.js
@@ -50,6 +50,11 @@ export default class WorkdirCache {
       const gitDir = await CompositeGitStrategy.create(startDir).exec(['rev-parse', '--absolute-git-dir']);
       return this.revParse(path.resolve(gitDir, '..'));
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Unable to locate git workspace root for ${startPath}. Expected if ${startPath} is not in a git repository.`,
+        e,
+      );
       return null;
     }
   }


### PR DESCRIPTION
@jasonrudolph saw something weird with the `WorkdirCache` on 0.15: a call to `WorkdirCache.revParse()` was returning `null` for a path that was pretty clearly within a git repository (a gitdir, to be exact). Calling `git rev-parse` manually at that path and its parent on the command line behaved normally.

We currently have a Pokémon catch block in place to handle `git rev-parse` errors:

https://github.com/atom/github/blob/ff5fb6ce173b2b797c7c7625e409111957dfd214/lib/models/workdir-cache.js#L52-L54

My theory is that this is overzealously catching a (possibly non-git?) error that would show us the real problem here.

As a temporary measure to gather more data, I'm adding a `console.error()` call to dump that error before returning `null`.

In the long term, we'll likely want to keep something like this in place, but maybe gated by an `instanceof GitError` check or something.