### PR TITLE
Never open panes while the StagingView does not have focus

### DIFF
--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -630,6 +630,10 @@ export default class StagingView extends React.Component {
   }
 
   async didSelectSingleItem(selectedItem, openNew = false) {
+    if (!this.hasFocus()) {
+      return;
+    }
+
     if (this.state.selection.getActiveListKey() === 'conflicts') {
       if (openNew) {
         await this.showMergeConflictFileForPath(selectedItem.filePath, {activate: true});
@@ -811,5 +815,9 @@ export default class StagingView extends React.Component {
     }
 
     return false;
+  }
+
+  hasFocus() {
+    return this.refRoot.contains(document.activeElement);
   }
 }

--- a/test/views/staging-view.test.js
+++ b/test/views/staging-view.test.js
@@ -331,6 +331,7 @@ describe('StagingView', function() {
         const wrapper = mount(React.cloneElement(app, {
           unstagedChanges: filePatches,
         }));
+        sinon.stub(wrapper.instance(), 'hasFocus').returns(true);
 
         const getPanesWithStalePendingFilePatchItem = sinon.stub(
           wrapper.instance(),
@@ -401,6 +402,7 @@ describe('StagingView', function() {
         const wrapper = mount(React.cloneElement(app, {
           unstagedChanges: filePatches,
         }));
+        sinon.stub(wrapper.instance(), 'hasFocus').returns(true);
 
         const getPanesWithStalePendingFilePatchItem = sinon.stub(
           wrapper.instance(),
@@ -482,6 +484,7 @@ describe('StagingView', function() {
       const wrapper = mount(React.cloneElement(app, {
         unstagedChanges: filePatches,
       }));
+      sinon.stub(wrapper.instance(), 'hasFocus').returns(true);
 
       let selectedItems = wrapper.instance().getSelectedItems();
       assert.lengthOf(selectedItems, 1);
@@ -501,6 +504,7 @@ describe('StagingView', function() {
       const wrapper = mount(React.cloneElement(app, {
         unstagedChanges: [{filePath: 'a.txt', status: 'modified'}],
       }));
+      sinon.stub(wrapper.instance(), 'hasFocus').returns(true);
 
       sinon.stub(wrapper.instance(), 'getPanesWithStalePendingFilePatchItem').returns(['item1']);
       wrapper.setProps({unstagedChanges: []}); // when repo is changed, lists are cleared out and data is fetched for new repo


### PR DESCRIPTION
The root cause of #1287 and #1444 is that FilePatch items are launched from a `didSelectSingleItem()` function that's triggered from a `componentDidUpdate()` lifecycle method when the selection model has changed. `componentDidUpdate()` is called when you click on an item or navigate with the keyboard because both actions call `setState()` with a modified selection model, but it's _also_ called when the component is re-rendered with changed props, and any time that this occurs with a referentially unequal selection model, the patch is shown.

Previously (#1472), I was trying to track down the causes of a component update being triggered with a referentially unequal selection model that weren't due to an explicit user interaction. That's tricky, though, and I'd never know if I actually caught them all. Now I'm taking a different tack and simply short-circuiting pane creation if the StagingView doesn't have focus. Let's see if this is more reliable.