### PR TITLE
Band-aids for focus management code

### DIFF
--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -319,6 +319,10 @@ export default class GitTabController extends React.Component {
   }
 
   rememberLastFocus(event) {
+    if (!this.refView) {
+      return;
+    }
+
     this.lastFocus = this.refView.rememberFocus(event) || GitTabView.focus.STAGING;
   }
 

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -556,7 +556,7 @@ export default class CommitView extends React.Component {
       return CommitView.focus.COMMIT_BUTTON;
     }
 
-    if (this.refCoAuthorSelect.map(c => c.wrapper.contains(event.target)).getOr(false)) {
+    if (this.refCoAuthorSelect.map(c => c.wrapper && c.wrapper.contains(event.target)).getOr(false)) {
       return CommitView.focus.COAUTHOR_INPUT;
     }
 


### PR DESCRIPTION
Until we can tackle #1403 and improve our approach to remembering focus within the git and GitHub tabs, let's add quick guards against trying to call methods on empty refs.