### PR TITLE
Revisit commit message processing

### DIFF
--- a/lib/controllers/commit-controller.js
+++ b/lib/controllers/commit-controller.js
@@ -122,16 +122,18 @@ export default class CommitController extends React.Component {
     this.subscriptions.dispose();
   }
 
-  commit(message, coAuthors = [], amend) {
-    let msg;
+  commit(message, coAuthors = [], amend = false) {
+    let msg, verbatim;
     if (this.isCommitMessageEditorExpanded()) {
       msg = this.getCommitMessageEditors()[0].getText();
+      verbatim = false;
     } else {
       const wrapMessage = this.props.config.get('github.automaticCommitMessageWrapping');
       msg = wrapMessage ? wrapCommitMessage(message) : message;
+      verbatim = true;
     }
 
-    return this.props.commit(msg.trim(), {amend, coAuthors});
+    return this.props.commit(msg.trim(), {amend, coAuthors, verbatim});
   }
 
   setCommitMessage(message) {

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -437,21 +437,31 @@ export default class GitShellOutStrategy {
     return this.exec(args, {stdin: patch, writeOperation: true});
   }
 
-  async commit(rawMessage, {allowEmpty, amend, coAuthors} = {}) {
+  async commit(rawMessage, {allowEmpty, amend, coAuthors, verbatim} = {}) {
     const args = ['commit'];
     let msg;
 
-    // if amending and no new message is passed, use last commit's message
+    // if amending and no new message is passed, use last commit's message. Ensure that we don't
+    // mangle it in the process.
     if (amend && rawMessage.length === 0) {
       const {unbornRef, messageBody, messageSubject} = await this.getHeadCommit();
       if (unbornRef) {
         msg = rawMessage;
       } else {
         msg = `${messageSubject}\n\n${messageBody}`.trim();
-        args.push('--cleanup=verbatim');
+        verbatim = true;
       }
     } else {
       msg = rawMessage;
+    }
+
+    // Determine the cleanup mode.
+    if (verbatim) {
+      args.push('--cleanup=verbatim');
+    } else {
+      const configured = await this.getConfig('commit.cleanup');
+      const mode = (configured && configured !== 'default') ? configured : 'strip';
+      args.push(`--cleanup=${mode}`);
     }
 
     // add co-author commit trailers if necessary

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -438,14 +438,18 @@ export default class GitShellOutStrategy {
   }
 
   async commit(rawMessage, {allowEmpty, amend, coAuthors} = {}) {
-    const args = ['commit', '--cleanup=strip'];
-
+    const args = ['commit'];
     let msg;
 
     // if amending and no new message is passed, use last commit's message
     if (amend && rawMessage.length === 0) {
       const {unbornRef, messageBody, messageSubject} = await this.getHeadCommit();
-      msg = unbornRef ? rawMessage : `${messageSubject}\n\n${messageBody}`.trim();
+      if (unbornRef) {
+        msg = rawMessage;
+      } else {
+        msg = `${messageSubject}\n\n${messageBody}`.trim();
+        args.push('--cleanup=verbatim');
+      }
     } else {
       msg = rawMessage;
     }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -332,19 +332,21 @@ export function destroyEmptyFilePatchPaneItems(workspace) {
 }
 
 export function extractCoAuthorsAndRawCommitMessage(commitMessage) {
-  let rawMessage = '';
-  const coAuthors = commitMessage.split(LINE_ENDING_REGEX).reduce((authors, line) => {
+  const messageLines = [];
+  const coAuthors = [];
+
+  for (const line of commitMessage.split(LINE_ENDING_REGEX)) {
     const match = line.match(CO_AUTHOR_REGEX);
     if (match) {
       // eslint-disable-next-line no-unused-vars
       const [_, name, email] = match;
-      authors.push({name, email});
+      coAuthors.push({name, email});
     } else {
-      rawMessage += line;
+      messageLines.push(line);
     }
-    return authors;
-  }, []);
-  return {message: rawMessage, coAuthors};
+  }
+
+  return {message: messageLines.join('\n'), coAuthors};
 }
 
 export function createItem(node, componentHolder = null, uri = null, extra = {}) {

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -132,7 +132,7 @@ export default class Repository {
   async getMergeMessage() {
     try {
       const contents = await fs.readFile(path.join(this.getGitDirectoryPath(), 'MERGE_MSG'), {encoding: 'utf8'});
-      return contents;
+      return contents.split(/\n/).filter(line => line.length > 0 && !line.startsWith('#')).join('\n');
     } catch (e) {
       return null;
     }

--- a/test/controllers/commit-controller.test.js
+++ b/test/controllers/commit-controller.test.js
@@ -159,44 +159,53 @@ describe('CommitController', function() {
     });
 
     describe('message formatting', function() {
-      let commitSpy;
+      let commitSpy, wrapper;
+
       beforeEach(function() {
         commitSpy = sinon.stub().returns(Promise.resolve());
         app = React.cloneElement(app, {commit: commitSpy});
+        wrapper = shallow(app, {disableLifecycleMethods: true});
       });
 
-      it('wraps the commit message body at 72 characters if github.automaticCommitMessageWrapping is true', async function() {
-        config.set('github.automaticCommitMessageWrapping', false);
+      describe('with automatic wrapping disabled', function() {
+        beforeEach(function() {
+          config.set('github.automaticCommitMessageWrapping', false);
+        });
 
-        const wrapper = shallow(app, {disableLifecycleMethods: true});
+        it('passes commit messages through unchanged', async function() {
+          await wrapper.instance().commit([
+            'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor',
+            '',
+            'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+          ].join('\n'));
 
-        await wrapper.instance().commit([
-          'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor',
-          '',
-          'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-        ].join('\n'));
+          assert.strictEqual(commitSpy.args[0][0], [
+            'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor',
+            '',
+            'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+          ].join('\n'));
+        });
+      });
 
-        assert.deepEqual(commitSpy.args[0][0].split('\n'), [
-          'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor',
-          '',
-          'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-        ]);
+      describe('with automatic wrapping enabled', function() {
+        beforeEach(function() {
+          config.set('github.automaticCommitMessageWrapping', true);
+        });
 
-        commitSpy.reset();
-        config.set('github.automaticCommitMessageWrapping', true);
+        it('wraps lines within the commit body at 72 characters', async function() {
+          await wrapper.instance().commit([
+            'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor',
+            '',
+            'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+          ].join('\n'));
 
-        await wrapper.instance().commit([
-          'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor',
-          '',
-          'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-        ].join('\n'));
-
-        assert.deepEqual(commitSpy.args[0][0].split('\n'), [
-          'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor',
-          '',
-          'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ',
-          'ut aliquip ex ea commodo consequat.',
-        ]);
+          assert.strictEqual(commitSpy.args[0][0], [
+            'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor',
+            '',
+            'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ',
+            'ut aliquip ex ea commodo consequat.',
+          ].join('\n'));
+        });
       });
     });
 

--- a/test/controllers/commit-controller.test.js
+++ b/test/controllers/commit-controller.test.js
@@ -206,6 +206,11 @@ describe('CommitController', function() {
             'ut aliquip ex ea commodo consequat.',
           ].join('\n'));
         });
+
+        it('preserves existing line wraps within the commit body', async function() {
+          await wrapper.instance().commit('a\n\nb\n\nc');
+          assert.strictEqual(commitSpy.args[0][0], 'a\n\nb\n\nc');
+        });
       });
     });
 

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -572,7 +572,10 @@ describe('GitTabController', function() {
           assert.strictEqual(wrapper.find('CommitView').instance().editor.getText(), '');
 
           commandRegistry.dispatch(workspaceElement, 'github:amend-last-commit');
-          await assert.async.deepEqual(repository.commit.args[0][1], {amend: true, coAuthors: []});
+          await assert.async.deepEqual(
+            repository.commit.args[0][1],
+            {amend: true, coAuthors: [], verbatim: true},
+          );
 
           // amending should commit all unstaged changes
           await updateWrapper(repository, wrapper);
@@ -594,7 +597,10 @@ describe('GitTabController', function() {
           assert.lengthOf(wrapper.find('GitTabView').prop('stagedChanges'), 0);
 
           commandRegistry.dispatch(workspaceElement, 'github:amend-last-commit');
-          await assert.async.deepEqual(repository.commit.args[0][1], {amend: true, coAuthors: []});
+          await assert.async.deepEqual(
+            repository.commit.args[0][1],
+            {amend: true, coAuthors: [], verbatim: true},
+          );
           await updateWrapper(repository, wrapper);
 
           // new commit message is used
@@ -617,7 +623,10 @@ describe('GitTabController', function() {
 
           commandRegistry.dispatch(workspaceElement, 'github:amend-last-commit');
           // verify that coAuthor was passed
-          await assert.async.deepEqual(repository.commit.args[0][1], {amend: true, coAuthors: [author]});
+          await assert.async.deepEqual(
+            repository.commit.args[0][1],
+            {amend: true, coAuthors: [author], verbatim: true},
+          );
           await repository.commit.returnValues[0];
           await updateWrapper(repository, wrapper);
 
@@ -640,7 +649,10 @@ describe('GitTabController', function() {
           commandRegistry.dispatch(workspaceElement, 'github:amend-last-commit');
 
           // verify that coAuthor was passed
-          await assert.async.deepEqual(repository.commit.args[0][1], {amend: true, coAuthors: [author]});
+          await assert.async.deepEqual(
+            repository.commit.args[0][1],
+            {amend: true, coAuthors: [author], verbatim: true},
+          );
           await repository.commit.returnValues[0];
           await updateWrapper(repository, wrapper);
 
@@ -673,7 +685,10 @@ describe('GitTabController', function() {
           // amend again
           commandRegistry.dispatch(workspaceElement, 'github:amend-last-commit');
           // verify that NO coAuthor was passed
-          await assert.async.deepEqual(repository.commit.args[0][1], {amend: true, coAuthors: []});
+          await assert.async.deepEqual(
+            repository.commit.args[0][1],
+            {amend: true, coAuthors: [], verbatim: true},
+          );
           await repository.commit.returnValues[0];
           await updateWrapper(repository, wrapper);
 

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -791,6 +791,17 @@ import {normalizeGitHelperPath, getTempDir} from '../lib/helpers';
           assert.notDeepEqual(lastCommit, amendedCommit);
           assert.deepEqual(lastCommitParent, amendedCommitParent);
         });
+
+        it('leaves the commit message unchanged', async function() {
+          const workingDirPath = await cloneRepository('multiple-commits');
+          const git = createTestStrategy(workingDirPath);
+          await git.commit('first\n\nsecond\n\nthird', {allowEmpty: true});
+
+          await git.commit('', {amend: true, allowEmpty: true});
+          const amendedCommit = await git.getHeadCommit();
+          assert.strictEqual(amendedCommit.messageSubject, 'first');
+          assert.strictEqual(amendedCommit.messageBody, 'second\n\nthird');
+        });
       });
     });
 

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -236,7 +236,7 @@ import {normalizeGitHelperPath, getTempDir} from '../lib/helpers';
 
           Detailed explanation paragraph 2
           #123 with an issue reference
-        `.trim(), {allowEmpty: true});
+        `.trim(), {allowEmpty: true, verbatim: true});
 
         const commits = await git.getCommits({max: 1});
         assert.lengthOf(commits, 1);
@@ -960,7 +960,7 @@ import {normalizeGitHelperPath, getTempDir} from '../lib/helpers';
           command: 'commit',
           progressiveTense: 'committing',
           usesPromptServerAlready: false,
-          action: () => git.commit('message'),
+          action: () => git.commit('message', {verbatim: true}),
         },
         {
           command: 'merge',

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -784,7 +784,7 @@ import {normalizeGitHelperPath, getTempDir} from '../lib/helpers';
             '',
             'other stuff        ',
             '',
-            '',
+            'and things',
             '',
           ].join('\n');
         });
@@ -792,12 +792,34 @@ import {normalizeGitHelperPath, getTempDir} from '../lib/helpers';
         it('strips out comments and whitespace from message passed', async function() {
           const workingDirPath = await cloneRepository('multiple-commits');
           const git = createTestStrategy(workingDirPath);
+          await git.setConfig('commit.cleanup', 'default');
 
           await git.commit(message, {allowEmpty: true});
 
           const lastCommit = await git.getHeadCommit();
-          assert.deepEqual(lastCommit.messageSubject, 'Make a commit');
-          assert.deepEqual(lastCommit.messageBody, 'other stuff');
+          assert.strictEqual(lastCommit.messageSubject, 'Make a commit');
+          assert.strictEqual(lastCommit.messageBody, 'other stuff\n\nand things');
+        });
+
+        it('passes a message through verbatim', async function() {
+          const workingDirPath = await cloneRepository('multiple-commits');
+          const git = createTestStrategy(workingDirPath);
+          await git.setConfig('commit.cleanup', 'default');
+
+          await git.commit(message, {allowEmpty: true, verbatim: true});
+
+          const lastCommit = await git.getHeadCommit();
+          assert.strictEqual(lastCommit.messageSubject, 'Make a commit');
+          assert.strictEqual(lastCommit.messageBody, [
+            '# Comments:',
+            '#  blah blah blah',
+            '',
+            '',
+            '',
+            'other stuff        ',
+            '',
+            'and things',
+          ].join('\n'));
         });
       });
 


### PR DESCRIPTION
Revisit the ways that we preprocess commit messages - both in JavaScript and in choosing a `--cleanup` argument to `git commit` - to better handle some edge cases and bugs.

- [x] Fixes #1465. It turns out that `GitShellOutStrategy.getHeadCommit()` was stripping newlines from the message body of any parsed commit, which was altering amended commit messages. Added `--cleanup=verbatim` as well to ensure that the message isn't manipulated by git either.
- [x] Fixes #1382 by adding a `{verbatim}` option to `GitShellOutStrategy.commit()`. When set to `true`, the message argument is used for the commit exactly as-is. When set to `false`, if `commit.cleanup` is set to a value and is not `"default"`, default to `"strip"`.
  - [x] Don't generate the "merge text" commit message template when a merge is detected (because we would no longer strip out the `#` lines).
  - [x] Set `{verbatim: true}` when committing from the mini editor, but not from a full editor.

Note that I'm defaulting `--cleanup` to `"strip"` for non-verbatim commits instead of `"whitespace"`. My logic here is that committing through Atom with a full-editor message feels more like editing a message in `$EDITOR` and committing than it does doing a `commit -m`, so we want to act like git "when the message is to be edited":

> Same as strip if the message is to be edited. Otherwise whitespace.