### PR TITLE
Forward methods from GitTabItem to GitTabController

### DIFF
--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -5,7 +5,9 @@ import PropTypes from 'prop-types';
 
 import GitTabView from '../views/git-tab-view';
 import UserStore from '../models/user-store';
-import {CommitPropType, BranchPropType, FilePatchItemPropType, MergeConflictItemPropType} from '../prop-types';
+import {
+  CommitPropType, BranchPropType, FilePatchItemPropType, MergeConflictItemPropType, RefHolderPropType,
+} from '../prop-types';
 import {autobind} from '../helpers';
 
 export default class GitTabController extends React.Component {
@@ -46,6 +48,7 @@ export default class GitTabController extends React.Component {
     discardWorkDirChangesForPaths: PropTypes.func.isRequired,
     openFiles: PropTypes.func.isRequired,
     initializeRepo: PropTypes.func.isRequired,
+    controllerRef: RefHolderPropType,
   };
 
   constructor(props, context) {
@@ -132,6 +135,10 @@ export default class GitTabController extends React.Component {
   componentDidMount() {
     this.refreshResolutionProgress(false, false);
     this.refView.refRoot.addEventListener('focusin', this.rememberLastFocus);
+
+    if (this.props.controllerRef) {
+      this.props.controllerRef.setter(this);
+    }
   }
 
   componentDidUpdate() {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -83,12 +83,12 @@ export default class RootController extends React.Component {
       credentialDialogQuery: null,
     };
 
-    this.refGitTabController = new RefHolder();
+    this.refGitTabItem = new RefHolder();
     this.refGitHubTabController = new RefHolder();
 
     this.gitTabTracker = new TabTracker('git', {
       uri: 'atom-github://dock-item/git',
-      getController: () => this.refGitTabController.get(),
+      getController: () => this.refGitTabItem.get(),
       getWorkspace: () => this.props.workspace,
     });
 
@@ -180,10 +180,10 @@ export default class RootController extends React.Component {
             workspace={this.props.workspace}
             onDidCloseItem={this.props.destroyGitTabItem}
             stubItem={this.props.gitTabStubItem}
-            itemHolder={this.refGitTabController}
+            itemHolder={this.refGitTabItem}
             activate={this.props.startOpen}>
             <GitTabItem
-              ref={this.refGitTabController.setter}
+              ref={this.refGitTabItem.setter}
               workspace={this.props.workspace}
               commandRegistry={this.props.commandRegistry}
               notificationManager={this.props.notificationManager}
@@ -464,7 +464,7 @@ export default class RootController extends React.Component {
   }
 
   surfaceFromFileAtPath(filePath, stagingStatus) {
-    this.refGitTabController.map(c => {
+    this.refGitTabItem.map(c => {
       return c.focusAndSelectStagingItem(filePath, stagingStatus);
     });
   }
@@ -482,7 +482,7 @@ export default class RootController extends React.Component {
   }
 
   quietlySelectItem(filePath, stagingStatus) {
-    return this.refGitTabController.map(c => {
+    return this.refGitTabItem.map(c => {
       return c.quietlySelectItem(filePath, stagingStatus);
     });
   }

--- a/lib/items/git-tab-item.js
+++ b/lib/items/git-tab-item.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import RefHolder from '../models/ref-holder';
 import GitTabContainer from '../containers/git-tab-container';
 
 export default class GitTabItem extends React.Component {
@@ -8,9 +9,18 @@ export default class GitTabItem extends React.Component {
     repository: PropTypes.object.isRequired,
   }
 
+  constructor(props) {
+    super(props);
+
+    this.refController = new RefHolder();
+  }
+
   render() {
     return (
-      <GitTabContainer {...this.props} />
+      <GitTabContainer
+        controllerRef={this.refController}
+        {...this.props}
+      />
     );
   }
 
@@ -43,5 +53,27 @@ export default class GitTabItem extends React.Component {
 
   getWorkingDirectory() {
     return this.props.repository.getWorkingDirectoryPath();
+  }
+
+  // Forwarded to the controller instance when one is present
+
+  rememberLastFocus(...args) {
+    return this.refController.map(c => c.rememberLastFocus(...args));
+  }
+
+  restoreFocus(...args) {
+    return this.refController.map(c => c.restoreFocus(...args));
+  }
+
+  hasFocus(...args) {
+    return this.refController.map(c => c.hasFocus(...args));
+  }
+
+  focusAndSelectStagingItem(...args) {
+    return this.refController.map(c => c.focusAndSelectStagingItem(...args));
+  }
+
+  quietlySelectItem(...args) {
+    return this.refController.map(c => c.quietlySelectItem(...args));
   }
 }


### PR DESCRIPTION
When GitTabController was split into multiple components in #1458, methods on GitTabController that were intended to be called imperatively broke because the ref contained a GitTabItem instead. Let's forward methods to the controller for now.

Fixes an uncaught exception when pressing `core:right` on a file patch item, likely along with other bugs.