### PR TITLE
Identity "large" file patches by diff byte size, not line count

### DIFF
--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -218,7 +218,7 @@ export default class FilePatchController extends React.Component {
             commandRegistry={this.props.commandRegistry}
             tooltips={this.props.tooltips}
             displayLargeDiffMessage={!this.shouldDisplayLargeDiff(this.state.filePatch)}
-            lineCount={this.lineCount}
+            byteCount={this.byteCount}
             handleShowDiffClick={this.handleShowDiffClick}
             hunks={hunks}
             executableModeChange={executableModeChange}
@@ -254,7 +254,8 @@ export default class FilePatchController extends React.Component {
       return true;
     }
 
-    return filePatch.getByteSize() < this.props.largeDiffByteThreshold;
+    this.byteCount = filePatch.getByteSize();
+    return this.byteCount < this.props.largeDiffByteThreshold;
   }
 
   onDidChangeTitle(callback) {

--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -1,5 +1,4 @@
 import path from 'path';
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Point} from 'atom';

--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -12,7 +12,7 @@ import {autobind} from '../helpers';
 
 export default class FilePatchController extends React.Component {
   static propTypes = {
-    largeDiffLineThreshold: PropTypes.number,
+    largeDiffByteThreshold: PropTypes.number,
     getRepositoryForWorkdir: PropTypes.func.isRequired,
     workingDirectoryPath: PropTypes.string.isRequired,
     commandRegistry: PropTypes.object.isRequired,
@@ -30,7 +30,7 @@ export default class FilePatchController extends React.Component {
   }
 
   static defaultProps = {
-    largeDiffLineThreshold: 1000,
+    largeDiffByteThreshold: 1000,
     switchboard: new Switchboard(),
   }
 
@@ -254,9 +254,7 @@ export default class FilePatchController extends React.Component {
       return true;
     }
 
-    const lineCount = filePatch.getHunks().reduce((acc, hunk) => hunk.getLines().length, 0);
-    this.lineCount = lineCount;
-    return lineCount < this.props.largeDiffLineThreshold;
+    return filePatch.getByteSize() < this.props.largeDiffByteThreshold;
   }
 
   onDidChangeTitle(callback) {

--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -30,7 +30,7 @@ export default class FilePatchController extends React.Component {
   }
 
   static defaultProps = {
-    largeDiffByteThreshold: 1000,
+    largeDiffByteThreshold: 32768,
     switchboard: new Switchboard(),
   }
 

--- a/lib/models/file-patch.js
+++ b/lib/models/file-patch.js
@@ -55,6 +55,10 @@ class Patch {
     return this.hunks;
   }
 
+  getByteSize() {
+    return this.getHunks().reduce((acc, hunk) => acc + hunk.getByteSize(), 0);
+  }
+
   clone(opts = {}) {
     return new Patch({
       status: opts.status !== undefined ? opts.status : this.status,
@@ -118,6 +122,10 @@ export default class FilePatch {
 
   getNewSymlink() {
     return this.getNewFile().getSymlink();
+  }
+
+  getByteSize() {
+    return this.getPatch().getByteSize();
   }
 
   didChangeExecutableMode() {

--- a/lib/models/hunk-line.js
+++ b/lib/models/hunk-line.js
@@ -86,4 +86,8 @@ export default class HunkLine {
   toString() {
     return this.getOrigin() + (this.getStatus() === 'nonewline' ? ' ' : '') + this.getText();
   }
+
+  getByteSize() {
+    return Buffer.byteLength(this.getText(), 'utf8');
+  }
 }

--- a/lib/models/hunk.js
+++ b/lib/models/hunk.js
@@ -76,4 +76,8 @@ export default class Hunk {
   toString() {
     return this.getLines().reduce((a, b) => a + b.toString() + '\n', this.getHeader());
   }
+
+  getByteSize() {
+    return this.getLines().reduce((acc, line) => acc + line.getByteSize(), 0);
+  }
 }

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -82,7 +82,8 @@ export default class FilePatchView extends React.Component {
     this.disposables.add(new Disposable(() => window.removeEventListener('mouseup', this.mouseup)));
   }
 
-  componentWillReceiveProps(nextProps) {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const hunksChanged = this.props.hunks.length !== nextProps.hunks.length ||
       this.props.hunks.some((hunk, index) => hunk !== nextProps.hunks[index]);
 

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -48,7 +48,7 @@ export default class FilePatchView extends React.Component {
     didDiveIntoCorrespondingFilePatch: PropTypes.func.isRequired,
     switchboard: PropTypes.instanceOf(Switchboard),
     displayLargeDiffMessage: PropTypes.bool,
-    lineCount: PropTypes.number,
+    byteCount: PropTypes.number,
     handleShowDiffClick: PropTypes.func.isRequired,
   }
 
@@ -150,7 +150,7 @@ export default class FilePatchView extends React.Component {
     return (
       <div className="large-file-patch">
         <p>
-          This is a large diff of {this.props.lineCount} lines. For performance reasons, it is not rendered by default.
+          This is a large diff of {this.props.byteCount} bytes. For performance reasons, it is not rendered by default.
         </p>
         <button className="btn btn-primary" onClick={this.props.handleShowDiffClick}>Show Diff</button>
       </div>

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import {CompositeDisposable, Disposable} from 'event-kit';
 import cx from 'classnames';
+import bytes from 'bytes';
 
 import HunkView from './hunk-view';
 import SimpleTooltip from '../atom/simple-tooltip';
@@ -147,10 +147,12 @@ export default class FilePatchView extends React.Component {
   }
 
   renderLargeDiffMessage() {
+    const human = bytes.format(this.props.byteCount);
+
     return (
       <div className="large-file-patch">
         <p>
-          This is a large diff of {this.props.byteCount} bytes. For performance reasons, it is not rendered by default.
+          This is a large {human} diff. For performance reasons, it is not rendered by default.
         </p>
         <button className="btn btn-primary" onClick={this.props.handleShowDiffClick}>Show Diff</button>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -252,7 +252,7 @@
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "integrity": "sha1-hNt+nrVTHfGKjF4L+25EnlXmVLI=",
       "dev": true,
       "requires": {
         "samsam": "1.3.0"
@@ -692,7 +692,7 @@
     "babel-core": {
       "version": "6.26.3",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "integrity": "sha1-suLwnjQtDwyI4vAuBneUEl51wgc=",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "babel-generator": "^6.26.0",
@@ -2019,6 +2019,11 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -2412,7 +2417,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -2678,7 +2683,7 @@
     "dugite": {
       "version": "1.66.0",
       "resolved": "https://registry.npmjs.org/dugite/-/dugite-1.66.0.tgz",
-      "integrity": "sha512-H5Dmc5HZIj1RKUCcgNvocSBXjoimWgcAXzwHEHXnQXJTv9ZYaCP/ZD7njmE635ShJ22xXAWz5Xm+tf4Klj181g==",
+      "integrity": "sha1-X9q2aDwLU4p5vb7Emenz0+pyEPk=",
       "requires": {
         "checksum": "^0.1.1",
         "mkdirp": "^0.5.1",
@@ -2700,7 +2705,7 @@
     "electron-devtools-installer": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-2.2.4.tgz",
-      "integrity": "sha512-b5kcM3hmUqn64+RUcHjjr8ZMpHS2WJ5YO0pnG9+P/RTdx46of/JrEjuciHWux6pE+On6ynWhHJF53j/EDJN0PA==",
+      "integrity": "sha1-JhpQM343Eh0zi5ZvB5IutJOah2M=",
       "dev": true,
       "requires": {
         "7zip": "0.0.6",
@@ -3291,7 +3296,7 @@
     "event-kit": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-2.5.0.tgz",
-      "integrity": "sha512-tUDxeNC9JzN2Tw/f8mLtksY34v1hHmaR7lV7X4p04XSjaeUhFMfzjF6Nwov9e0EKGEx63BaKcgXKxjpQaPo0wg=="
+      "integrity": "sha1-L3KxHitfUzzByVA4cEBiSkoCX+g="
     },
     "execa": {
       "version": "0.7.0",
@@ -3696,7 +3701,7 @@
     "fs-extra": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "integrity": "sha1-DYUhIuW8W+tFP7Ao6cDJvzY0DJQ=",
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3977,7 +3982,7 @@
     "graphql": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
-      "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
+      "integrity": "sha1-THQK48Iigj5wBAlvgy57k7IQgnA=",
       "requires": {
         "iterall": "^1.2.1"
       }
@@ -4741,7 +4746,7 @@
     "just-extend": {
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "integrity": "sha1-7G55QQ/5FORyZSq/oOYDwD1g6QU=",
       "dev": true
     },
     "keytar": {
@@ -5212,7 +5217,7 @@
     "lolex": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
-      "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
+      "integrity": "sha1-nAh6aexEDjnT95Z2fPGyzcQ9XqU=",
       "dev": true
     },
     "loose-envify": {
@@ -5316,7 +5321,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -5494,7 +5499,8 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true
         }
       }
@@ -6159,7 +6165,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
     },
     "process": {
       "version": "0.5.2",
@@ -6338,7 +6344,7 @@
     "react": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.4.0.tgz",
-      "integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
+      "integrity": "sha1-QCwtuDM1M2+6GWLAi5jGJyYX1YU=",
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
@@ -6349,7 +6355,7 @@
     "react-dom": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.0.tgz",
-      "integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
+      "integrity": "sha1-CZ8GfdWCfONqKer5ps3Hy/Yhax4=",
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
@@ -6982,7 +6988,7 @@
     "request": {
       "version": "2.87.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "integrity": "sha1-MvACNc0I1IK00NaNuTqCnA7VdW4=",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.6.0",
@@ -7074,7 +7080,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "requires": {
         "glob": "^7.0.5"
       }
@@ -7130,7 +7136,7 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
       "dev": true
     },
     "semver": {
@@ -7231,7 +7237,7 @@
     "sinon": {
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.10.tgz",
-      "integrity": "sha512-+YT7Mjr8BpNndQqUUydO/daggF4yuOAnsVjo+5Ayx3mLLUqojfkXhDkho4HB5VgfnZYSdhxVDPbfJ2EBXFMSvA==",
+      "integrity": "sha1-ooKzanR1ZkyfmHGRCOVUaQcSkCM=",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "^2.0.0",
@@ -7246,7 +7252,7 @@
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -7413,7 +7419,7 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
       "requires": {
         "source-map": "^0.5.6"
       }
@@ -7599,7 +7605,7 @@
     "stringstream": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI=",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
     "babel-preset-react": "6.24.1",
+    "bytes": "^3.0.0",
     "classnames": "2.2.5",
     "compare-sets": "1.0.1",
     "dugite": "^1.66.0",

--- a/test/controllers/file-patch-controller.test.js
+++ b/test/controllers/file-patch-controller.test.js
@@ -97,9 +97,8 @@ describe('FilePatchController', function() {
       getFilePatchForPath = sinon.stub(repository, 'getFilePatchForPath');
     });
 
-    describe('when the FilePatch has many lines', function() {
+    describe('when the FilePatch is too large', function() {
       it('renders a confirmation widget', async function() {
-
         const hunk1 = new Hunk(0, 0, 1, 1, '', [
           new HunkLine('line-1', 'added', 1, 1),
           new HunkLine('line-2', 'added', 2, 2),
@@ -112,7 +111,7 @@ describe('FilePatchController', function() {
 
         getFilePatchForPath.returns(filePatch);
 
-        const wrapper = mount(React.cloneElement(component, {largeDiffLineThreshold: 5}));
+        const wrapper = mount(React.cloneElement(component, {largeDiffByteThreshold: 5}));
 
         await assert.async.match(wrapper.text(), /large diff/);
       });
@@ -129,7 +128,7 @@ describe('FilePatchController', function() {
         const filePatch = createFilePatch(filePath, filePath, 'modified', [hunk]);
         getFilePatchForPath.returns(filePatch);
 
-        const wrapper = mount(React.cloneElement(component, {largeDiffLineThreshold: 5}));
+        const wrapper = mount(React.cloneElement(component, {largeDiffByteThreshold: 5}));
 
         await assert.async.isTrue(wrapper.update().find('.large-file-patch').exists());
         wrapper.find('.large-file-patch').find('button').simulate('click');
@@ -152,7 +151,7 @@ describe('FilePatchController', function() {
         getFilePatchForPath.returns(filePatch1);
 
         const wrapper = mount(React.cloneElement(component, {
-          filePath: filePatch1.getPath(), largeDiffLineThreshold: 5,
+          filePath: filePatch1.getPath(), largeDiffByteThreshold: 5,
         }));
 
         await assert.async.isTrue(wrapper.update().find('.large-file-patch').exists());

--- a/test/controllers/file-patch-controller.test.js
+++ b/test/controllers/file-patch-controller.test.js
@@ -113,7 +113,7 @@ describe('FilePatchController', function() {
 
         const wrapper = mount(React.cloneElement(component, {largeDiffByteThreshold: 5}));
 
-        await assert.async.match(wrapper.text(), /large diff/);
+        await assert.async.match(wrapper.text(), /large .+ diff/);
       });
 
       it('renders the full diff when the confirmation is clicked', async function() {

--- a/test/models/file-patch.test.js
+++ b/test/models/file-patch.test.js
@@ -370,4 +370,21 @@ describe('FilePatch', function() {
       `);
     });
   });
+
+  it('returns the size in bytes from getByteSize()', function() {
+    const filePatch = createFilePatch('a.txt', 'a.txt', 'modified', [
+      new Hunk(1, 1, 1, 3, '', [
+        new HunkLine('line-1', 'added', -1, 1),
+        new HunkLine('line-2', 'added', -1, 2),
+        new HunkLine('line-3', 'unchanged', 1, 3),
+      ]),
+      new Hunk(5, 7, 5, 4, '', [
+        new HunkLine('line-4', 'unchanged', 5, 7),
+        new HunkLine('line-5', 'deleted', 6, -1),
+        new HunkLine('line-6', 'deleted', 7, -1),
+      ]),
+    ]);
+
+    assert.strictEqual(filePatch.getByteSize(), 36);
+  });
 });


### PR DESCRIPTION
A diff that contains changes to a small number of very long lines still chokes up the works. Let's call a patch "large" if it exceeds a given byte count instead of line count.

Fixes #1425.