### PR TITLE
ID-based email avatars

### DIFF
--- a/lib/views/recent-commits-view.js
+++ b/lib/views/recent-commits-view.js
@@ -42,21 +42,35 @@ class RecentCommitView extends React.Component {
     );
   }
 
+  renderAuthor(email) {
+    let match = email.match(/^(\d+)\+[^@]+@users.noreply.github.com$/)
+
+    if (match) {
+      return (
+        <img className="github-RecentCommit-avatar"
+          key={email}
+          src={'https://avatars.githubusercontent.com/u/' + match[1] + '?s=32'}
+          title={email}
+        />
+      )
+    } else {
+      return (
+        <img className="github-RecentCommit-avatar"
+          key={email}
+          src={'https://avatars.githubusercontent.com/u/e?email=' + encodeURIComponent(email) + '&s=32'}
+          title={email}
+        />
+      )
+    }
+  }
+
   renderAuthors() {
     const coAuthorEmails = this.props.commit.getCoAuthors().map(author => author.email);
     const authorEmails = [this.props.commit.getAuthorEmail(), ...coAuthorEmails];
 
     return (
       <span className="github-RecentCommit-authors">
-        {authorEmails.map(authorEmail => {
-          return (
-            <img className="github-RecentCommit-avatar"
-              key={authorEmail}
-              src={'https://avatars.githubusercontent.com/u/e?email=' + encodeURIComponent(authorEmail) + '&s=32'}
-              title={authorEmail}
-            />
-          );
-        })}
+        {authorEmails.map(this.renderAuthor)}
       </span>
     );
   }

--- a/lib/views/recent-commits-view.js
+++ b/lib/views/recent-commits-view.js
@@ -43,13 +43,13 @@ class RecentCommitView extends React.Component {
   }
 
   renderAuthor(email) {
-    let match = email.match(/^(\d+)\+[^@]+@users.noreply.github.com$/)
+    const match = email.match(/^(\d+)\+[^@]+@users.noreply.github.com$/);
 
-    let avatarUrl
+    let avatarUrl;
     if (match) {
-      avatarUrl = 'https://avatars.githubusercontent.com/u/' + match[1] + '?s=32'
+      avatarUrl = 'https://avatars.githubusercontent.com/u/' + match[1] + '?s=32';
     } else {
-      avatarUrl = 'https://avatars.githubusercontent.com/u/e?email=' + encodeURIComponent(email) + '&s=32'
+      avatarUrl = 'https://avatars.githubusercontent.com/u/e?email=' + encodeURIComponent(email) + '&s=32';
     }
 
     return (
@@ -58,7 +58,7 @@ class RecentCommitView extends React.Component {
         src={avatarUrl}
         title={email}
       />
-    )
+    );
   }
 
   renderAuthors() {

--- a/lib/views/recent-commits-view.js
+++ b/lib/views/recent-commits-view.js
@@ -45,23 +45,20 @@ class RecentCommitView extends React.Component {
   renderAuthor(email) {
     let match = email.match(/^(\d+)\+[^@]+@users.noreply.github.com$/)
 
+    let avatarUrl
     if (match) {
-      return (
-        <img className="github-RecentCommit-avatar"
-          key={email}
-          src={'https://avatars.githubusercontent.com/u/' + match[1] + '?s=32'}
-          title={email}
-        />
-      )
+      avatarUrl = 'https://avatars.githubusercontent.com/u/' + match[1] + '?s=32'
     } else {
-      return (
-        <img className="github-RecentCommit-avatar"
-          key={email}
-          src={'https://avatars.githubusercontent.com/u/e?email=' + encodeURIComponent(email) + '&s=32'}
-          title={email}
-        />
-      )
+      avatarUrl = 'https://avatars.githubusercontent.com/u/e?email=' + encodeURIComponent(email) + '&s=32'
     }
+
+    return (
+      <img className="github-RecentCommit-avatar"
+        key={email}
+        src={avatarUrl}
+        title={email}
+      />
+    )
   }
 
   renderAuthors() {


### PR DESCRIPTION
### Description of the Change

Render avatars for ID-based anonymous GitHub email addresses.

### Alternate Designs

None considered.

### Benefits

People using ID-based anonymous GitHub email addresses get their avatars rendered too :grinning:

### Possible Drawbacks

Makes the code a little more complex.

### Applicable Issues

Fixes #1341
