### PR TITLE
RFC for Issueish List View

### DIFF
--- a/docs/rfcs/002-issueish-list.md
+++ b/docs/rfcs/002-issueish-list.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Summary
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -61,7 +61,7 @@ For a pull request, the issueish pane shows:
 * Reaction emoji and counts.
 * Details and links for all status checks.
 
-_TBD: Issueish pane item design_
+![pane](https://user-images.githubusercontent.com/378023/41007657-cfc8d3c0-6961-11e8-9bf7-7d5b7353199c.png)
 
 ## Drawbacks
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -42,7 +42,7 @@ Each list item renders a tile containing a compact set of information about that
 
 ![list item](https://user-images.githubusercontent.com/378023/41136622-1102db54-6b12-11e8-8b9b-49ecc45ac98f.png)
 
-Clicking on a list item opens an issueish pane item for the chosen issueish in the same pane container as the parent component (by default, the right dock). If the issuish pane item is already open, it is activated instead.
+Clicking on a list item opens an issueish pane item for the chosen issueish. If the issueish pane item is already open, it is activated instead.
 
 ### Issueish Pane Item: Pull Request
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -61,7 +61,7 @@ For a pull request, the issueish pane shows:
 * Reaction emoji and counts.
 * Details and links for all status checks.
 
-![pane](https://user-images.githubusercontent.com/378023/41007657-cfc8d3c0-6961-11e8-9bf7-7d5b7353199c.png)
+![pane](https://user-images.githubusercontent.com/378023/41007709-0f9ba9a0-6962-11e8-8b2f-bf6aee8cf8fc.png)
 
 ## Drawbacks
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -50,18 +50,24 @@ For a pull request, the issueish pane shows:
 
 * Author avatar
 * Title
+* Link to .com. -> [atom/github#1503](https://github.com/atom/github/pull/1503)
+* PR status badge. -> `Open`.
+* Branches -> `master` < `aw/rfc-pr-list`
+* `Commits` with count, links to .com (for now)
+* `Checks` with count, links to .com (for now)
+* `Files changed` with count, links to .com (for now)
+  * Plus a "Checkout" button to fetch (if necessary) and check out the pull request. Only enabled if the current pull request is not the current one.
+* `Conversation` with comment count.
+  * Reaction emoji and counts.
+  * Full description as rendered markdown.
+  * Comments as rendered markdown.
 * Controls for actions:
-  * "Checkout" to fetch (if necessary) and check out the pull request. Only enabled if the current pull request is not the current one.
-  * "Browse" to launch a browser on the corresponding GitHub page.
-  * "Merge" to merge the pull request on GitHub if it is open.
+  * Mergability status -> `Able to merge`, links to the [Merging controls at the bottom](https://github.com/atom/github/pull/1503#partial-pull-merging)
+  * "Merge PR" to merge the pull request on GitHub if it is open.
   * "Close" to close the pull request, unmerged, if it is open.
-  * "Re-open" to re-open a pull request if it is closed.
-* Pull request overview details: commit count, files changed.
-* Full description as rendered markdown.
-* Reaction emoji and counts.
-* Details and links for all status checks.
+  * "Re-open PR" to re-open a pull request if it is closed.
 
-![pane](https://user-images.githubusercontent.com/378023/41007709-0f9ba9a0-6962-11e8-8b2f-bf6aee8cf8fc.png)
+![pane](https://user-images.githubusercontent.com/378023/41033008-0900b4ec-69c0-11e8-9def-68e6f5b40901.png)
 
 ## Drawbacks
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -22,7 +22,7 @@ As an initial building block toward a pull request review workflow.
 
 Within the GitHub panel, render a vertical stack of two collapsible lists of _issueish_ (pull request or issue) items:
 
-_First list: current pull request_. If the active branch is associated with one or more open pull requests on the GitHub repository, render an item for each.
+_First list: current pull request_. If the active branch is associated with one or more open pull requests on a GitHub repository, render an item for each. "Associated with" means that the pull request's head ref and head repository matches the upstream remote ref for the current branch in the active git repository.
 
 _Second list: all open pull requests_. List all open pull requests on the GitHub repository.
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -72,7 +72,7 @@ For a pull request, the issueish pane shows:
 
 If no current PR can be found, an "open new pull request" button is shown. If needed it also offers to "Publish" or "Push".
 
-![new pr](https://user-images.githubusercontent.com/378023/41100932-9a3cd7be-6a9d-11e8-85c4-c995b71548c7.png)
+![new pr](https://user-images.githubusercontent.com/378023/41136021-33249004-6b0f-11e8-9cf0-08bf4a9a2767.png)
 
 When the current branch is the default branch, e.g. `master`, a message is shown that suggests to "Create a new branch".
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -99,8 +99,8 @@ With that said, the choices for the specific lists we show are a bit arbitrary. 
 
 ### Before RFC merge:
 
-- [ ] What else from the existing issueish pane should we keep? Comments, timeline events?
-- [ ] Are there other pull request actions it would be useful to support?
+- [x] What else from the existing issueish pane should we keep? Comments, timeline events?
+- [x] Are there other pull request actions it would be useful to support?
 
 ### Out of scope:
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -24,7 +24,7 @@ Within the GitHub panel, render a vertical stack of two collapsible lists of _is
 
 _First list: current pull request_. If the active branch is associated with one or more open pull requests on a GitHub repository, render an item for each. "Associated with" means that the pull request's head ref and head repository matches the upstream remote ref for the current branch in the active git repository.
 
-_Second list: all open pull requests_. List all open pull requests on the GitHub repository.
+_Second list: all open pull requests_. List all open pull requests on the GitHub repository, ordered by decreasing creation date.
 
 Each list has a "collapse arrow" in its header. Clicking the collapse arrow toggles the visibility of that list's items, accordion-style.
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -78,7 +78,8 @@ When the current branch is the default branch, e.g. `master`, a message is shown
 
 ## Drawbacks
 
-None!
+* "All pull requests" could easily be overwhelming on moderate to high traffic repositories. Stay tuned for more refinements on this front.
+* Opening a pane item for each pull request click is heavyweight from a navigational standpoint. We may explore showing a popup as an intermediate state.
 
 ## Rationale and alternatives
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -106,6 +106,7 @@ With that said, the choices for the specific lists we show are a bit arbitrary. 
 
 - [ ] How can we allow a user to customize the lists?
 - [ ] How can we notify a user about updated activity on a visible PR?
+- [ ] Where should you be able to merge, close, or re-open pull requests?
 
 ## Implementation phases
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -1,0 +1,98 @@
+# Issueish List
+
+## Status
+
+Proposed
+
+## Summary
+
+Display a list of all open pull requests in the current repository in the GitHub tab.
+
+## Motivation
+
+To provide a navigational element that makes sense even if you aren't on an active feature branch.
+
+To give users a way to see an overview of what's going on in the repository.
+
+As an initial building block toward a pull request review workflow.
+
+## Explanation
+
+### Accordion Lists
+
+Within the GitHub panel, render a vertical stack of two collapsible lists of _issueish_ (pull request or issue) items:
+
+_First list: current pull request_. If the active branch is associated with one or more open pull requests on the GitHub repository, render an item for each.
+
+_Second list: all open pull requests_. List all open pull requests on the GitHub repository.
+
+Each list has a "collapse arrow" in its header. Clicking the collapse arrow toggles the visibility of that list's items, accordion-style.
+
+If either list exceeds 20 items, truncate the list and render a "More" link after its final item. Clicking "more" opens the corresponding search on GitHub.
+
+Each list item renders a tile containing a compact set of information about that pull request:
+
+* Mini author avatar
+* Title, truncated if necessary
+* Terse relative timestamp (1d, 2h, 30m)
+* Pull request state: open, closed, merged
+* Status check summary
+
+_TBD: Tile design_
+
+Clicking on a list item opens an issueish pane item for the chosen issueish in the same pane container as the parent component (by default, the right dock). If the issuish pane item is already open, it is activated instead.
+
+### Issueish Pane Item: Pull Request
+
+For a pull request, the issueish pane shows:
+
+* Author avatar
+* Title
+* Controls for actions:
+  * "Checkout" to fetch (if necessary) and check out the pull request. Only enabled if the current pull request is not the current one.
+  * "Browse" to launch a browser on the corresponding GitHub page.
+  * "Merge" to merge the pull request on GitHub if it is open.
+  * "Close" to close the pull request, unmerged, if it is open.
+  * "Re-open" to re-open a pull request if it is closed.
+* Pull request overview details: commit count, files changed.
+* Full description as rendered markdown.
+* Reaction emoji and counts.
+* Details and links for all status checks.
+
+_TBD: Issueish pane item design_
+
+## Drawbacks
+
+This does not offer a mechanism to create _new_ pull requests, which we have now. We also lose timeline events on the pull request.
+
+## Rationale and alternatives
+
+Our current GitHub panel focuses on showing you stuff about _the pull request that's associated with your current branch._ The problem is, it's difficult to unambiguously determine that in the general case.
+
+The first thing you see today when you open the GitHub panel on the `master` branch of an active repository is not very helpful:
+
+![wat](https://user-images.githubusercontent.com/17565/40857603-99b92304-65a9-11e8-986e-0f14290bda8a.png)
+
+This is a list of _all pull requests on GitHub that have a head ref called "master", from any head repository_. You can then "pin" any of them to see that pull request's details. This isn't useful on master and it's unclear to users what this is supposed to accomplish. Pinning was intended to be an infrequent edge case when we couldn't find the right PR for a given ref, not the first interaction you have with the package.
+
+Showing a PR list instead provides a uniform, more easily understood entry point to the package's GitHub functionality, and paves the way to other pull-request-focused activities in the future. "All open PRs" seems like a reasonable starting point, and "current PRs" preserves the ability to take advantage of your local editor context.
+
+With that said, the choices for the specific lists we show are a bit arbitrary. We'll need to research and iterate on them quite a bit to find what's most useful for the most people, but for now we need to start with something.
+
+## Unresolved questions
+
+### Before RFC merge:
+
+- [ ] How can we still offer "push/publish+new pull request"?
+- [ ] What else from the existing issueish pane should we keep? Comments, timeline events?
+- [ ] Are there other pull request actions it would be useful to support?
+
+### Out of scope:
+
+- [ ] How can we allow a user to customize the lists?
+- [ ] How can we notify a user about updated activity on a visible PR?
+
+## Implementation phases
+
+1. Accordion list infrastructure: search model, collapsible list component.
+2. Revisit the issueish pane item and add action controls.

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -68,9 +68,17 @@ For a pull request, the issueish pane shows:
 
 ![detail](https://user-images.githubusercontent.com/378023/41097077-ba228d00-6a91-11e8-9445-a9557c03e6b6.png)
 
+## New PR
+
+If no current PR can be found, an "open new pull request" button is shown. If needed it also offers to "Publish" or "Push".
+
+![new pr](https://user-images.githubusercontent.com/378023/41100932-9a3cd7be-6a9d-11e8-85c4-c995b71548c7.png)
+
+When the current branch is the default branch, e.g. `master`, a message is shown that suggests to "Create a new branch".
+
 ## Drawbacks
 
-This does not offer a mechanism to create _new_ pull requests, which we have now. We also lose timeline events on the pull request.
+None!
 
 ## Rationale and alternatives
 
@@ -90,7 +98,6 @@ With that said, the choices for the specific lists we show are a bit arbitrary. 
 
 ### Before RFC merge:
 
-- [ ] How can we still offer "push/publish+new pull request"?
 - [ ] What else from the existing issueish pane should we keep? Comments, timeline events?
 - [ ] Are there other pull request actions it would be useful to support?
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -56,9 +56,9 @@ For a pull request, the issueish pane shows:
 * "Checkout" button to fetch (if necessary) and check out the pull request. Only enabled if the current pull request is not the current one.
 * `Commits` with count, links to .com (for now), optional with avatars
 * `Checks` with count, links to .com (for now)
+  * CI status, each item links to the detail page
 * `Files changed` with count, links to .com (for now), optional with "+-" bar
-* Controls for actions:
-  * Mergability status -> `Able to merge`, links to the [Merging controls at the bottom](https://github.com/atom/github/pull/1503#partial-pull-merging)
+* Mergability status -> `Able to merge`, links to the [Merging controls at the bottom](https://github.com/atom/github/pull/1503#partial-pull-merging)
   * "Merge PR" to merge the pull request on GitHub if it is open.
   * "Close" to close the pull request, unmerged, if it is open.
   * "Re-open PR" to re-open a pull request if it is closed.
@@ -66,7 +66,7 @@ For a pull request, the issueish pane shows:
   * Reaction emoji and counts.
   * Description (PR body) as rendered markdown.
 
-![detail](https://user-images.githubusercontent.com/378023/41097077-ba228d00-6a91-11e8-9445-a9557c03e6b6.png)
+![detail](https://user-images.githubusercontent.com/378023/41140383-368c45d4-6b28-11e8-87c2-d4bc0b47fbe1.png)
 
 ## New PR
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -30,17 +30,17 @@ Each list has a "collapse arrow" in its header. Clicking the collapse arrow togg
 
 If either list exceeds 20 items, truncate the list and render a "More" link after its final item. Clicking "more" opens the corresponding search on GitHub.
 
-![list](https://user-images.githubusercontent.com/378023/41097007-7a32992e-6a91-11e8-9c4b-2417cf94dce9.png)
+![list](https://user-images.githubusercontent.com/378023/41136538-ad5c461c-6b11-11e8-9e1d-e4a674f628cd.png)
 
 Each list item renders a tile containing a compact set of information about that pull request:
 
 * Mini author avatar
 * Title, truncated if necessary
-* Terse relative timestamp (1d, 2h, 30m)
-* Pull request state: open, closed, merged
+* PR number (`#1503`)
 * Status check summary
+* Terse relative timestamp (1d, 2h, 30m)
 
-![List item](https://user-images.githubusercontent.com/378023/40964791-f4b28fbc-68e6-11e8-907b-c7d436d0d315.png)
+![list item](https://user-images.githubusercontent.com/378023/41136622-1102db54-6b12-11e8-8b9b-49ecc45ac98f.png)
 
 Clicking on a list item opens an issueish pane item for the chosen issueish in the same pane container as the parent component (by default, the right dock). If the issuish pane item is already open, it is activated instead.
 
@@ -72,7 +72,7 @@ For a pull request, the issueish pane shows:
 
 If no current PR can be found, an "open new pull request" button is shown. If needed it also offers to "Publish" or "Push".
 
-![new pr](https://user-images.githubusercontent.com/378023/41136021-33249004-6b0f-11e8-9cf0-08bf4a9a2767.png)
+![new pr](https://user-images.githubusercontent.com/378023/41136463-5d8dd3da-6b11-11e8-8e28-72275a691430.png)
 
 When the current branch is the default branch, e.g. `master`, a message is shown that suggests to "Create a new branch".
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -30,6 +30,8 @@ Each list has a "collapse arrow" in its header. Clicking the collapse arrow togg
 
 If either list exceeds 20 items, truncate the list and render a "More" link after its final item. Clicking "more" opens the corresponding search on GitHub.
 
+![Lists](https://user-images.githubusercontent.com/378023/40964722-ceb9d95a-68e6-11e8-90b3-1c155cdc2c00.png)
+
 Each list item renders a tile containing a compact set of information about that pull request:
 
 * Mini author avatar
@@ -38,7 +40,7 @@ Each list item renders a tile containing a compact set of information about that
 * Pull request state: open, closed, merged
 * Status check summary
 
-![tile](https://user-images.githubusercontent.com/378023/40955959-8458ae7c-68c8-11e8-974e-40441a3b5679.png)
+![List item](https://user-images.githubusercontent.com/378023/40964791-f4b28fbc-68e6-11e8-907b-c7d436d0d315.png)
 
 Clicking on a list item opens an issueish pane item for the chosen issueish in the same pane container as the parent component (by default, the right dock). If the issuish pane item is already open, it is activated instead.
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -38,7 +38,7 @@ Each list item renders a tile containing a compact set of information about that
 * Pull request state: open, closed, merged
 * Status check summary
 
-_TBD: Tile design_
+![tile](https://user-images.githubusercontent.com/378023/40955959-8458ae7c-68c8-11e8-974e-40441a3b5679.png)
 
 Clicking on a list item opens an issueish pane item for the chosen issueish in the same pane container as the parent component (by default, the right dock). If the issuish pane item is already open, it is activated instead.
 

--- a/docs/rfcs/004-issueish-list.md
+++ b/docs/rfcs/004-issueish-list.md
@@ -30,7 +30,7 @@ Each list has a "collapse arrow" in its header. Clicking the collapse arrow togg
 
 If either list exceeds 20 items, truncate the list and render a "More" link after its final item. Clicking "more" opens the corresponding search on GitHub.
 
-![Lists](https://user-images.githubusercontent.com/378023/40964722-ceb9d95a-68e6-11e8-90b3-1c155cdc2c00.png)
+![list](https://user-images.githubusercontent.com/378023/41097007-7a32992e-6a91-11e8-9c4b-2417cf94dce9.png)
 
 Each list item renders a tile containing a compact set of information about that pull request:
 
@@ -48,26 +48,25 @@ Clicking on a list item opens an issueish pane item for the chosen issueish in t
 
 For a pull request, the issueish pane shows:
 
+* PR status badge. -> `Open`.
+* Link to .com. -> [atom/github#1503](https://github.com/atom/github/pull/1503)
 * Author avatar
 * Title
-* Link to .com. -> [atom/github#1503](https://github.com/atom/github/pull/1503)
-* PR status badge. -> `Open`.
 * Branches -> `master` < `aw/rfc-pr-list`
-* `Commits` with count, links to .com (for now)
+* "Checkout" button to fetch (if necessary) and check out the pull request. Only enabled if the current pull request is not the current one.
+* `Commits` with count, links to .com (for now), optional with avatars
 * `Checks` with count, links to .com (for now)
-* `Files changed` with count, links to .com (for now)
-  * Plus a "Checkout" button to fetch (if necessary) and check out the pull request. Only enabled if the current pull request is not the current one.
-* `Conversation` with comment count.
-  * Reaction emoji and counts.
-  * Full description as rendered markdown.
-  * Comments as rendered markdown.
+* `Files changed` with count, links to .com (for now), optional with "+-" bar
 * Controls for actions:
   * Mergability status -> `Able to merge`, links to the [Merging controls at the bottom](https://github.com/atom/github/pull/1503#partial-pull-merging)
   * "Merge PR" to merge the pull request on GitHub if it is open.
   * "Close" to close the pull request, unmerged, if it is open.
   * "Re-open PR" to re-open a pull request if it is closed.
+* `Conversation` with comment count, opens the current PR timeline in a center pane.
+  * Reaction emoji and counts.
+  * Description (PR body) as rendered markdown.
 
-![pane](https://user-images.githubusercontent.com/378023/41033008-0900b4ec-69c0-11e8-9def-68e6f5b40901.png)
+![detail](https://user-images.githubusercontent.com/378023/41097077-ba228d00-6a91-11e8-9445-a9557c03e6b6.png)
 
 ## Drawbacks
 


### PR DESCRIPTION
:stars: _This is based heavily on some excellent internal design ideation by @simurai._ :stars:

I've tried to identify a subset of his vision we could reasonably ship within the next month. My goals here are to rework the GitHub panel to explore an alternate navigation flow (accordion list :point_right: detail panes) and to set the stage just enough to be able to start on pull request reviews. This will likely not be the final form of "the first pane you see," because we'll probably have at least one level of navigation above it - but we can explore that in follow-on work.

**[:art: rendered :art:](https://github.com/atom/github/blob/aw/rfc-pr-list/docs/rfcs/004-issueish-list.md)**

/cc @donokuda 
/cc @sguthals 
/cc @shana 