### PR TITLE
Restore getRealItemPromise()

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -353,6 +353,8 @@ export function createItem(node, componentHolder = null, uri = null, extra = {})
 
     getRealItem: () => componentHolder.get(),
 
+    getRealItemPromise: () => componentHolder.getPromise(),
+
     ...extra,
   };
 

--- a/lib/models/ref-holder.js
+++ b/lib/models/ref-holder.js
@@ -65,6 +65,19 @@ export default class RefHolder {
     return this.value;
   }
 
+  getPromise() {
+    if (this.isEmpty()) {
+      return new Promise(resolve => {
+        const sub = this.observe(value => {
+          resolve(value);
+          sub.dispose();
+        });
+      });
+    }
+
+    return Promise.resolve(this.get());
+  }
+
   map(block) {
     if (!this.isEmpty()) {
       return block(this.get());

--- a/test/models/ref-holder.test.js
+++ b/test/models/ref-holder.test.js
@@ -52,6 +52,17 @@ describe('RefHolder', function() {
     assert.isTrue(callback.calledWith(12));
   });
 
+  it('resolves a promise when it becomes available', async function() {
+    const thing = Symbol('Thing');
+    const h = new RefHolder();
+
+    const promise = h.getPromise();
+
+    h.setter(thing);
+    assert.strictEqual(await promise, thing);
+    assert.strictEqual(await h.getPromise(), thing);
+  });
+
   describe('.on()', function() {
     it('returns an existing RefHolder as-is', function() {
       const original = new RefHolder();


### PR DESCRIPTION
Our item proxy was missing a `getRealItemPromise()` method that some methods in `RootController` were expecting to be present. Let's implement it.

Fixes #1451.