### PR TITLE
Populate co-authors from mentionable users from the GitHub API

### DIFF
--- a/keymaps/git.cson
+++ b/keymaps/git.cson
@@ -70,3 +70,4 @@
   'home': 'github:co-author:home'
   'end': 'github:co-author:end'
   'delete': 'github:co-author:delete'
+  'shift-backspace': 'github:co-author-exclude'

--- a/lib/controllers/commit-controller.js
+++ b/lib/controllers/commit-controller.js
@@ -7,7 +7,7 @@ import {CompositeDisposable} from 'event-kit';
 import fs from 'fs-extra';
 
 import CommitView from '../views/commit-view';
-import {AuthorPropType} from '../prop-types';
+import {AuthorPropType, UserStorePropType} from '../prop-types';
 import {autobind} from '../helpers';
 
 export const COMMIT_GRAMMAR_SCOPE = 'text.git-commit';
@@ -31,7 +31,7 @@ export default class CommitController extends React.Component {
     stagedChangesExist: PropTypes.bool.isRequired,
     lastCommit: PropTypes.object.isRequired,
     currentBranch: PropTypes.object.isRequired,
-    mentionableUsers: PropTypes.arrayOf(AuthorPropType),
+    userStore: UserStorePropType.isRequired,
     selectedCoAuthors: PropTypes.arrayOf(AuthorPropType),
     updateSelectedCoAuthors: PropTypes.func,
     prepareToCommit: PropTypes.func.isRequired,
@@ -105,7 +105,7 @@ export default class CommitController extends React.Component {
         onChangeMessage={this.handleMessageChange}
         toggleExpandedCommitMessageEditor={this.toggleExpandedCommitMessageEditor}
         deactivateCommitBox={this.isCommitMessageEditorExpanded()}
-        mentionableUsers={this.props.mentionableUsers}
+        userStore={this.props.userStore}
         selectedCoAuthors={this.props.selectedCoAuthors}
         updateSelectedCoAuthors={this.props.updateSelectedCoAuthors}
       />

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 
 import GitTabView from '../views/git-tab-view';
 import UserStore from '../models/user-store';
-import Author from '../models/author';
 import {CommitPropType, BranchPropType, FilePatchItemPropType, MergeConflictItemPropType} from '../prop-types';
 import {autobind} from '../helpers';
 

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -66,12 +66,7 @@ export default class GitTabController extends React.Component {
       selectedCoAuthors: [],
     };
 
-    this.userStore = new UserStore({
-      repository: this.props.repository,
-      onDidUpdate: users => {
-        this.setState({mentionableUsers: users});
-      },
-    });
+    this.userStore = new UserStore({repository: this.props.repository});
   }
 
   render() {
@@ -135,16 +130,8 @@ export default class GitTabController extends React.Component {
     this.refView.refRoot.addEventListener('focusin', this.rememberLastFocus);
   }
 
-  componentDidUpdate(prevProps) {
-    if (prevProps.repository !== this.props.repository) {
-      this.userStore = new UserStore({
-        repository: this.props.repository,
-        onDidUpdate: users => {
-          this.setState({mentionableUsers: users});
-        },
-      });
-    }
-
+  componentDidUpdate() {
+    this.userStore.setRepository(this.props.repository);
     this.refreshResolutionProgress(false, false);
   }
 

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -63,7 +63,6 @@ export default class GitTabController extends React.Component {
     this.refView = null;
 
     this.state = {
-      mentionableUsers: [],
       selectedCoAuthors: [],
     };
 
@@ -89,7 +88,7 @@ export default class GitTabController extends React.Component {
         mergeConflicts={this.props.mergeConflicts}
         workingDirectoryPath={this.props.workingDirectoryPath}
         mergeMessage={this.props.mergeMessage}
-        mentionableUsers={this.state.mentionableUsers}
+        userStore={this.userStore}
         selectedCoAuthors={this.state.selectedCoAuthors}
         updateSelectedCoAuthors={this.updateSelectedCoAuthors}
 

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -69,6 +69,7 @@ export default class GitTabController extends React.Component {
     this.userStore = new UserStore({
       repository: this.props.repository,
       login: this.props.loginModel,
+      config: this.props.config,
     });
   }
 

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 
 import GitTabView from '../views/git-tab-view';
 import UserStore from '../models/user-store';
+import Author from '../models/author';
 import {CommitPropType, BranchPropType, FilePatchItemPropType, MergeConflictItemPropType} from '../prop-types';
 import {autobind} from '../helpers';
 
@@ -245,7 +246,7 @@ export default class GitTabController extends React.Component {
 
   updateSelectedCoAuthors(selectedCoAuthors, newAuthor) {
     if (newAuthor) {
-      this.userStore.addUsers({[newAuthor.email]: newAuthor.name});
+      this.userStore.addUsers([newAuthor]);
       selectedCoAuthors = selectedCoAuthors.concat([newAuthor]);
     }
     this.setState({selectedCoAuthors});

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -15,6 +15,7 @@ export default class GitTabController extends React.Component {
 
   static propTypes = {
     repository: PropTypes.object.isRequired,
+    loginModel: PropTypes.object.isRequired,
 
     lastCommit: CommitPropType.isRequired,
     recentCommits: PropTypes.arrayOf(CommitPropType).isRequired,
@@ -65,7 +66,10 @@ export default class GitTabController extends React.Component {
       selectedCoAuthors: [],
     };
 
-    this.userStore = new UserStore({repository: this.props.repository});
+    this.userStore = new UserStore({
+      repository: this.props.repository,
+      login: this.props.loginModel,
+    });
   }
 
   render() {
@@ -131,6 +135,7 @@ export default class GitTabController extends React.Component {
 
   componentDidUpdate() {
     this.userStore.setRepository(this.props.repository);
+    this.userStore.setLoginModel(this.props.loginModel);
     this.refreshResolutionProgress(false, false);
   }
 

--- a/lib/controllers/remote-pr-controller.js
+++ b/lib/controllers/remote-pr-controller.js
@@ -4,9 +4,10 @@ import yubikiri from 'yubikiri';
 import {shell} from 'electron';
 
 import {RemotePropType, BranchSetPropType} from '../prop-types';
+import LoadingView from '../views/loading-view';
 import GithubLoginView from '../views/github-login-view';
 import ObserveModel from '../views/observe-model';
-import {UNAUTHENTICATED} from '../shared/keytar-strategy';
+import {UNAUTHENTICATED, INSUFFICIENT} from '../shared/keytar-strategy';
 import {nullRemote} from '../models/remote';
 import PrInfoController from './pr-info-controller';
 import {autobind} from '../helpers';
@@ -49,29 +50,34 @@ export default class RemotePrController extends React.Component {
     );
   }
 
-  renderWithData(loginData) {
-    const {
-      host, remote, branches, loginModel, selectedPrUrl,
-      aheadCount, pushInProgress, onSelectPr, onUnpinPr,
-    } = this.props;
-    const token = loginData.token;
+  renderWithData({token}) {
+    let inner;
+    if (token === null) {
+      inner = <LoadingView />;
+    } else if (token === UNAUTHENTICATED) {
+      inner = <GithubLoginView onLogin={this.handleLogin} scopeExpansion={false} />;
+    } else if (token === INSUFFICIENT) {
+      inner = <GithubLoginView onLogin={this.handleLogin} scopeExpansion={true} />;
+    } else {
+      const {
+        host, remote, branches, loginModel, selectedPrUrl,
+        aheadCount, pushInProgress, onSelectPr, onUnpinPr,
+      } = this.props;
 
-    return (
-      <div className="github-RemotePrController">
-        {token && token !== UNAUTHENTICATED &&
-          <PrInfoController
-            {...{
-              host, remote, branches, token, loginModel, selectedPrUrl,
-              aheadCount, pushInProgress, onSelectPr, onUnpinPr,
-            }}
-            onLogin={this.handleLogin}
-            onLogout={this.handleLogout}
-            onCreatePr={this.handleCreatePr}
-          />
-        }
-        {(!token || token === UNAUTHENTICATED) && <GithubLoginView onLogin={this.handleLogin} />}
-      </div>
-    );
+      inner = (
+        <PrInfoController
+          {...{
+            host, remote, branches, token, loginModel, selectedPrUrl,
+            aheadCount, pushInProgress, onSelectPr, onUnpinPr,
+          }}
+          onLogin={this.handleLogin}
+          onLogout={this.handleLogout}
+          onCreatePr={this.handleCreatePr}
+        />
+      );
+    }
+
+    return <div className="github-RemotePrController">{inner}</div>;
   }
 
   handleLogin(token) {

--- a/lib/controllers/remote-pr-controller.js
+++ b/lib/controllers/remote-pr-controller.js
@@ -55,9 +55,15 @@ export default class RemotePrController extends React.Component {
     if (token === null) {
       inner = <LoadingView />;
     } else if (token === UNAUTHENTICATED) {
-      inner = <GithubLoginView onLogin={this.handleLogin} scopeExpansion={false} />;
+      inner = <GithubLoginView onLogin={this.handleLogin} />;
     } else if (token === INSUFFICIENT) {
-      inner = <GithubLoginView onLogin={this.handleLogin} scopeExpansion={true} />;
+      inner = (
+        <GithubLoginView onLogin={this.handleLogin}>
+          <p>
+            Your token no longer has sufficient authorizations. Please re-authenticate and generate a new one.
+          </p>
+        </GithubLoginView>
+      );
     } else {
       const {
         host, remote, branches, loginModel, selectedPrUrl,

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -193,6 +193,7 @@ export default class RootController extends React.Component {
               confirm={this.props.confirm}
               config={this.props.config}
               repository={this.props.repository}
+              loginModel={this.loginModel}
               initializeRepo={this.initializeRepo}
               resolutionProgress={this.props.resolutionProgress}
               ensureGitTab={this.gitTabTracker.ensureVisible}

--- a/lib/models/author.js
+++ b/lib/models/author.js
@@ -26,4 +26,46 @@ export default class Author {
   hasLogin() {
     return this.login !== null;
   }
+
+  isPresent() {
+    return true;
+  }
+
+  toString() {
+    let s = `${this.fullName} <${this.email}>`;
+    if (this.hasLogin()) {
+      s += ` @${this.login}`;
+    }
+    return s;
+  }
 }
+
+export const nullAuthor = {
+  getEmail() {
+    return '';
+  },
+
+  getFullName() {
+    return '';
+  },
+
+  getLogin() {
+    return null;
+  },
+
+  isNoReply() {
+    return false;
+  },
+
+  hasLogin() {
+    return false;
+  },
+
+  isPresent() {
+    return false;
+  },
+
+  toString() {
+    return 'null author';
+  },
+};

--- a/lib/models/author.js
+++ b/lib/models/author.js
@@ -1,0 +1,29 @@
+export const NO_REPLY_GITHUB_EMAIL = 'noreply@github.com';
+
+export default class Author {
+  constructor(email, fullName, login = null) {
+    this.email = email;
+    this.fullName = fullName;
+    this.login = login;
+  }
+
+  getEmail() {
+    return this.email;
+  }
+
+  getFullName() {
+    return this.fullName;
+  }
+
+  getLogin() {
+    return this.login;
+  }
+
+  isNoReply() {
+    return this.email === NO_REPLY_GITHUB_EMAIL;
+  }
+
+  hasLogin() {
+    return this.login !== null;
+  }
+}

--- a/lib/models/author.js
+++ b/lib/models/author.js
@@ -31,12 +31,22 @@ export default class Author {
     return true;
   }
 
+  matches(other) {
+    return this.getEmail() === other.getEmail();
+  }
+
   toString() {
     let s = `${this.fullName} <${this.email}>`;
     if (this.hasLogin()) {
       s += ` @${this.login}`;
     }
     return s;
+  }
+
+  static compare(a, b) {
+    if (a.getFullName() < b.getFullName()) { return -1; }
+    if (a.getFullName() > b.getFullName()) { return 1; }
+    return 0;
   }
 }
 
@@ -63,6 +73,10 @@ export const nullAuthor = {
 
   isPresent() {
     return false;
+  },
+
+  matches(other) {
+    return other === this;
   },
 
   toString() {

--- a/lib/models/author.js
+++ b/lib/models/author.js
@@ -1,10 +1,17 @@
+const NEW = Symbol('new');
+
 export const NO_REPLY_GITHUB_EMAIL = 'noreply@github.com';
 
 export default class Author {
-  constructor(email, fullName, login = null) {
+  constructor(email, fullName, login = null, isNew = null) {
     this.email = email;
     this.fullName = fullName;
     this.login = login;
+    this.new = isNew === NEW;
+  }
+
+  static createNew(email, fullName) {
+    return new this(email, fullName, null, NEW);
   }
 
   getEmail() {
@@ -25,6 +32,10 @@ export default class Author {
 
   hasLogin() {
     return this.login !== null;
+  }
+
+  isNew() {
+    return this.new;
   }
 
   isPresent() {
@@ -68,6 +79,10 @@ export const nullAuthor = {
   },
 
   hasLogin() {
+    return false;
+  },
+
+  isNew() {
     return false;
   },
 

--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -46,7 +46,7 @@ export default class GithubLoginModel {
       return UNAUTHENTICATED;
     }
 
-    if (/^https?:/.test(account)) {
+    if (/^https?:\/\//.test(account)) {
       // Avoid storing tokens in memory longer than necessary. Let's cache token scope checks by storing a set of
       // checksums instead.
       const hash = crypto.createHash('md5');
@@ -54,17 +54,24 @@ export default class GithubLoginModel {
       const fingerprint = hash.digest('base64');
 
       if (!this.checked.has(fingerprint)) {
-        const scopes = new Set(await this.getScopes(account, password));
+        try {
+          const scopes = new Set(await this.getScopes(account, password));
 
-        for (const scope of this.constructor.REQUIRED_SCOPES) {
-          if (!scopes.has(scope)) {
-            // Token doesn't have enough OAuth scopes, need to reauthenticate
-            return INSUFFICIENT;
+          for (const scope of this.constructor.REQUIRED_SCOPES) {
+            if (!scopes.has(scope)) {
+              // Token doesn't have enough OAuth scopes, need to reauthenticate
+              return INSUFFICIENT;
+            }
           }
-        }
 
-        // We're good
-        this.checked.add(fingerprint);
+          // We're good
+          this.checked.add(fingerprint);
+        } catch (e) {
+          // Bad credential most likely
+          // eslint-disable-next-line no-console
+          console.error(`Unable to validate token scopes against ${account}`, e);
+          return UNAUTHENTICATED;
+        }
       }
     }
 

--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -1,10 +1,15 @@
+import crypto from 'crypto';
 import {Emitter} from 'event-kit';
 
-import {UNAUTHENTICATED, createStrategy} from '../shared/keytar-strategy';
+import {UNAUTHENTICATED, INSUFFICIENT, createStrategy} from '../shared/keytar-strategy';
 
 let instance = null;
 
 export default class GithubLoginModel {
+  // Be sure that we're requesting at least this many scopes on the token we grant through github.atom.io or we'll
+  // give everyone a really frustrating experience ;-)
+  static REQUIRED_SCOPES = ['repo', 'user:email']
+
   static get() {
     if (!instance) {
       instance = new GithubLoginModel();
@@ -16,6 +21,7 @@ export default class GithubLoginModel {
     this._Strategy = Strategy;
     this._strategy = null;
     this.emitter = new Emitter();
+    this.checked = new Set();
   }
 
   async getStrategy() {
@@ -34,11 +40,34 @@ export default class GithubLoginModel {
 
   async getToken(account) {
     const strategy = await this.getStrategy();
-    let password = await strategy.getPassword('atom-github', account);
+    const password = await strategy.getPassword('atom-github', account);
     if (!password) {
       // User is not logged in
-      password = UNAUTHENTICATED;
+      return UNAUTHENTICATED;
     }
+
+    if (/^https?:/.test(account)) {
+      // Avoid storing tokens in memory longer than necessary. Let's cache token scope checks by storing a set of
+      // checksums instead.
+      const hash = crypto.createHash('md5');
+      hash.update(password);
+      const fingerprint = hash.digest('base64');
+
+      if (!this.checked.has(fingerprint)) {
+        const scopes = new Set(await this.getScopes(account, password));
+
+        for (const scope of this.constructor.REQUIRED_SCOPES) {
+          if (!scopes.has(scope)) {
+            // Token doesn't have enough OAuth scopes, need to reauthenticate
+            return INSUFFICIENT;
+          }
+        }
+
+        // We're good
+        this.checked.add(fingerprint);
+      }
+    }
+
     return password;
   }
 
@@ -52,6 +81,23 @@ export default class GithubLoginModel {
     const strategy = await this.getStrategy();
     await strategy.deletePassword('atom-github', account);
     this.didUpdate();
+  }
+
+  async getScopes(host, token) {
+    if (atom.inSpecMode()) {
+      throw new Error('Attempt to check token scopes in specs');
+    }
+
+    const response = await fetch(host, {
+      method: 'HEAD',
+      headers: {Authorization: `bearer ${token}`},
+    });
+
+    if (response.status !== 200) {
+      throw new Error(`Unable to check token for OAuth scopes against ${host}: ${await response.text()}`);
+    }
+
+    return response.headers.get('X-OAuth-Scopes').split(/\s*,\s*/);
   }
 
   didUpdate() {

--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -41,7 +41,7 @@ export default class GithubLoginModel {
   async getToken(account) {
     const strategy = await this.getStrategy();
     const password = await strategy.getPassword('atom-github', account);
-    if (!password) {
+    if (!password || password === UNAUTHENTICATED) {
       // User is not logged in
       return UNAUTHENTICATED;
     }

--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -8,7 +8,7 @@ let instance = null;
 export default class GithubLoginModel {
   // Be sure that we're requesting at least this many scopes on the token we grant through github.atom.io or we'll
   // give everyone a really frustrating experience ;-)
-  static REQUIRED_SCOPES = ['repo', 'user:email']
+  static REQUIRED_SCOPES = ['repo', 'read:org', 'user:email']
 
   static get() {
     if (!instance) {

--- a/lib/models/remote.js
+++ b/lib/models/remote.js
@@ -33,6 +33,10 @@ export default class Remote {
     return this.getName();
   }
 
+  getSlug() {
+    return `${this.owner}/${this.repo}`;
+  }
+
   isPresent() {
     return true;
   }
@@ -88,6 +92,10 @@ export const nullRemote = {
 
   getNameOr(fallback) {
     return fallback;
+  },
+
+  getSlug() {
+    return '';
   },
 
   isPresent() {

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -233,7 +233,16 @@ export default class Present extends State {
       ],
       // eslint-disable-next-line no-shadow
       () => this.executePipelineAction('COMMIT', (message, options) => {
-        return this.git().commit(message, options);
+        const opts = (!options || !options.coAuthors)
+          ? options
+          : {
+            ...options,
+            coAuthors: options.coAuthors.map(author => {
+              return {email: author.getEmail(), name: author.getFullName()};
+            }),
+          };
+
+        return this.git().commit(message, opts);
       }, message, options),
     );
   }

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -11,6 +11,7 @@ import Hunk from '../hunk';
 import HunkLine from '../hunk-line';
 import DiscardHistory from '../discard-history';
 import Branch, {nullBranch} from '../branch';
+import Author from '../author';
 import BranchSet from '../branch-set';
 import Remote from '../remote';
 import Commit from '../commit';
@@ -616,8 +617,9 @@ export default class Present extends State {
     // For now we'll do the naive thing and invalidate anytime HEAD moves. This ensures that we get new authors
     // introduced by newly created commits or pulled commits.
     // This means that we are constantly re-fetching data. If performance becomes a concern we can optimize
-    return this.cache.getOrSet(Keys.authors, () => {
-      return this.git().getAuthors(options);
+    return this.cache.getOrSet(Keys.authors, async () => {
+      const authorMap = await this.git().getAuthors(options);
+      return Object.keys(authorMap).map(email => new Author(email, authorMap[email]));
     });
   }
 

--- a/lib/models/repository-states/state.js
+++ b/lib/models/repository-states/state.js
@@ -293,7 +293,7 @@ export default class State {
   // Author information
 
   getAuthors() {
-    return Promise.resolve({});
+    return Promise.resolve([]);
   }
 
   // Branches

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -6,6 +6,7 @@ import fs from 'fs-extra';
 import {getNullActionPipelineManager} from '../action-pipeline';
 import CompositeGitStrategy from '../composite-git-strategy';
 import Remote, {nullRemote} from './remote';
+import Author, {nullAuthor} from './author';
 import Branch from './branch';
 import {Loading, Absent, LoadingGuess, AbsentGuess} from './repository-states';
 
@@ -241,7 +242,10 @@ export default class Repository {
         }
       });
     }
-    return committer;
+
+    return committer.name !== null && committer.email !== null
+      ? new Author(committer.email, committer.name)
+      : nullAuthor;
   }
 }
 

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -35,16 +35,15 @@ export default class UserStore {
     this.setCommitter(committer);
 
     const githubRemotes = (await this.repository.getRemotes()).filter(remote => remote.isGithubRepo());
-    const users = githubRemotes.length === 0
+    githubRemotes.length === 0
       ? await this.loadUsersFromLocalRepo()
       : await this.loadUsersFromGraphQL(githubRemotes);
-
-    this.addUsers(users);
-    this.didUpdate();
   }
 
-  loadUsersFromLocalRepo() {
-    return this.repository.getAuthors({max: MAX_COMMITS});
+  async loadUsersFromLocalRepo() {
+    const users = await this.repository.getAuthors({max: MAX_COMMITS});
+    this.addUsers(users);
+    this.didUpdate();
   }
 
   loadUsersFromGraphQL(remotes) {

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -1,4 +1,5 @@
 import yubikiri from 'yubikiri';
+import {Emitter} from 'event-kit';
 
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
 import Author, {nullAuthor} from './author';
@@ -8,10 +9,10 @@ import ModelObserver from './model-observer';
 const MAX_COMMITS = 5000;
 
 export default class UserStore {
-  constructor({repository, onDidUpdate}) {
-    this.onDidUpdate = onDidUpdate || (() => {});
-    // TODO: [ku 3/2018] Consider using Dexie (indexDB wrapper) like Desktop and persist users across sessions
+  constructor({repository}) {
+    this.emitter = new Emitter();
 
+    // TODO: [ku 3/2018] Consider using Dexie (indexDB wrapper) like Desktop and persist users across sessions
     this.allUsers = new Map();
     this.users = [];
     this.committer = nullAuthor;
@@ -141,7 +142,11 @@ export default class UserStore {
   }
 
   didUpdate() {
-    this.onDidUpdate(this.getUsers());
+    this.emitter.emit('did-update', this.getUsers());
+  }
+
+  onDidUpdate(callback) {
+    return this.emitter.on('did-update', callback);
   }
 
   getUsers() {

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -128,6 +128,10 @@ async function getMentionableUsers(remote, callback) {
     const connection = response.data.repository.mentionableUsers;
 
     callback(connection.nodes.reduce((acc, node) => {
+      if (node.email === '') {
+        node.email = `${node.login}@users.noreply.github.com`;
+      }
+
       acc[node.email] = node.name;
       return acc;
     }, {}));

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -3,7 +3,7 @@ import {Emitter} from 'event-kit';
 
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
 import Author, {nullAuthor} from './author';
-import {UNAUTHENTICATED} from '../shared/keytar-strategy';
+import {UNAUTHENTICATED, INSUFFICIENT} from '../shared/keytar-strategy';
 import ModelObserver from './model-observer';
 
 // This is a guess about what a reasonable value is. Can adjust if performance is poor.
@@ -109,7 +109,7 @@ export default class UserStore {
     }
 
     const token = await loginModel.getToken('https://api.github.com');
-    if (token === UNAUTHENTICATED) {
+    if (token === UNAUTHENTICATED || token === INSUFFICIENT) {
       return;
     }
 

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -1,5 +1,5 @@
 import yubikiri from 'yubikiri';
-import {Emitter} from 'event-kit';
+import {Emitter, CompositeDisposable} from 'event-kit';
 
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
 import Author, {nullAuthor} from './author';
@@ -43,17 +43,20 @@ class GraphQLCache {
 }
 
 export default class UserStore {
-  constructor({repository, login}) {
+  constructor({repository, login, config}) {
     this.emitter = new Emitter();
+    this.subs = new CompositeDisposable();
 
     // TODO: [ku 3/2018] Consider using Dexie (indexDB wrapper) like Desktop and persist users across sessions
     this.allUsers = new Map();
+    this.excludedUsers = new Set();
     this.users = [];
     this.committer = nullAuthor;
 
     this.last = {
       source: source.PENDING,
       repository: null,
+      excludedUsers: this.excludedUsers,
     };
     this.cache = new GraphQLCache();
 
@@ -71,6 +74,20 @@ export default class UserStore {
       didUpdate: () => this.loadUsers(),
     });
     this.loginObserver.setActiveModel(login);
+
+    this.subs.add(
+      config.observe('github.excludedUsers', value => {
+        this.excludedUsers = new Set(
+          (value || '').split(/\s*,\s*/).filter(each => each.length > 0),
+        );
+        return this.loadUsers();
+      }),
+    );
+  }
+
+  dispose() {
+    this.subs.dispose();
+    this.emitter.dispose();
   }
 
   async loadUsers() {
@@ -165,14 +182,17 @@ export default class UserStore {
   }
 
   addUsers(users, nextSource) {
+    let changed = false;
+
     if (
       nextSource !== this.last.source ||
-      this.repositoryObserver.getActiveModel() !== this.last.repository
+      this.repositoryObserver.getActiveModel() !== this.last.repository ||
+      this.excludedUsers !== this.last.excludedUsers
     ) {
+      changed = true;
       this.allUsers.clear();
     }
 
-    let changed = false;
     for (const author of users) {
       if (!this.allUsers.has(author.getEmail())) {
         changed = true;
@@ -185,6 +205,7 @@ export default class UserStore {
     }
     this.last.source = nextSource;
     this.last.repository = this.repositoryObserver.getActiveModel();
+    this.last.excludedUsers = this.excludedUsers;
   }
 
   finalize() {
@@ -193,6 +214,7 @@ export default class UserStore {
     for (const author of this.allUsers.values()) {
       if (author.matches(this.committer)) { continue; }
       if (author.isNoReply()) { continue; }
+      if (this.excludedUsers.has(author.getEmail())) { continue; }
 
       users.push(author);
     }

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -15,6 +15,33 @@ export const source = {
   GITHUBAPI: Symbol('github API'),
 };
 
+class GraphQLCache {
+  // One hour
+  static MAX_AGE_MS = 3.6e6
+
+  constructor() {
+    this.bySlug = new Map();
+  }
+
+  get(remote) {
+    const slug = remote.getSlug();
+    const {ts, data} = this.bySlug.get(slug) || {
+      ts: -Infinity,
+      data: {},
+    };
+
+    if (Date.now() - ts > this.constructor.MAX_AGE_MS) {
+      this.bySlug.delete(slug);
+      return null;
+    }
+    return data;
+  }
+
+  set(remote, data) {
+    this.bySlug.set(remote.getSlug(), {ts: Date.now(), data});
+  }
+}
+
 export default class UserStore {
   constructor({repository, login}) {
     this.emitter = new Emitter();
@@ -28,6 +55,7 @@ export default class UserStore {
       source: source.PENDING,
       repository: null,
     };
+    this.cache = new GraphQLCache();
 
     this.repositoryObserver = new ModelObserver({
       fetchData: r => yubikiri({
@@ -69,6 +97,12 @@ export default class UserStore {
   }
 
   async loadMentionableUsers(remote) {
+    const cached = this.cache.get(remote);
+    if (cached !== null) {
+      this.addUsers(cached, source.GITHUBAPI);
+      return;
+    }
+
     const loginModel = this.loginObserver.getActiveModel();
     if (!loginModel) {
       return;
@@ -83,6 +117,7 @@ export default class UserStore {
 
     let hasMore = true;
     let cursor = null;
+    const remoteUsers = [];
 
     while (hasMore) {
       const response = await fetchQuery({
@@ -112,18 +147,21 @@ export default class UserStore {
       });
 
       const connection = response.data.repository.mentionableUsers;
-
-      this.addUsers(connection.nodes.map(node => {
+      const authors = connection.nodes.map(node => {
         if (node.email === '') {
           node.email = `${node.login}@users.noreply.github.com`;
         }
 
         return new Author(node.email, node.name, node.login);
-      }), source.GITHUBAPI);
+      });
+      this.addUsers(authors, source.GITHUBAPI);
+      remoteUsers.push(...authors);
 
       cursor = connection.pageInfo.endCursor;
       hasMore = connection.pageInfo.hasNextPage;
     }
+
+    this.cache.set(remote, remoteUsers);
   }
 
   addUsers(users, nextSource) {

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -47,12 +47,13 @@ export default class UserStore {
     return this.repository.getAuthors({max: MAX_COMMITS});
   }
 
-  async loadUsersFromGraphQL(remotes) {
-    const mentionableUsers = await Promise.all(remotes.map(remote => getMentionableUsers(remote)));
-    return mentionableUsers.reduce((acc, list) => {
-      acc = {...acc, ...list};
-      return acc;
-    }, {});
+  loadUsersFromGraphQL(remotes) {
+    for (const remote of remotes) {
+      getMentionableUsers(remote, users => {
+        this.addUsers(users);
+        this.didUpdate();
+      });
+    }
   }
 
   addUsers(users) {
@@ -87,41 +88,51 @@ export default class UserStore {
   }
 }
 
-async function getMentionableUsers(remote) {
+async function getMentionableUsers(remote, callback) {
   const fetchQuery = RelayNetworkLayerManager.getExistingFetchQuery('https://api.github.com/graphql');
   if (!fetchQuery) {
     // No authentication token
-    return [];
+    return;
   }
 
-  const response = await fetchQuery({
-    name: 'GetMentionableUsers',
-    text: `
-      query GetMentionableUsers {
-        repository(owner: $owner, name: $name) {
-          mentionableUsers(first: $first, after: $after) {
-            nodes {
-              login
-              email
-              name
-            }
-            pageInfo {
-              hasNextPage
-              endCursor
+  let hasMore = true;
+  let cursor = null;
+
+  while (hasMore) {
+    const response = await fetchQuery({
+      name: 'GetMentionableUsers',
+      text: `
+        query GetMentionableUsers {
+          repository(owner: $owner, name: $name) {
+            mentionableUsers(first: $first, after: $after) {
+              nodes {
+                login
+                email
+                name
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
             }
           }
         }
-      }
-    `,
-  }, {
-    owner: remote.getOwner(),
-    name: remote.getRepo(),
-    first: 100,
-    after: null,
-  });
+      `,
+    }, {
+      owner: remote.getOwner(),
+      name: remote.getRepo(),
+      first: 100,
+      after: cursor,
+    });
 
-  return response.data.repository.mentionableUsers.nodes.reduce((acc, node) => {
-    acc[node.email] = node.name;
-    return acc;
-  }, {});
+    const connection = response.data.repository.mentionableUsers;
+
+    callback(connection.nodes.reduce((acc, node) => {
+      acc[node.email] = node.name;
+      return acc;
+    }, {}));
+
+    cursor = connection.pageInfo.endCursor;
+    hasMore = connection.pageInfo.hasNextPage;
+  }
 }

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -9,6 +9,12 @@ import ModelObserver from './model-observer';
 // This is a guess about what a reasonable value is. Can adjust if performance is poor.
 const MAX_COMMITS = 5000;
 
+export const source = {
+  PENDING: Symbol('pending'),
+  GITLOG: Symbol('git log'),
+  GITHUBAPI: Symbol('github API'),
+};
+
 export default class UserStore {
   constructor({repository, login}) {
     this.emitter = new Emitter();
@@ -17,6 +23,10 @@ export default class UserStore {
     this.allUsers = new Map();
     this.users = [];
     this.committer = nullAuthor;
+
+    this.last = {
+      source: source.PENDING,
+    };
 
     this.repositoryObserver = new ModelObserver({
       fetchData: r => yubikiri({
@@ -42,10 +52,10 @@ export default class UserStore {
     }
 
     this.setCommitter(data.committer);
-
     const githubRemotes = data.remotes.filter(remote => remote.isGithubRepo());
+
     if (githubRemotes.length === 0) {
-      this.addUsers(data.authors);
+      this.addUsers(data.authors, source.GITLOG);
     } else {
       await this.loadUsersFromGraphQL(githubRemotes);
     }
@@ -108,14 +118,18 @@ export default class UserStore {
         }
 
         return new Author(node.email, node.name, node.login);
-      }));
+      }), source.GITHUBAPI);
 
       cursor = connection.pageInfo.endCursor;
       hasMore = connection.pageInfo.hasNextPage;
     }
   }
 
-  addUsers(users) {
+  addUsers(users, nextSource) {
+    if (nextSource !== this.last.source) {
+      this.allUsers.clear();
+    }
+
     let changed = false;
     for (const author of users) {
       if (!this.allUsers.has(author.getEmail())) {
@@ -127,6 +141,7 @@ export default class UserStore {
     if (changed) {
       this.finalize();
     }
+    this.last.source = nextSource;
   }
 
   finalize() {

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -3,13 +3,14 @@ import {Emitter} from 'event-kit';
 
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
 import Author, {nullAuthor} from './author';
+import {UNAUTHENTICATED} from '../shared/keytar-strategy';
 import ModelObserver from './model-observer';
 
 // This is a guess about what a reasonable value is. Can adjust if performance is poor.
 const MAX_COMMITS = 5000;
 
 export default class UserStore {
-  constructor({repository}) {
+  constructor({repository, login}) {
     this.emitter = new Emitter();
 
     // TODO: [ku 3/2018] Consider using Dexie (indexDB wrapper) like Desktop and persist users across sessions
@@ -23,12 +24,19 @@ export default class UserStore {
         authors: r.getAuthors({max: MAX_COMMITS}),
         remotes: r.getRemotes(),
       }),
-      didUpdate: () => this.loadUsers(this.repositoryObserver.getActiveModelData()),
+      didUpdate: () => this.loadUsers(),
     });
     this.repositoryObserver.setActiveModel(repository);
+
+    this.loginObserver = new ModelObserver({
+      didUpdate: () => this.loadUsers(),
+    });
+    this.loginObserver.setActiveModel(login);
   }
 
-  async loadUsers(data) {
+  async loadUsers() {
+    const data = this.repositoryObserver.getActiveModelData();
+
     if (!data) {
       return;
     }
@@ -50,11 +58,17 @@ export default class UserStore {
   }
 
   async loadMentionableUsers(remote) {
-    const fetchQuery = RelayNetworkLayerManager.getExistingFetchQuery('https://api.github.com/graphql');
-    if (!fetchQuery) {
-      // No authentication token
+    const loginModel = this.loginObserver.getActiveModel();
+    if (!loginModel) {
       return;
     }
+
+    const token = await loginModel.getToken('https://api.github.com');
+    if (token === UNAUTHENTICATED) {
+      return;
+    }
+
+    const fetchQuery = RelayNetworkLayerManager.getFetchQuery('https://api.github.com/graphql', token);
 
     let hasMore = true;
     let cursor = null;

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -1,51 +1,45 @@
+import yubikiri from 'yubikiri';
+
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
 import Author, {nullAuthor} from './author';
+import ModelObserver from './model-observer';
 
 // This is a guess about what a reasonable value is. Can adjust if performance is poor.
 const MAX_COMMITS = 5000;
 
 export default class UserStore {
   constructor({repository, onDidUpdate}) {
-    this.repository = repository;
-    this.repository.onDidUpdate(() => {
-      this.loadUsers();
-    });
     this.onDidUpdate = onDidUpdate || (() => {});
     // TODO: [ku 3/2018] Consider using Dexie (indexDB wrapper) like Desktop and persist users across sessions
 
     this.allUsers = new Map();
     this.users = [];
     this.committer = nullAuthor;
-    this.populate();
+
+    this.repositoryObserver = new ModelObserver({
+      fetchData: r => yubikiri({
+        committer: r.getCommitter(),
+        authors: r.getAuthors({max: MAX_COMMITS}),
+        remotes: r.getRemotes(),
+      }),
+      didUpdate: () => this.loadUsers(this.repositoryObserver.getActiveModelData()),
+    });
+    this.repositoryObserver.setActiveModel(repository);
   }
 
-  populate() {
-    if (this.repository.isPresent()) {
-      this.loadUsers();
-    } else {
-      this.repository.onDidChangeState(({from, to}) => {
-        if (!from.isPresent() && to.isPresent()) {
-          this.loadUsers();
-        }
-      });
+  async loadUsers(data) {
+    if (!data) {
+      return;
     }
-  }
 
-  async loadUsers() {
-    const committer = await this.repository.getCommitter();
-    this.setCommitter(committer);
+    this.setCommitter(data.committer);
 
-    const githubRemotes = (await this.repository.getRemotes()).filter(remote => remote.isGithubRepo());
+    const githubRemotes = data.remotes.filter(remote => remote.isGithubRepo());
     if (githubRemotes.length === 0) {
-      await this.loadUsersFromLocalRepo();
+      this.addUsers(data.authors);
     } else {
       await this.loadUsersFromGraphQL(githubRemotes);
     }
-  }
-
-  async loadUsersFromLocalRepo() {
-    const users = await this.repository.getAuthors({max: MAX_COMMITS});
-    this.addUsers(users);
   }
 
   loadUsersFromGraphQL(remotes) {
@@ -132,6 +126,10 @@ export default class UserStore {
     users.sort(Author.compare);
     this.users = users;
     this.didUpdate();
+  }
+
+  setRepository(repository) {
+    this.repositoryObserver.setActiveModel(repository);
   }
 
   setCommitter(committer) {

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -167,6 +167,11 @@ export default class UserStore {
     this.repositoryObserver.setActiveModel(repository);
   }
 
+  setLoginModel(login) {
+    this.loginObserver.setActiveModel(login);
+    console.log('setLoginModel login model:', login);
+  }
+
   setCommitter(committer) {
     const changed = !this.committer.matches(committer);
     this.committer = committer;

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -88,7 +88,7 @@ export default class UserStore {
       const response = await fetchQuery({
         name: 'GetMentionableUsers',
         text: `
-          query GetMentionableUsers {
+          query GetMentionableUsers($owner: String!, $name: String!, $first: Int!, $after: String) {
             repository(owner: $owner, name: $name) {
               mentionableUsers(first: $first, after: $after) {
                 nodes {

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -26,6 +26,7 @@ export default class UserStore {
 
     this.last = {
       source: source.PENDING,
+      repository: null,
     };
 
     this.repositoryObserver = new ModelObserver({
@@ -126,7 +127,10 @@ export default class UserStore {
   }
 
   addUsers(users, nextSource) {
-    if (nextSource !== this.last.source) {
+    if (
+      nextSource !== this.last.source ||
+      this.repositoryObserver.getActiveModel() !== this.last.repository
+    ) {
       this.allUsers.clear();
     }
 
@@ -142,6 +146,7 @@ export default class UserStore {
       this.finalize();
     }
     this.last.source = nextSource;
+    this.last.repository = this.repositoryObserver.getActiveModel();
   }
 
   finalize() {

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -169,7 +169,6 @@ export default class UserStore {
 
   setLoginModel(login) {
     this.loginObserver.setActiveModel(login);
-    console.log('setLoginModel login model:', login);
   }
 
   setCommitter(committer) {

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -1,9 +1,8 @@
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
+import Author, {nullAuthor} from './author';
 
 // This is a guess about what a reasonable value is. Can adjust if performance is poor.
 const MAX_COMMITS = 5000;
-
-export const NO_REPLY_GITHUB_EMAIL = 'noreply@github.com';
 
 export default class UserStore {
   constructor({repository, onDidUpdate}) {
@@ -13,8 +12,10 @@ export default class UserStore {
     });
     this.onDidUpdate = onDidUpdate || (() => {});
     // TODO: [ku 3/2018] Consider using Dexie (indexDB wrapper) like Desktop and persist users across sessions
-    this.users = {};
-    this.committer = {};
+
+    this.allUsers = new Map();
+    this.users = [];
+    this.committer = nullAuthor;
     this.populate();
   }
 
@@ -35,32 +36,110 @@ export default class UserStore {
     this.setCommitter(committer);
 
     const githubRemotes = (await this.repository.getRemotes()).filter(remote => remote.isGithubRepo());
-    githubRemotes.length === 0
-      ? await this.loadUsersFromLocalRepo()
-      : await this.loadUsersFromGraphQL(githubRemotes);
+    if (githubRemotes.length === 0) {
+      await this.loadUsersFromLocalRepo();
+    } else {
+      await this.loadUsersFromGraphQL(githubRemotes);
+    }
   }
 
   async loadUsersFromLocalRepo() {
     const users = await this.repository.getAuthors({max: MAX_COMMITS});
     this.addUsers(users);
-    this.didUpdate();
   }
 
   loadUsersFromGraphQL(remotes) {
-    for (const remote of remotes) {
-      getMentionableUsers(remote, users => {
-        this.addUsers(users);
-        this.didUpdate();
+    return Promise.all(
+      remotes.map(remote => this.loadMentionableUsers(remote)),
+    );
+  }
+
+  async loadMentionableUsers(remote) {
+    const fetchQuery = RelayNetworkLayerManager.getExistingFetchQuery('https://api.github.com/graphql');
+    if (!fetchQuery) {
+      // No authentication token
+      return;
+    }
+
+    let hasMore = true;
+    let cursor = null;
+
+    while (hasMore) {
+      const response = await fetchQuery({
+        name: 'GetMentionableUsers',
+        text: `
+          query GetMentionableUsers {
+            repository(owner: $owner, name: $name) {
+              mentionableUsers(first: $first, after: $after) {
+                nodes {
+                  login
+                  email
+                  name
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          }
+        `,
+      }, {
+        owner: remote.getOwner(),
+        name: remote.getRepo(),
+        first: 100,
+        after: cursor,
       });
+
+      const connection = response.data.repository.mentionableUsers;
+
+      this.addUsers(connection.nodes.map(node => {
+        if (node.email === '') {
+          node.email = `${node.login}@users.noreply.github.com`;
+        }
+
+        return new Author(node.email, node.name, node.login);
+      }));
+
+      cursor = connection.pageInfo.endCursor;
+      hasMore = connection.pageInfo.hasNextPage;
     }
   }
 
   addUsers(users) {
-    this.users = {...this.users, ...users};
+    let changed = false;
+    for (const author of users) {
+      if (!this.allUsers.has(author.getEmail())) {
+        changed = true;
+      }
+      this.allUsers.set(author.getEmail(), author);
+    }
+
+    if (changed) {
+      this.finalize();
+    }
+  }
+
+  finalize() {
+    // TODO: [ku 3/2018] consider sorting based on most recent authors or commit frequency
+    const users = [];
+    for (const author of this.allUsers.values()) {
+      if (author.matches(this.committer)) { continue; }
+      if (author.isNoReply()) { continue; }
+
+      users.push(author);
+    }
+    users.sort(Author.compare);
+    this.users = users;
+    this.didUpdate();
   }
 
   setCommitter(committer) {
+    const changed = !this.committer.matches(committer);
     this.committer = committer;
+    if (changed) {
+      this.finalize();
+    }
   }
 
   didUpdate() {
@@ -68,74 +147,6 @@ export default class UserStore {
   }
 
   getUsers() {
-    // TODO: [ku 3/2018] consider sorting based on most recent authors or commit frequency
-    // Also, this is obviously not the most performant. Optimize once we incorporate github username info,
-    // as this will likely impact the shape of the data we store
-    const users = this.users;
-
-    // you wouldn't download a car.  you wouldn't add yourself as a co author.
-    delete users[this.committer.email];
-    delete users[NO_REPLY_GITHUB_EMAIL];
-
-    return Object.keys(users)
-      .map(email => ({email, name: this.users[email]}))
-      .sort((a, b) => {
-        if (a.name < b.name) { return -1; }
-        if (a.name > b.name) { return 1; }
-        return 0;
-      });
-  }
-}
-
-async function getMentionableUsers(remote, callback) {
-  const fetchQuery = RelayNetworkLayerManager.getExistingFetchQuery('https://api.github.com/graphql');
-  if (!fetchQuery) {
-    // No authentication token
-    return;
-  }
-
-  let hasMore = true;
-  let cursor = null;
-
-  while (hasMore) {
-    const response = await fetchQuery({
-      name: 'GetMentionableUsers',
-      text: `
-        query GetMentionableUsers {
-          repository(owner: $owner, name: $name) {
-            mentionableUsers(first: $first, after: $after) {
-              nodes {
-                login
-                email
-                name
-              }
-              pageInfo {
-                hasNextPage
-                endCursor
-              }
-            }
-          }
-        }
-      `,
-    }, {
-      owner: remote.getOwner(),
-      name: remote.getRepo(),
-      first: 100,
-      after: cursor,
-    });
-
-    const connection = response.data.repository.mentionableUsers;
-
-    callback(connection.nodes.reduce((acc, node) => {
-      if (node.email === '') {
-        node.email = `${node.login}@users.noreply.github.com`;
-      }
-
-      acc[node.email] = node.name;
-      return acc;
-    }, {}));
-
-    cursor = connection.pageInfo.endCursor;
-    hasMore = connection.pageInfo.hasNextPage;
+    return this.users;
   }
 }

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -163,6 +163,15 @@ export default class UserStore {
         after: cursor,
       });
 
+      if (response.errors && response.errors.length > 1) {
+        // eslint-disable-next-line no-console
+        console.error(`Error fetching mentionable users:\n${response.errors.map(e => e.message).join('\n')}`);
+      }
+
+      if (!response.data) {
+        break;
+      }
+
       const connection = response.data.repository.mentionableUsers;
       const authors = connection.nodes.map(node => {
         if (node.email === '') {

--- a/lib/prop-types.js
+++ b/lib/prop-types.js
@@ -38,8 +38,8 @@ export const CommitPropType = PropTypes.shape({
 });
 
 export const AuthorPropType = PropTypes.shape({
-  email: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
+  getEmail: PropTypes.func.isRequired,
+  getFullName: PropTypes.func.isRequired,
 });
 
 export const RelayConnectionPropType = nodePropType => PropTypes.shape({
@@ -85,4 +85,9 @@ export const MergeConflictItemPropType = PropTypes.shape({
     ours: PropTypes.oneOf(statusNames).isRequired,
     theirs: PropTypes.oneOf(statusNames).isRequired,
   }).isRequired,
+});
+
+export const UserStorePropType = PropTypes.shape({
+  getUsers: PropTypes.func.isRequired,
+  onDidUpdate: PropTypes.func.isRequired,
 });

--- a/lib/relay-network-layer-manager.js
+++ b/lib/relay-network-layer-manager.js
@@ -113,7 +113,7 @@ export default class RelayNetworkLayerManager {
     if (!environment) {
       const source = new RecordSource();
       const store = new Store(source);
-      network = Network.create(this.getFetchQuery(url));
+      network = Network.create(this.getFetchQuery(url, token));
       environment = new Environment({network, store});
 
       relayEnvironmentPerGithubHost.set(host, {environment, network});

--- a/lib/relay-network-layer-manager.js
+++ b/lib/relay-network-layer-manager.js
@@ -73,10 +73,10 @@ function createFetchQuery(url) {
     };
   }
 
-  return function fetchQuery(operation, variables, cacheConfig, uploadables) {
+  return async function fetchQuery(operation, variables, cacheConfig, uploadables) {
     const currentToken = tokenPerURL.get(url);
 
-    return fetch(url, {
+    const response = await fetch(url, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -87,13 +87,20 @@ function createFetchQuery(url) {
         query: operation.text,
         variables,
       }),
-    }).then(response => {
-      try {
-        atom && atom.inDevMode() && logRatelimitApi(response.headers);
-      } catch (_e) { /* do nothing */ }
-
-      return response.json();
     });
+
+    try {
+      atom && atom.inDevMode() && logRatelimitApi(response.headers);
+    } catch (_e) { /* do nothing */ }
+
+    if (response.status !== 200) {
+      const e = new Error(`GraphQL API endpoint at ${url} returned ${response.status}`);
+      e.response = response;
+      e.rawStack = e.stack;
+      throw e;
+    }
+
+    return response.json();
   };
 }
 

--- a/lib/relay-network-layer-manager.js
+++ b/lib/relay-network-layer-manager.js
@@ -22,7 +22,9 @@ export function expectRelayQuery(operationPattern, response) {
     reject = reject0;
   });
 
-  responsesByQuery.set(operationPattern.name, {promise, response, variables: operationPattern.variables || {}});
+  const existing = responsesByQuery.get(operationPattern.name) || [];
+  existing.push({promise, response, variables: operationPattern.variables || {}});
+  responsesByQuery.set(operationPattern.name, existing);
 
   return {promise, resolve, reject};
 }
@@ -37,8 +39,22 @@ const fetchPerURL = new Map();
 function createFetchQuery(url) {
   if (atom.inSpecMode()) {
     return function specFetchQuery(operation, variables, cacheConfig, uploadables) {
-      const expectation = responsesByQuery.get(operation.name);
-      if (!expectation) {
+      const expectations = responsesByQuery.get(operation.name) || [];
+      const match = expectations.find(expectation => {
+        if (Object.keys(expectation.variables).length !== Object.keys(variables).length) {
+          return false;
+        }
+
+        for (const key in expectation.variables) {
+          if (expectation.variables[key] !== variables[key]) {
+            return false;
+          }
+        }
+
+        return true;
+      });
+
+      if (!match) {
         // eslint-disable-next-line no-console
         console.log(`GraphQL query ${operation.name} was:\n  ${operation.text.replace(/\n/g, '\n  ')}`);
 
@@ -46,7 +62,8 @@ function createFetchQuery(url) {
         e.rawStack = e.stack;
         throw e;
       }
-      return expectation.promise;
+
+      return match.promise;
     };
   }
 

--- a/lib/relay-network-layer-manager.js
+++ b/lib/relay-network-layer-manager.js
@@ -100,7 +100,7 @@ export default class RelayNetworkLayerManager {
     if (!environment) {
       const source = new RecordSource();
       const store = new Store(source);
-      network = Network.create(this.getExistingFetchQuery(url));
+      network = Network.create(this.getFetchQuery(url));
       environment = new Environment({network, store});
 
       relayEnvironmentPerGithubHost.set(host, {environment, network});
@@ -108,11 +108,8 @@ export default class RelayNetworkLayerManager {
     return environment;
   }
 
-  static getExistingFetchQuery(url) {
-    if (!tokenPerURL.has(url)) {
-      return null;
-    }
-
+  static getFetchQuery(url, token) {
+    tokenPerURL.set(url, token);
     let fetch = fetchPerURL.get(url);
     if (!fetch) {
       fetch = createFetchQuery(url);

--- a/lib/relay-network-layer-manager.js
+++ b/lib/relay-network-layer-manager.js
@@ -26,7 +26,9 @@ export function expectRelayQuery(operationPattern, response) {
   existing.push({promise, response, variables: operationPattern.variables || {}});
   responsesByQuery.set(operationPattern.name, existing);
 
-  return {promise, resolve, reject};
+  const disable = () => responsesByQuery.delete(operationPattern.name);
+
+  return {promise, resolve, reject, disable};
 }
 
 export function clearRelayExpectations() {

--- a/lib/relay-network-layer-manager.js
+++ b/lib/relay-network-layer-manager.js
@@ -1,3 +1,4 @@
+import util from 'util';
 import {Environment, Network, RecordSource, Store} from 'relay-runtime';
 import moment from 'moment';
 
@@ -58,7 +59,10 @@ function createFetchQuery(url) {
 
       if (!match) {
         // eslint-disable-next-line no-console
-        console.log(`GraphQL query ${operation.name} was:\n  ${operation.text.replace(/\n/g, '\n  ')}`);
+        console.log(
+          `GraphQL query ${operation.name} was:\n  ${operation.text.replace(/\n/g, '\n  ')}\n` +
+          util.inspect(variables),
+        );
 
         const e = new Error(`Unexpected GraphQL query: ${operation.name}`);
         e.rawStack = e.stack;

--- a/lib/shared/keytar-strategy.js
+++ b/lib/shared/keytar-strategy.js
@@ -18,6 +18,8 @@ if (typeof atom === 'undefined') {
 
 const UNAUTHENTICATED = Symbol('UNAUTHENTICATED');
 
+const INSUFFICIENT = Symbol('INSUFFICIENT');
+
 class KeytarStrategy {
   static get keytar() {
     return require('keytar');
@@ -245,6 +247,7 @@ async function createStrategy() {
 
 module.exports = {
   UNAUTHENTICATED,
+  INSUFFICIENT,
   KeytarStrategy,
   SecurityBinaryStrategy,
   InMemoryStrategy,

--- a/lib/views/co-author-form.js
+++ b/lib/views/co-author-form.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Author from '../models/author';
 import Commands, {Command} from '../atom/commands';
 import {autobind} from '../helpers';
 
@@ -75,7 +76,7 @@ export default class CoAuthorForm extends React.Component {
 
   confirm() {
     if (this.isInputValid()) {
-      this.props.onSubmit({name: this.state.name, email: this.state.email});
+      this.props.onSubmit(new Author(this.state.email, this.state.name));
     }
   }
 

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -470,8 +470,12 @@ export default class CommitView extends React.Component {
   matchAuthors(authors, filterText, selectedAuthors) {
     const matchedAuthors = authors.filter((author, index) => {
       const isAlreadySelected = selectedAuthors && selectedAuthors.find(selected => selected.matches(author));
-      const matchesFilter = `${author.getFullName()}${author.getEmail()}`.toLowerCase()
-        .indexOf(filterText.toLowerCase()) !== -1;
+      const matchesFilter = [
+        author.getLogin(),
+        author.getFullName(),
+        author.getEmail(),
+      ].some(field => field && field.toLowerCase().indexOf(filterText.toLowerCase()) !== -1);
+
       return !isAlreadySelected && matchesFilter;
     });
     matchedAuthors.push(Author.createNew('Add new author', filterText));

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -57,7 +57,7 @@ export default class CommitView extends React.Component {
       this,
       'submitNewCoAuthor', 'cancelNewCoAuthor', 'didChangeCommitMessage', 'didMoveCursor', 'toggleHardWrap',
       'toggleCoAuthorInput', 'abortMerge', 'commit', 'amendLastCommit', 'toggleExpandedCommitMessageEditor',
-      'renderCoAuthorListItem', 'onSelectedCoAuthorsChanged',
+      'renderCoAuthorListItem', 'onSelectedCoAuthorsChanged', 'excludeCoAuthor',
     );
 
     this.state = {
@@ -132,6 +132,7 @@ export default class CommitView extends React.Component {
         'github:co-author:home': this.proxyKeyCode(36),
         'github:co-author:delete': this.proxyKeyCode(46),
         'github:co-author:escape': this.proxyKeyCode(27),
+        'github:co-author-exclude': this.excludeCoAuthor,
       }),
       this.props.config.onDidChange('github.automaticCommitMessageWrapping', () => this.forceUpdate()),
     );
@@ -384,6 +385,20 @@ export default class CommitView extends React.Component {
         this.props.updateSelectedCoAuthors([]);
       }
     });
+  }
+
+  excludeCoAuthor() {
+    const author = this.refCoAuthorSelect.map(c => c.getFocusedOption());
+    if (!author || author.isNew()) {
+      return;
+    }
+
+    let excluded = this.props.config.get('github.excludedUsers');
+    if (excluded && excluded !== '') {
+      excluded += ', ';
+    }
+    excluded += author.getEmail();
+    this.props.config.set('github.excludedUsers', excluded);
   }
 
   abortMerge() {

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -8,6 +8,7 @@ import Tooltip from '../atom/tooltip';
 import AtomTextEditor from '../atom/atom-text-editor';
 import CoAuthorForm from './co-author-form';
 import RefHolder from '../models/ref-holder';
+import Author from '../models/author';
 import ObserveModel from './observe-model';
 import {LINE_ENDING_REGEX, autobind} from '../helpers';
 import {AuthorPropType, UserStorePropType} from '../prop-types';
@@ -260,7 +261,7 @@ export default class CommitView extends React.Component {
             placeholder="Co-Authors"
             arrowRenderer={null}
             options={mentionableUsers}
-            labelKey="name"
+            labelKey="fullName"
             valueKey="email"
             filterOptions={this.matchAuthors}
             optionRenderer={this.renderCoAuthorListItem}
@@ -468,11 +469,12 @@ export default class CommitView extends React.Component {
 
   matchAuthors(authors, filterText, selectedAuthors) {
     const matchedAuthors = authors.filter((author, index) => {
-      const isAlreadySelected = selectedAuthors && selectedAuthors.find(selected => selected.email === author.email);
-      const matchesFilter = `${author.name}${author.email}`.toLowerCase().indexOf(filterText.toLowerCase()) !== -1;
+      const isAlreadySelected = selectedAuthors && selectedAuthors.find(selected => selected.matches(author));
+      const matchesFilter = `${author.getFullName()}${author.getEmail()}`.toLowerCase()
+        .indexOf(filterText.toLowerCase()) !== -1;
       return !isAlreadySelected && matchesFilter;
     });
-    matchedAuthors.push({name: filterText, email: 'Add new author', isNew: true});
+    matchedAuthors.push(Author.createNew('Add new author', filterText));
     return matchedAuthors;
   }
 
@@ -488,24 +490,24 @@ export default class CommitView extends React.Component {
 
   renderCoAuthorListItem(author) {
     return (
-      <div className={cx('github-CommitView-coAuthorEditor-selectListItem', {'new-author': author.isNew})}>
-        {this.renderCoAuthorListItemField('name', author.name)}
-        {this.renderCoAuthorListItemField('email', author.email)}
+      <div className={cx('github-CommitView-coAuthorEditor-selectListItem', {'new-author': author.isNew()})}>
+        {this.renderCoAuthorListItemField('name', author.getFullName())}
+        {this.renderCoAuthorListItemField('email', author.getEmail())}
       </div>
     );
   }
 
   renderCoAuthorValue(author) {
     return (
-      <span>{author.name}</span>
+      <span>{author.getFullName()}</span>
     );
   }
 
   onSelectedCoAuthorsChanged(selectedCoAuthors) {
-    const newAuthor = selectedCoAuthors.find(author => author.isNew);
+    const newAuthor = selectedCoAuthors.find(author => author.isNew());
 
     if (newAuthor) {
-      this.setState({coAuthorInput: newAuthor.name, showCoAuthorForm: true});
+      this.setState({coAuthorInput: newAuthor.getFullName(), showCoAuthorForm: true});
     } else {
       this.props.updateSelectedCoAuthors(selectedCoAuthors);
     }

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -8,8 +8,9 @@ import Tooltip from '../atom/tooltip';
 import AtomTextEditor from '../atom/atom-text-editor';
 import CoAuthorForm from './co-author-form';
 import RefHolder from '../models/ref-holder';
+import ObserveModel from './observe-model';
 import {LINE_ENDING_REGEX, autobind} from '../helpers';
-import {AuthorPropType} from '../prop-types';
+import {AuthorPropType, UserStorePropType} from '../prop-types';
 
 const TOOLTIP_DELAY = 200;
 
@@ -39,7 +40,7 @@ export default class CommitView extends React.Component {
     deactivateCommitBox: PropTypes.bool.isRequired,
     maximumCharacterLimit: PropTypes.number.isRequired,
     message: PropTypes.string.isRequired,
-    mentionableUsers: PropTypes.arrayOf(AuthorPropType),
+    userStore: UserStorePropType.isRequired,
     selectedCoAuthors: PropTypes.arrayOf(AuthorPropType),
     updateSelectedCoAuthors: PropTypes.func,
     commit: PropTypes.func.isRequired,
@@ -246,30 +247,33 @@ export default class CommitView extends React.Component {
   }
 
   renderCoAuthorInput() {
-
     if (!this.state.showCoAuthorInput) {
       return null;
     }
 
     return (
-      <Select
-        ref={this.refCoAuthorSelect.setter}
-        className="github-CommitView-coAuthorEditor input-textarea native-key-bindings"
-        placeholder="Co-Authors"
-        arrowRenderer={null}
-        options={this.props.mentionableUsers}
-        labelKey="name"
-        valueKey="email"
-        filterOptions={this.matchAuthors}
-        optionRenderer={this.renderCoAuthorListItem}
-        valueRenderer={this.renderCoAuthorValue}
-        onChange={this.onSelectedCoAuthorsChanged}
-        value={this.props.selectedCoAuthors}
-        multi={true}
-        openOnClick={false}
-        openOnFocus={false}
-        tabIndex="5"
-      />
+      <ObserveModel model={this.props.userStore} fetchData={store => store.getUsers()}>
+        {mentionableUsers => (
+          <Select
+            ref={this.refCoAuthorSelect.setter}
+            className="github-CommitView-coAuthorEditor input-textarea native-key-bindings"
+            placeholder="Co-Authors"
+            arrowRenderer={null}
+            options={mentionableUsers}
+            labelKey="name"
+            valueKey="email"
+            filterOptions={this.matchAuthors}
+            optionRenderer={this.renderCoAuthorListItem}
+            valueRenderer={this.renderCoAuthorValue}
+            onChange={this.onSelectedCoAuthorsChanged}
+            value={this.props.selectedCoAuthors}
+            multi={true}
+            openOnClick={false}
+            openOnFocus={false}
+            tabIndex="5"
+          />
+        )}
+      </ObserveModel>
     );
   }
 

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -496,15 +496,22 @@ export default class CommitView extends React.Component {
     return (
       <div className={cx('github-CommitView-coAuthorEditor-selectListItem', {'new-author': author.isNew()})}>
         {this.renderCoAuthorListItemField('name', author.getFullName())}
+        {author.hasLogin() && this.renderCoAuthorListItemField('login', '@' + author.getLogin())}
         {this.renderCoAuthorListItemField('email', author.getEmail())}
       </div>
     );
   }
 
   renderCoAuthorValue(author) {
-    return (
-      <span>{author.getFullName()}</span>
-    );
+    const fullName = author.getFullName();
+    if (fullName && fullName.length > 0) {
+      return <span>{author.getFullName()}</span>;
+    }
+    if (author.hasLogin()) {
+      return <span>@{author.getLogin()}</span>;
+    }
+
+    return <span>{author.getEmail()}</span>;
   }
 
   onSelectedCoAuthorsChanged(selectedCoAuthors) {

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -8,7 +8,7 @@ import GitLogo from './git-logo';
 import CommitController from '../controllers/commit-controller';
 import RecentCommitsController from '../controllers/recent-commits-controller';
 import {isValidWorkdir, autobind} from '../helpers';
-import {AuthorPropType} from '../prop-types';
+import {AuthorPropType, UserStorePropType} from '../prop-types';
 
 export default class GitTabView extends React.Component {
   static focus = {
@@ -32,7 +32,7 @@ export default class GitTabView extends React.Component {
     mergeConflicts: PropTypes.arrayOf(PropTypes.object),
     workingDirectoryPath: PropTypes.string,
     mergeMessage: PropTypes.string,
-    mentionableUsers: PropTypes.arrayOf(AuthorPropType),
+    userStore: UserStorePropType.isRequired,
     selectedCoAuthors: PropTypes.arrayOf(AuthorPropType),
     updateSelectedCoAuthors: PropTypes.func.isRequired,
 
@@ -184,7 +184,7 @@ export default class GitTabView extends React.Component {
             isLoading={this.props.isLoading}
             lastCommit={this.props.lastCommit}
             repository={this.props.repository}
-            mentionableUsers={this.props.mentionableUsers}
+            userStore={this.props.userStore}
             selectedCoAuthors={this.props.selectedCoAuthors}
             updateSelectedCoAuthors={this.props.updateSelectedCoAuthors}
           />

--- a/lib/views/loading-view.js
+++ b/lib/views/loading-view.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default class LoadingView extends React.Component {
+  render() {
+    return (
+      <div className="github-Loader">
+        <span className="github-Spinner" />
+      </div>
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -150,6 +150,11 @@
       "type": "boolean",
       "default": true,
       "description": "Resolve merge conflicts with in-editor controls"
+    },
+    "excludedUsers": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-separated list of email addresses to exclude from the co-author selection list"
     }
   },
   "deserializers": {

--- a/test/controllers/commit-controller.test.js
+++ b/test/controllers/commit-controller.test.js
@@ -5,6 +5,7 @@ import {shallow} from 'enzyme';
 
 import Commit from '../../lib/models/commit';
 import {nullBranch} from '../../lib/models/branch';
+import UserStore from '../../lib/models/user-store';
 
 import CommitController, {COMMIT_GRAMMAR_SCOPE} from '../../lib/controllers/commit-controller';
 import {cloneRepository, buildRepository, buildRepositoryWithPipeline} from '../helpers';
@@ -24,6 +25,7 @@ describe('CommitController', function() {
 
     lastCommit = new Commit({sha: 'a1e23fd45', message: 'last commit message'});
     const noop = () => {};
+    const store = new UserStore({});
 
     app = (
       <CommitController
@@ -40,6 +42,7 @@ describe('CommitController', function() {
         mergeMessage={''}
         lastCommit={lastCommit}
         currentBranch={nullBranch}
+        userStore={store}
         prepareToCommit={noop}
         commit={noop}
         abortMerge={noop}

--- a/test/controllers/commit-controller.test.js
+++ b/test/controllers/commit-controller.test.js
@@ -25,7 +25,7 @@ describe('CommitController', function() {
 
     lastCommit = new Commit({sha: 'a1e23fd45', message: 'last commit message'});
     const noop = () => {};
-    const store = new UserStore({});
+    const store = new UserStore({config});
 
     app = (
       <CommitController

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -1,20 +1,17 @@
 import fs from 'fs';
 import path from 'path';
-
 import React from 'react';
 import {mount} from 'enzyme';
-
 import dedent from 'dedent-js';
 import until from 'test-until';
 
 import GitTabController from '../../lib/controllers/git-tab-controller';
 import {gitTabControllerProps} from '../fixtures/props/git-tab-props';
-
 import {cloneRepository, buildRepository, buildRepositoryWithPipeline, initRepository} from '../helpers';
 import Repository from '../../lib/models/repository';
-import {GitError} from '../../lib/git-shell-out-strategy';
-
+import Author from '../../lib/models/author';
 import ResolutionProgress from '../../lib/models/conflicts/resolution-progress';
+import {GitError} from '../../lib/git-shell-out-strategy';
 
 describe('GitTabController', function() {
   let atomEnvironment, workspace, workspaceElement, commandRegistry, notificationManager;

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -169,8 +169,8 @@ describe('GitTabController', function() {
       const repository = await buildRepository(workdirPath);
 
       const wrapper = mount(await buildApp(repository));
-      const coAuthors = [{name: 'Mona Lisa', email: 'mona@lisa.com'}];
-      const newAuthor = {name: 'Mr. Hubot', email: 'hubot@github.com'};
+      const coAuthors = [new Author('mona@lisa.com', 'Mona Lisa')];
+      const newAuthor = new Author('hubot@github.com', 'Mr. Hubot');
 
       wrapper.instance().updateSelectedCoAuthors(coAuthors, newAuthor);
 

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -609,7 +609,7 @@ describe('GitTabController', function() {
           assert.deepEqual(commitBeforeAmend.coAuthors, []);
 
           // add co author
-          const author = {email: 'foo@bar.com', name: 'foo bar'};
+          const author = new Author('foo@bar.com', 'foo bar');
           const commitView = wrapper.find('CommitView').instance();
           commitView.setState({showCoAuthorInput: true});
           commitView.onSelectedCoAuthorsChanged([author]);
@@ -621,7 +621,7 @@ describe('GitTabController', function() {
           await repository.commit.returnValues[0];
           await updateWrapper(repository, wrapper);
 
-          assert.deepEqual(getLastCommit().coAuthors, [author]);
+          assert.deepEqual(getLastCommit().coAuthors, [{email: author.getEmail(), name: author.getFullName()}]);
           assert.strictEqual(getLastCommit().getMessageSubject(), commitBeforeAmend.getMessageSubject());
         });
 

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -65,6 +65,9 @@ describe('GitTabController', function() {
     assert.lengthOf(wrapper.find('StagingView'), 1);
     assert.lengthOf(wrapper.find('CommitController'), 1);
 
+    await repository.getLoadPromise();
+    await updateWrapper(repository, wrapper);
+
     await assert.async.isFalse(wrapper.update().find('.github-Panel').hasClass('is-loading'));
     assert.lengthOf(wrapper.find('StagingView'), 1);
     assert.lengthOf(wrapper.find('CommitController'), 1);

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -631,7 +631,7 @@ describe('GitTabController', function() {
           assert.deepEqual(commitBeforeAmend.coAuthors, []);
 
           // add co author
-          const author = {email: 'foo@bar.com', name: 'foo bar'};
+          const author = new Author('foo@bar.com', 'foo bar');
           const commitView = wrapper.find('CommitView').instance();
           commitView.setState({showCoAuthorInput: true});
           commitView.onSelectedCoAuthorsChanged([author]);
@@ -645,7 +645,7 @@ describe('GitTabController', function() {
           await updateWrapper(repository, wrapper);
 
           // verify that commit message has coauthor
-          assert.deepEqual(getLastCommit().coAuthors, [author]);
+          assert.deepEqual(getLastCommit().coAuthors, [{email: author.getEmail(), name: author.getFullName()}]);
           assert.strictEqual(getLastCommit().getMessageSubject(), newMessage);
         });
 

--- a/test/controllers/remote-pr-controller.test.js
+++ b/test/controllers/remote-pr-controller.test.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import GithubLoginModel from '../../lib/models/github-login-model';
+import BranchSet from '../../lib/models/branch-set';
+import Remote from '../../lib/models/remote';
+import {expectRelayQuery} from '../../lib/relay-network-layer-manager';
+import {InMemoryStrategy, UNAUTHENTICATED, INSUFFICIENT} from '../../lib/shared/keytar-strategy';
+import RemotePrController from '../../lib/controllers/remote-pr-controller';
+
+describe('RemotePrController', function() {
+  let loginModel, remote, branchSet;
+
+  beforeEach(function() {
+    loginModel = new GithubLoginModel(InMemoryStrategy);
+    sinon.stub(loginModel, 'getToken').returns(Promise.resolve('1234'));
+
+    remote = new Remote('origin', 'git@github.com:atom/github');
+    branchSet = new BranchSet();
+
+    expectRelayQuery({
+      name: 'prInfoControllerByBranchQuery',
+      variables: {repoOwner: 'atom', repoName: 'github', branchName: ''},
+    }, {
+      repository: {
+        defaultBranchRef: {
+          prefix: 'refs/heads',
+          name: 'master',
+        },
+        pullRequests: {
+          totalCount: 0,
+          edges: [],
+        },
+        id: '1',
+      },
+    });
+  });
+
+  function createApp(props = {}) {
+    const noop = () => {};
+
+    return (
+      <RemotePrController
+        remote={remote}
+        loginModel={loginModel}
+        branches={branchSet}
+        pushInProgress={false}
+        onSelectPr={noop}
+        onUnpinPr={noop}
+        onPushBranch={noop}
+        {...props}
+      />
+    );
+  }
+
+  it('renders a loading message while fetching the token', function() {
+    const wrapper = mount(createApp());
+    assert.isTrue(wrapper.find('LoadingView').exists());
+  });
+
+  it('shows the login view if unauthenticated', async function() {
+    loginModel.getToken.restore();
+    sinon.stub(loginModel, 'getToken').returns(Promise.resolve(UNAUTHENTICATED));
+
+    const wrapper = mount(createApp());
+
+    await assert.async.isTrue(wrapper.update().find('GithubLoginView').exists());
+    assert.isFalse(wrapper.find('GithubLoginView').prop('scopeExpansion'));
+  });
+
+  it('shows the login view if more scopes are required', async function() {
+    loginModel.getToken.restore();
+    sinon.stub(loginModel, 'getToken').returns(Promise.resolve(INSUFFICIENT));
+
+    const wrapper = mount(createApp());
+
+    await assert.async.isTrue(wrapper.update().find('GithubLoginView').exists());
+    assert.isTrue(wrapper.find('GithubLoginView').prop('scopeExpansion'));
+  });
+
+  it('renders pull request info if authenticated', async function() {
+    const wrapper = mount(createApp());
+
+    await assert.async.isTrue(wrapper.update().find('PrInfoController').exists());
+
+    const controller = wrapper.update().find('PrInfoController');
+    assert.strictEqual(controller.prop('remote'), remote);
+    assert.strictEqual(controller.prop('branches'), branchSet);
+    assert.strictEqual(controller.prop('loginModel'), loginModel);
+  });
+});

--- a/test/controllers/remote-pr-controller.test.js
+++ b/test/controllers/remote-pr-controller.test.js
@@ -65,7 +65,10 @@ describe('RemotePrController', function() {
     const wrapper = mount(createApp());
 
     await assert.async.isTrue(wrapper.update().find('GithubLoginView').exists());
-    assert.isFalse(wrapper.find('GithubLoginView').prop('scopeExpansion'));
+    assert.strictEqual(
+      wrapper.find('GithubLoginView').find('p').text(),
+      'Log in to GitHub to access PR information and more!',
+    );
   });
 
   it('shows the login view if more scopes are required', async function() {
@@ -75,7 +78,10 @@ describe('RemotePrController', function() {
     const wrapper = mount(createApp());
 
     await assert.async.isTrue(wrapper.update().find('GithubLoginView').exists());
-    assert.isTrue(wrapper.find('GithubLoginView').prop('scopeExpansion'));
+    assert.strictEqual(
+      wrapper.find('GithubLoginView').find('p').text(),
+      'Your token no longer has sufficient authorizations. Please re-authenticate and generate a new one.',
+    );
   });
 
   it('renders pull request info if authenticated', async function() {

--- a/test/models/author.test.js
+++ b/test/models/author.test.js
@@ -1,0 +1,19 @@
+import Author, {NO_REPLY_GITHUB_EMAIL} from '../../lib/models/author';
+
+describe('Author', function() {
+  it('recognizes the no-reply GitHub email address', function() {
+    const a0 = new Author('foo@bar.com', 'Eh');
+    assert.isFalse(a0.isNoReply());
+
+    const a1 = new Author(NO_REPLY_GITHUB_EMAIL, 'Whatever');
+    assert.isTrue(a1.isNoReply());
+  });
+
+  it('distinguishes authors with a GitHub handle', function() {
+    const a0 = new Author('foo@bar.com', 'Eh', 'handle');
+    assert.isTrue(a0.hasLogin());
+
+    const a1 = new Author('other@bar.com', 'Nah');
+    assert.isFalse(a1.hasLogin());
+  });
+});

--- a/test/models/author.test.js
+++ b/test/models/author.test.js
@@ -1,4 +1,4 @@
-import Author, {NO_REPLY_GITHUB_EMAIL} from '../../lib/models/author';
+import Author, {nullAuthor, NO_REPLY_GITHUB_EMAIL} from '../../lib/models/author';
 
 describe('Author', function() {
   it('recognizes the no-reply GitHub email address', function() {
@@ -15,5 +15,17 @@ describe('Author', function() {
 
     const a1 = new Author('other@bar.com', 'Nah');
     assert.isFalse(a1.hasLogin());
+  });
+
+  it('implements matching by email address', function() {
+    const a0 = new Author('same@same.com', 'Zero');
+    const a1 = new Author('same@same.com', 'One');
+    const a2 = new Author('same@same.com', 'Two', 'two');
+    const a3 = new Author('different@same.com', 'Three');
+
+    assert.isTrue(a0.matches(a1));
+    assert.isTrue(a0.matches(a2));
+    assert.isFalse(a0.matches(a3));
+    assert.isFalse(a0.matches(nullAuthor));
   });
 });

--- a/test/models/github-login-model.test.js
+++ b/test/models/github-login-model.test.js
@@ -1,5 +1,11 @@
 import GithubLoginModel from '../../lib/models/github-login-model';
-import {KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy, UNAUTHENTICATED} from '../../lib/shared/keytar-strategy';
+import {
+  KeytarStrategy,
+  SecurityBinaryStrategy,
+  InMemoryStrategy,
+  UNAUTHENTICATED,
+  INSUFFICIENT,
+} from '../../lib/shared/keytar-strategy';
 
 describe('GithubLoginModel', function() {
   [null, KeytarStrategy, SecurityBinaryStrategy, InMemoryStrategy].forEach(function(Strategy) {
@@ -21,6 +27,37 @@ describe('GithubLoginModel', function() {
           console.warn(`Skipping tests for ${Strategy.name} as they are not supported on this platform (or maybe your Atom is unsigned?)`);
         }
       });
+    });
+  });
+
+  describe('required OAuth scopes', function() {
+    let loginModel;
+
+    beforeEach(async function() {
+      loginModel = new GithubLoginModel(InMemoryStrategy);
+      await loginModel.setToken('https://api.github.com', '1234');
+    });
+
+    it('returns INSUFFICIENT if scopes are present', async function() {
+      sinon.stub(loginModel, 'getScopes').returns(Promise.resolve(['repo']));
+
+      assert.strictEqual(await loginModel.getToken('https://api.github.com'), INSUFFICIENT);
+    });
+
+    it('returns the token if at least the required scopes are present', async function() {
+      sinon.stub(loginModel, 'getScopes').returns(Promise.resolve(['repo', 'user:email', 'extra']));
+
+      assert.strictEqual(await loginModel.getToken('https://api.github.com'), '1234');
+    });
+
+    it('caches checked tokens', async function() {
+      sinon.stub(loginModel, 'getScopes').returns(Promise.resolve(['repo', 'user:email']));
+
+      assert.strictEqual(await loginModel.getToken('https://api.github.com'), '1234');
+      assert.strictEqual(loginModel.getScopes.callCount, 1);
+
+      assert.strictEqual(await loginModel.getToken('https://api.github.com'), '1234');
+      assert.strictEqual(loginModel.getScopes.callCount, 1);
     });
   });
 });

--- a/test/models/github-login-model.test.js
+++ b/test/models/github-login-model.test.js
@@ -39,19 +39,19 @@ describe('GithubLoginModel', function() {
     });
 
     it('returns INSUFFICIENT if scopes are present', async function() {
-      sinon.stub(loginModel, 'getScopes').returns(Promise.resolve(['repo']));
+      sinon.stub(loginModel, 'getScopes').returns(Promise.resolve(['repo', 'read:org']));
 
       assert.strictEqual(await loginModel.getToken('https://api.github.com'), INSUFFICIENT);
     });
 
     it('returns the token if at least the required scopes are present', async function() {
-      sinon.stub(loginModel, 'getScopes').returns(Promise.resolve(['repo', 'user:email', 'extra']));
+      sinon.stub(loginModel, 'getScopes').returns(Promise.resolve(['repo', 'read:org', 'user:email', 'extra']));
 
       assert.strictEqual(await loginModel.getToken('https://api.github.com'), '1234');
     });
 
     it('caches checked tokens', async function() {
-      sinon.stub(loginModel, 'getScopes').returns(Promise.resolve(['repo', 'user:email']));
+      sinon.stub(loginModel, 'getScopes').returns(Promise.resolve(['repo', 'read:org', 'user:email']));
 
       assert.strictEqual(await loginModel.getToken('https://api.github.com'), '1234');
       assert.strictEqual(loginModel.getScopes.callCount, 1);

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -536,6 +536,41 @@ describe('Repository', function() {
     });
   });
 
+  describe('getAuthors', function() {
+    it('returns user names and emails', async function() {
+      const workingDirPath = await cloneRepository('multiple-commits');
+      const repository = new Repository(workingDirPath);
+      await repository.getLoadPromise();
+
+      await repository.git.exec(['config', 'user.name', 'Mona Lisa']);
+      await repository.git.exec(['config', 'user.email', 'mona@lisa.com']);
+      await repository.git.commit('Commit from Mona', {allowEmpty: true});
+
+      await repository.git.exec(['config', 'user.name', 'Hubot']);
+      await repository.git.exec(['config', 'user.email', 'hubot@github.com']);
+      await repository.git.commit('Commit from Hubot', {allowEmpty: true});
+
+      await repository.git.exec(['config', 'user.name', 'Me']);
+      await repository.git.exec(['config', 'user.email', 'me@github.com']);
+      await repository.git.commit('Commit from me', {allowEmpty: true});
+
+      const authors = await repository.getAuthors({max: 3});
+      assert.lengthOf(authors, 3);
+
+      const expected = [
+        ['mona@lisa.com', 'Mona Lisa'],
+        ['hubot@github.com', 'Hubot'],
+        ['me@github.com', 'Me'],
+      ];
+      for (const [email, fullName] of expected) {
+        assert.isTrue(
+          authors.some(author => author.getEmail() === email && author.getFullName() === fullName),
+          `getAuthors() output includes ${fullName} <${email}>`,
+        );
+      }
+    });
+  });
+
   describe('pull()', function() {
     it('updates the remote branch and merges into local branch', async function() {
       const {localRepoPath} = await setUpLocalAndRemoteRepositories({remoteAhead: true});

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -514,13 +514,14 @@ describe('Repository', function() {
       const workingDirPath = await cloneRepository('three-files');
       const repository = new Repository(workingDirPath);
       await repository.getLoadPromise();
-      assert.deepEqual(await repository.getCommitter(), {
-        name: FAKE_USER.name,
-        email: FAKE_USER.email,
-      });
+
+      const committer = await repository.getCommitter();
+      assert.isTrue(committer.isPresent());
+      assert.strictEqual(committer.getFullName(), FAKE_USER.name);
+      assert.strictEqual(committer.getEmail(), FAKE_USER.email);
     });
 
-    it('returns empty object if user name or email do not exist', async function() {
+    it('returns a null object if user name or email do not exist', async function() {
       const workingDirPath = await cloneRepository('three-files');
       const repository = new Repository(workingDirPath);
       await repository.getLoadPromise();
@@ -529,10 +530,8 @@ describe('Repository', function() {
 
       // getting the local config for testing purposes only because we don't
       // want to blow away global config when running tests.
-      assert.deepEqual(await repository.getCommitter({local: true}), {
-        name: null,
-        email: null,
-      });
+      const committer = await repository.getCommitter({local: true});
+      assert.isFalse(committer.isPresent());
     });
   });
 

--- a/test/models/user-store.test.js
+++ b/test/models/user-store.test.js
@@ -53,6 +53,7 @@ describe('UserStore', function() {
 
   beforeEach(function() {
     login = new GithubLoginModel(InMemoryStrategy);
+    sinon.stub(login, 'getScopes').returns(Promise.resolve(GithubLoginModel.REQUIRED_SCOPES));
   });
 
   it('loads store with local git users and committer in a repo with no GitHub remote', async function() {

--- a/test/models/user-store.test.js
+++ b/test/models/user-store.test.js
@@ -38,9 +38,9 @@ describe('UserStore', function() {
       repository: {
         mentionableUsers: {
           nodes: [
-            {login: 'kuychaco', email: 'kuychaco@github.com', name: 'Katrina Uychaco'},
-            {login: 'smashwilson', email: 'smashwilson@github.com', name: 'Ash Wilson'},
+            {login: 'annthurium', email: 'annthurium@github.com', name: 'Tilde Ann Thurium'},
             {login: 'octocat', email: 'mona@lisa.com', name: 'Mona Lisa'},
+            {login: 'smashwilson', email: 'smashwilson@github.com', name: 'Ash Wilson'},
           ],
           pageInfo: {
             hasNextPage: false,
@@ -57,8 +57,8 @@ describe('UserStore', function() {
 
     await assert.async.deepEqual(store.getUsers(), [
       {email: 'smashwilson@github.com', name: 'Ash Wilson'},
-      {email: 'kuychaco@github.com', name: 'Katrina Uychaco'},
       {email: 'mona@lisa.com', name: 'Mona Lisa'},
+      {email: 'annthurium@github.com', name: 'Tilde Ann Thurium'},
     ]);
   });
 

--- a/test/models/user-store.test.js
+++ b/test/models/user-store.test.js
@@ -167,7 +167,7 @@ describe('UserStore', function() {
     const workdirPath = await cloneRepository('multiple-commits');
     const repository = await buildRepository(workdirPath);
     const store = new UserStore({repository});
-    await store.loadUsersFromLocalRepo();
+    await assert.async.lengthOf(store.getUsers(), 1);
 
     sinon.spy(store, 'addUsers');
     // make a commit with FAKE_USER as committer

--- a/test/models/user-store.test.js
+++ b/test/models/user-store.test.js
@@ -1,6 +1,6 @@
 import dedent from 'dedent-js';
 
-import UserStore from '../../lib/models/user-store';
+import UserStore, {source} from '../../lib/models/user-store';
 import Author, {nullAuthor} from '../../lib/models/author';
 import GithubLoginModel from '../../lib/models/github-login-model';
 import {InMemoryStrategy} from '../../lib/shared/keytar-strategy';
@@ -219,13 +219,14 @@ describe('UserStore', function() {
       const workdirPath = await cloneRepository('multiple-commits');
       const repository = await buildRepository(workdirPath);
       const store = new UserStore({repository});
+      await nextUpdatePromise(store);
 
-      await assert.async.lengthOf(store.getUsers(), 1);
+      assert.lengthOf(store.getUsers(), 1);
 
       store.addUsers([
         new Author('mona@lisa.com', 'Mona Lisa'),
         new Author('hubot@github.com', 'Hubot Robot'),
-      ]);
+      ], source.GITLOG);
 
       assert.deepEqual(store.getUsers(), [
         new Author('hubot@github.com', 'Hubot Robot'),

--- a/test/models/user-store.test.js
+++ b/test/models/user-store.test.js
@@ -329,25 +329,20 @@ describe('UserStore', function() {
 
     const store = new UserStore({repository, login});
     await nextUpdatePromise(store);
-    console.log('initial load complete');
 
     assert.deepEqual(store.getUsers(), gitAuthors);
 
     await repository.setConfig('remote.origin.url', 'git@github.com:me/stuff.git');
     await repository.setConfig('remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*');
 
-    console.log('about to refresh repository');
     repository.refresh();
-    console.log('updated after repository refresh');
 
     // Token is not available, so authors are still queried from git
     assert.deepEqual(store.getUsers(), gitAuthors);
 
-    console.log('about to fire login update');
     await login.setToken('https://api.github.com', '1234');
 
     await nextUpdatePromise(store);
-    console.log('updated after login update');
     assert.deepEqual(store.getUsers(), graphqlAuthors);
   });
 });

--- a/test/views/co-author-form.test.js
+++ b/test/views/co-author-form.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {mount} from 'enzyme';
 
 import CoAuthorForm from '../../lib/views/co-author-form';
+import Author from '../../lib/models/author';
 
 describe('CoAuthorForm', function() {
   let atomEnv;
@@ -50,10 +51,7 @@ describe('CoAuthorForm', function() {
 
       wrapper.find('.btn-primary').simulate('click');
 
-      assert.deepEqual(didSubmit.firstCall.args[0], {
-        name,
-        email,
-      });
+      assert.deepEqual(didSubmit.firstCall.args[0], new Author(email, name));
     });
 
     it('submit button is initially disabled', function() {

--- a/test/views/commit-view.test.js
+++ b/test/views/commit-view.test.js
@@ -4,6 +4,7 @@ import {shallow, mount} from 'enzyme';
 import {cloneRepository, buildRepository} from '../helpers';
 import Commit, {nullCommit} from '../../lib/models/commit';
 import Branch, {nullBranch} from '../../lib/models/branch';
+import UserStore from '../../lib/models/user-store';
 import CommitView from '../../lib/views/commit-view';
 
 describe('CommitView', function() {
@@ -19,6 +20,7 @@ describe('CommitView', function() {
     lastCommit = new Commit({sha: '1234abcd', message: 'commit message'});
     const noop = () => {};
     const returnTruthyPromise = () => Promise.resolve(true);
+    const store = new UserStore({});
 
     app = (
       <CommitView
@@ -26,6 +28,7 @@ describe('CommitView', function() {
         tooltips={tooltips}
         config={config}
         lastCommit={lastCommit}
+        userStore={store}
         currentBranch={nullBranch}
         isMerging={false}
         stagedChangesExist={false}

--- a/test/views/commit-view.test.js
+++ b/test/views/commit-view.test.js
@@ -20,7 +20,7 @@ describe('CommitView', function() {
     lastCommit = new Commit({sha: '1234abcd', message: 'commit message'});
     const noop = () => {};
     const returnTruthyPromise = () => Promise.resolve(true);
-    const store = new UserStore({});
+    const store = new UserStore({config});
 
     app = (
       <CommitView


### PR DESCRIPTION
If the current repository has one or more remotes hosted on a GitHub instance _and_ you've authenticated to that instance on the GitHub tab, fetch the "mentionable" users from the GraphQL API rather than the local git history. This will give us GitHub usernames which we can use for autocompletion, and, importantly, it will omit users who have been blocked by the current user.

Along the way, I'm building out some infrastructure we can use to test components that query GraphQL.

- [x] Acquire fetch query functions for GraphQL endpoints that have already been authenticated within `RelayNetworkLayerManager`.
- [x] When the current repository has at least one GitHub remote with an authentication token:
  - [x] Retrieve mentionable users from that repository via GraphQL instead of pulling them from git history
  - [x] Iterate over multiple pages
  - [x] Handle users without a public email account
- [x] Use an `Author` model now that we have enough data to warrant one
- [x] Restructure `UserStore` storage to pre-sort authors
- [x] Use a `ModelObserver` within the `UserStore` to watch the `Repository` and reload authors when it broadcasts a change
- [x] Pass the `UserStore` through the component tree as a prop. Extract authors with an `<ObserveModel>` component closer to the co-author field.
- [x] Observe the login model and ensure that co-authors are fetched if a token becomes available later
- [x] Clear authors entirely when the Repository changes or when a GitHub remote is added or removed.
- [x] Throttle GraphQL requests so we don't query over and over again when the local Repository changes
- [x] Render and autocomplete GitHub handles when they are available
- [x] Verify OAuth scopes and treat insufficient scopes as "logged out"
- [x] Remove users from the list with `shift-delete`