### PR TITLE
RefHolder.map() should return a RefHolder

### DIFF
--- a/lib/models/ref-holder.js
+++ b/lib/models/ref-holder.js
@@ -78,11 +78,8 @@ export default class RefHolder {
     return Promise.resolve(this.get());
   }
 
-  map(block) {
-    if (!this.isEmpty()) {
-      return block(this.get());
-    }
-    return null;
+  map(present, absent = () => this) {
+    return RefHolder.on(this.isEmpty() ? absent() : present(this.get()));
   }
 
   setter = value => {

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -388,7 +388,7 @@ export default class CommitView extends React.Component {
   }
 
   excludeCoAuthor() {
-    const author = this.refCoAuthorSelect.map(c => c.getFocusedOption());
+    const author = this.refCoAuthorSelect.map(c => c.getFocusedOption()).getOr(null);
     if (!author || author.isNew()) {
       return;
     }
@@ -548,15 +548,15 @@ export default class CommitView extends React.Component {
       return CommitView.focus.EDITOR;
     }
 
-    if (this.refAbortMergeButton.map(e => e.contains(event.target))) {
+    if (this.refAbortMergeButton.map(e => e.contains(event.target)).getOr(false)) {
       return CommitView.focus.ABORT_MERGE_BUTTON;
     }
 
-    if (this.refCommitButton.map(e => e.contains(event.target))) {
+    if (this.refCommitButton.map(e => e.contains(event.target)).getOr(false)) {
       return CommitView.focus.COMMIT_BUTTON;
     }
 
-    if (this.refCoAuthorSelect.map(c => c.wrapper.contains(event.target))) {
+    if (this.refCoAuthorSelect.map(c => c.wrapper.contains(event.target)).getOr(false)) {
       return CommitView.focus.COAUTHOR_INPUT;
     }
 

--- a/test/models/ref-holder.test.js
+++ b/test/models/ref-holder.test.js
@@ -26,6 +26,51 @@ describe('RefHolder', function() {
     assert.strictEqual(h.get(), 1234);
   });
 
+  describe('map', function() {
+    it('returns an empty RefHolder as-is', function() {
+      const h = new RefHolder();
+      assert.strictEqual(h.map(() => 14), h);
+    });
+
+    it('returns a new RefHolder wrapping the value returned from its present block', function() {
+      const h = new RefHolder();
+      h.setter(12);
+      assert.strictEqual(h.map(x => x + 1).get(), 13);
+    });
+
+    it('returns a RefHolder returned from its present block', function() {
+      const h0 = new RefHolder();
+      h0.setter(14);
+
+      const o = h0.map(() => {
+        const h1 = new RefHolder();
+        h1.setter(12);
+        return h1;
+      });
+
+      assert.notStrictEqual(0, h0);
+      assert.strictEqual(o.get(), 12);
+    });
+
+    it('returns a new RefHolder wrapping the value returned from its absent block', function() {
+      const h = new RefHolder();
+
+      const o = h.map(x => 1, () => 2);
+      assert.strictEqual(o.get(), 2);
+    });
+
+    it('returns a RefHolder returned from its absent block', function() {
+      const h0 = new RefHolder();
+
+      const o = h0.map(x => 1, () => {
+        const h1 = new RefHolder();
+        h1.setter(1);
+        return h1;
+      });
+      assert.strictEqual(o.get(), 1);
+    });
+  });
+
   it('notifies subscribers when it becomes available', function() {
     const h = new RefHolder();
     const callback = sinon.spy();


### PR DESCRIPTION
Some ambient code cleanup. It was bugging me that `RefHolder` _looked_ monadic but implemented `.map()` inconsistently: it returned `null` on an empty holder but the block result when an item was present.