### PR TITLE
Improve ListSelection change detection in StagingView

### DIFF
--- a/lib/models/list-selection.js
+++ b/lib/models/list-selection.js
@@ -157,6 +157,7 @@ export default class ListSelection {
       mostRecentEnd++;
     }
 
+    let changed = false;
     const newSelections = [mostRecent];
     for (let i = 1; i < this.selections.length;) {
       const current = this.selections[i];
@@ -179,6 +180,7 @@ export default class ListSelection {
               newSelections.push({head: mostRecentEnd + 1, tail: currentEnd});
             }
           }
+          changed = true;
           i++;
         } else {
           mostRecentStart = Math.min(mostRecentStart, currentStart);
@@ -190,6 +192,7 @@ export default class ListSelection {
             mostRecent.head = mostRecentStart;
             mostRecent.tail = mostRecentEnd;
           }
+          changed = true;
           i++;
         }
       } else {
@@ -198,9 +201,12 @@ export default class ListSelection {
       }
     }
 
-    if (mostRecent.negate) { newSelections.shift(); }
+    if (mostRecent.negate) {
+      changed = true;
+      newSelections.shift();
+    }
 
-    return this.copy({selections: newSelections});
+    return changed ? this.copy({selections: newSelections}) : this;
   }
 
   getSelectedItems() {

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -115,10 +115,6 @@ export default class StagingView extends React.Component {
     this.mouseSelectionInProgress = false;
     this.listElementsByItem = new WeakMap();
     this.refRoot = null;
-    this.last = {
-      workingDirectoryPath: this.props.workingDirectoryPath,
-      selection: this.state.selection,
-    };
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -156,19 +152,16 @@ export default class StagingView extends React.Component {
     );
   }
 
-  componentDidUpdate() {
-    const isRepoSame = this.last.workingDirectoryPath === this.props.workingDirectoryPath;
+  componentDidUpdate(prevProps, prevState) {
+    const isRepoSame = prevProps.workingDirectoryPath === this.props.workingDirectoryPath;
     const hasSelectionsPresent =
-      this.last.selection.getSelectedItems().size > 0 &&
+      prevState.selection.getSelectedItems().size > 0 &&
       this.state.selection.getSelectedItems().size > 0;
-    const selectionChanged = this.state.selection !== this.last.selection;
+    const selectionChanged = this.state.selection !== prevState.selection;
 
     if (isRepoSame && hasSelectionsPresent && selectionChanged) {
       this.debouncedDidChangeSelectedItem();
     }
-
-    this.last.selection = this.state.selection;
-    this.last.workingDirectoryPath = this.props.workingDirectoryPath;
 
     const headItem = this.state.selection.getHeadItem();
     if (headItem) {


### PR DESCRIPTION
`ListSelection#coalesce()` was returning a copied `ListSelection` even if it didn't actually change any selections. This caused `StagingView#componentDidUpdate()` to trigger the "selection changed" method even when the selection didn't actually change, which in turn showed the current FilePatchItem.

Another take on #1444. I was actually able to consistently reproduce this and confirm that it was fixed, but I don't know for sure that this is _only_ reason it can happen.