### PR TITLE
Markers and Layers and Contexts

### DIFF
--- a/lib/atom/atom-text-editor.js
+++ b/lib/atom/atom-text-editor.js
@@ -35,6 +35,8 @@ const editorProps = {
   showCursorOnSelection: PropTypes.bool,
 };
 
+export const TextEditorContext = React.createContext();
+
 export default class AtomTextEditor extends React.PureComponent {
   static propTypes = {
     ...editorProps,
@@ -48,7 +50,6 @@ export default class AtomTextEditor extends React.PureComponent {
     text: '',
     didChange: () => {},
     didChangeCursorPosition: () => {},
-    refElement: () => {},
   }
 
   constructor(props, context) {
@@ -59,13 +60,20 @@ export default class AtomTextEditor extends React.PureComponent {
     this.suppressChange = false;
 
     this.refElement = new RefHolder();
+    this.refModel = new RefHolder();
+
+    this.subs.add(
+      this.refElement.observe(element => this.refModel.setter(element.getModel())),
+    );
   }
 
   render() {
     return (
       <Fragment>
         <atom-text-editor ref={this.refElement.setter} />
-        {this.props.children}
+        <TextEditorContext.Provider value={this.refModel}>
+          {this.props.children}
+        </TextEditorContext.Provider>
       </Fragment>
     );
   }

--- a/lib/atom/atom-text-editor.js
+++ b/lib/atom/atom-text-editor.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
 import {CompositeDisposable} from 'event-kit';
 
@@ -41,6 +41,7 @@ export default class AtomTextEditor extends React.PureComponent {
     text: PropTypes.string,
     didChange: PropTypes.func,
     didChangeCursorPosition: PropTypes.func,
+    children: PropTypes.element,
   }
 
   static defaultProps = {
@@ -62,7 +63,10 @@ export default class AtomTextEditor extends React.PureComponent {
 
   render() {
     return (
-      <atom-text-editor ref={this.refElement.setter} />
+      <Fragment>
+        <atom-text-editor ref={this.refElement.setter} />
+        {this.props.children}
+      </Fragment>
     );
   }
 

--- a/lib/atom/atom-text-editor.js
+++ b/lib/atom/atom-text-editor.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {CompositeDisposable} from 'event-kit';
 
 import RefHolder from '../models/ref-holder';
-import {autobind} from '../helpers';
+import {autobind, extractProps} from '../helpers';
 
 const editorProps = {
   autoIndent: PropTypes.bool,
@@ -106,12 +106,7 @@ export default class AtomTextEditor extends React.PureComponent {
   }
 
   setAttributesOnElement(theProps) {
-    const modelProps = Object.keys(editorProps).reduce((ps, key) => {
-      if (theProps[key] !== undefined) {
-        ps[key] = theProps[key];
-      }
-      return ps;
-    }, {});
+    const modelProps = extractProps(this.props, editorProps);
 
     const editor = this.getModel();
     editor.update(modelProps);

--- a/lib/atom/decoration.js
+++ b/lib/atom/decoration.js
@@ -1,15 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import {CompositeDisposable} from 'event-kit';
+import {Disposable} from 'event-kit';
 
-import {createItem} from '../helpers';
+import {createItem, autobind} from '../helpers';
 import {RefHolderPropType} from '../prop-types';
+import {TextEditorContext} from './atom-text-editor';
+import {MarkerContext} from './marker';
+import RefHolder from '../models/ref-holder';
 
-export default class Decoration extends React.Component {
+class WrappedDecoration extends React.Component {
   static propTypes = {
-    editor: PropTypes.object.isRequired,
-    marker: PropTypes.object.isRequired,
+    editorHolder: RefHolderPropType.isRequired,
+    markerHolder: RefHolderPropType.isRequired,
     type: PropTypes.oneOf(['line', 'line-number', 'highlight', 'overlay', 'gutter', 'block']).isRequired,
     position: PropTypes.oneOf(['head', 'tail', 'before', 'after']),
     className: PropTypes.string,
@@ -26,10 +29,14 @@ export default class Decoration extends React.Component {
   constructor(props, context) {
     super(props, context);
 
-    this.decoration = null;
-    this.subscriptions = new CompositeDisposable();
+    autobind(this, 'observeParents');
+
+    this.decorationHolder = new RefHolder();
+    this.editorSub = new Disposable();
+    this.markerSub = new Disposable();
 
     this.domNode = null;
+    this.item = null;
     if (['gutter', 'overlay', 'block'].includes(this.props.type)) {
       this.domNode = document.createElement('div');
       this.domNode.className = 'react-atom-decoration';
@@ -41,40 +48,20 @@ export default class Decoration extends React.Component {
   }
 
   componentDidMount() {
-    this.setupDecoration();
+    this.editorSub = this.props.editorHolder.observe(this.observeParents);
+    this.markerSub = this.props.markerHolder.observe(this.observeParents);
   }
 
-  shouldComponentUpdate(nextProps) {
-    if (
-      this.props.editor !== nextProps.editor ||
-      this.props.marker !== nextProps.marker ||
-      this.props.type !== nextProps.type ||
-      this.props.position !== nextProps.position ||
-      this.props.className !== nextProps.className ||
-      this.props.children !== nextProps.children
-    ) { return true; }
-
-    // Compare additional options.
-    const optionKeys = Object.keys(this.props.options);
-    const nextOptionKeys = Object.keys(nextProps.options);
-
-    if (optionKeys.length !== nextOptionKeys.length) {
-      return true;
-    } else {
-      for (let i = 0; i < optionKeys.length; i++) {
-        const key = optionKeys[i];
-        if (this.props.options[key] !== nextProps.options[key]) {
-          return true;
-        }
-      }
+  componentDidUpdate(prevProps) {
+    if (this.props.editorHolder !== prevProps.editorHolder) {
+      this.editorSub.dispose();
+      this.editorSub = this.state.editorHolder.observe(this.observeParents);
     }
 
-    return false;
-  }
-
-  componentDidUpdate() {
-    this.decoration && this.decoration.destroy();
-    this.setupDecoration();
+    if (this.props.markerHolder !== prevProps.markerHolder) {
+      this.markerSub.dispose();
+      this.markerSub = this.state.markerHolder.observe(this.observeParents);
+    }
   }
 
   render() {
@@ -88,14 +75,19 @@ export default class Decoration extends React.Component {
     }
   }
 
-  setupDecoration() {
-    if (this.decoration) {
+  observeParents() {
+    if (this.props.editorHolder.isEmpty() || this.props.markerHolder.isEmpty()) {
       return;
     }
 
-    let item = null;
-    if (this.usesItem()) {
-      item = createItem(this.domNode, this.props.itemHolder);
+    this.createDecoration();
+  }
+
+  createDecoration() {
+    this.decorationHolder.map(decoration => decoration.destroy());
+
+    if (!this.item) {
+      this.item = createItem(this.domNode, this.props.itemHolder);
     }
 
     const options = {
@@ -103,18 +95,78 @@ export default class Decoration extends React.Component {
       type: this.props.type,
       position: this.props.position,
       class: this.props.className,
-      item,
+      item: this.item,
     };
 
-    this.decoration = this.props.editor.decorateMarker(this.props.marker, options);
-    this.subscriptions.add(this.decoration.onDidDestroy(() => {
-      this.decoration = null;
-      this.subscriptions.dispose();
-    }));
+    const editor = this.props.editorHolder.get();
+    const marker = this.props.markerHolder.get();
+
+    this.decorationHolder.setter(
+      editor.decorateMarker(marker, options),
+    );
   }
 
   componentWillUnmount() {
-    this.decoration && this.decoration.destroy();
-    this.subscriptions.dispose();
+    this.decorationHolder.map(decoration => decoration.destroy());
+    this.editorSub.dispose();
+    this.markerSub.dispose();
+  }
+}
+
+export default class Decoration extends React.Component {
+  static propTypes = {
+    editor: PropTypes.object,
+    marker: PropTypes.object,
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      editorHolder: RefHolder.on(this.props.editor),
+      markerHolder: RefHolder.on(this.props.marker),
+    };
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    const editorChanged = state.editorHolder.map(editor => editor !== props.editor).getOr(props.editor !== undefined);
+    const markerChanged = state.markerHolder.map(marker => marker !== props.marker).getOr(props.marker !== undefined);
+
+    if (!editorChanged && !markerChanged) {
+      return null;
+    }
+
+    const nextState = {};
+    if (editorChanged) {
+      nextState.editorHolder = RefHolder.on(props.editor);
+    }
+    if (markerChanged) {
+      nextState.markerHolder = RefHolder.on(props.marker);
+    }
+    return nextState;
+  }
+
+  render() {
+    if (!this.state.editorHolder.isEmpty() && !this.state.markerHolder.isEmpty()) {
+      return (
+        <WrappedDecoration
+          {...this.props}
+          editorHolder={this.state.editorHolder}
+          markerHolder={this.state.markerHolder}
+        />
+      );
+    }
+
+    return (
+      <TextEditorContext.Consumer>
+        {editorHolder => (
+          <MarkerContext.Consumer>
+            {markerHolder => (
+              <WrappedDecoration {...this.props} editorHolder={editorHolder} markerHolder={markerHolder} />
+            )}
+          </MarkerContext.Consumer>
+        )}
+      </TextEditorContext.Consumer>
+    );
   }
 }

--- a/lib/atom/marker-layer.js
+++ b/lib/atom/marker-layer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Disposable} from 'event-kit';
 
-import {autobind} from '../helpers';
+import {autobind, extractProps} from '../helpers';
 import RefHolder from '../models/ref-holder';
 import {TextEditorContext} from './atom-text-editor';
 
@@ -76,10 +76,7 @@ class WrappedMarkerLayer extends React.Component {
       this.layer.destroy();
     }
 
-    const options = Object.keys(markerLayerProps).reduce((opts, propName) => {
-      opts[propName] = this.props[propName];
-      return opts;
-    }, {});
+    const options = extractProps(this.props, markerLayerProps);
 
     this.layer = this.state.editorHolder.map(editor => editor.addMarkerLayer(options)).getOr(null);
     this.props.handleID(this.getID());

--- a/lib/atom/marker-layer.js
+++ b/lib/atom/marker-layer.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Disposable} from 'event-kit';
+
+import {autobind} from '../helpers';
+import RefHolder from '../models/ref-holder';
+
+const markerLayerProps = {
+  maintainHistory: PropTypes.bool,
+  persistent: PropTypes.bool,
+};
+
+export default class MarkerLayer extends React.Component {
+  static propTypes = {
+    ...markerLayerProps,
+    editor: PropTypes.object,
+    children: PropTypes.element,
+  };
+
+  constructor(props) {
+    super(props);
+
+    autobind(this, 'createLayer');
+
+    this.sub = new Disposable();
+    this.layer = null;
+    this.state = {
+      editorHolder: RefHolder.on(this.props.editor),
+    };
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    if (state.editorHolder.map(e => e === props.editor).getOr(props.editor === undefined)) {
+      return null;
+    }
+
+    return {
+      editorHolder: RefHolder.on(props.editor),
+    };
+  }
+
+  componentDidMount() {
+    this.observeEditor();
+  }
+
+  render() {
+    return this.props.children || null;
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.editorHolder !== prevState.editorHolder) {
+      this.observeEditor();
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.layer) {
+      this.layer.destroy();
+    }
+    this.sub.dispose();
+  }
+
+  observeEditor() {
+    this.sub.dispose();
+    this.sub = this.state.editorHolder.observe(this.createLayer);
+  }
+
+  createLayer() {
+    if (this.layer) {
+      this.layer.destroy();
+    }
+
+    const options = Object.keys(markerLayerProps).reduce((opts, propName) => {
+      opts[propName] = this.props[propName];
+      return opts;
+    }, {});
+
+    this.layer = this.state.editorHolder.map(editor => editor.addMarkerLayer(options)).getOr(null);
+  }
+
+  getID() {
+    return this.layer ? this.layer.id : undefined;
+  }
+}

--- a/lib/atom/marker-layer.js
+++ b/lib/atom/marker-layer.js
@@ -11,6 +11,8 @@ const markerLayerProps = {
   persistent: PropTypes.bool,
 };
 
+export const MarkerLayerContext = React.createContext();
+
 class WrappedMarkerLayer extends React.Component {
   static propTypes = {
     ...markerLayerProps,
@@ -29,7 +31,7 @@ class WrappedMarkerLayer extends React.Component {
     autobind(this, 'createLayer');
 
     this.sub = new Disposable();
-    this.layer = null;
+    this.layerHolder = new RefHolder();
     this.state = {
       editorHolder: RefHolder.on(this.props.editor),
     };
@@ -50,7 +52,11 @@ class WrappedMarkerLayer extends React.Component {
   }
 
   render() {
-    return this.props.children || null;
+    return (
+      <MarkerLayerContext.Provider value={this.layerHolder}>
+        {this.props.children}
+      </MarkerLayerContext.Provider>
+    );
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -60,9 +66,7 @@ class WrappedMarkerLayer extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.layer) {
-      this.layer.destroy();
-    }
+    this.layerHolder.map(layer => layer.destroy());
     this.sub.dispose();
   }
 
@@ -72,18 +76,19 @@ class WrappedMarkerLayer extends React.Component {
   }
 
   createLayer() {
-    if (this.layer) {
-      this.layer.destroy();
-    }
+    this.layerHolder.map(layer => layer.destroy());
 
     const options = extractProps(this.props, markerLayerProps);
 
-    this.layer = this.state.editorHolder.map(editor => editor.addMarkerLayer(options)).getOr(null);
+
+    this.layerHolder.setter(
+      this.state.editorHolder.map(editor => editor.addMarkerLayer(options)).getOr(null),
+    );
     this.props.handleID(this.getID());
   }
 
   getID() {
-    return this.layer ? this.layer.id : undefined;
+    return this.layerHolder.map(layer => layer.id).getOr(undefined);
   }
 }
 

--- a/lib/atom/marker-layer.js
+++ b/lib/atom/marker-layer.js
@@ -4,18 +4,24 @@ import {Disposable} from 'event-kit';
 
 import {autobind} from '../helpers';
 import RefHolder from '../models/ref-holder';
+import {TextEditorContext} from './atom-text-editor';
 
 const markerLayerProps = {
   maintainHistory: PropTypes.bool,
   persistent: PropTypes.bool,
 };
 
-export default class MarkerLayer extends React.Component {
+class WrappedMarkerLayer extends React.Component {
   static propTypes = {
     ...markerLayerProps,
     editor: PropTypes.object,
     children: PropTypes.element,
+    handleID: PropTypes.func,
   };
+
+  static defaultProps = {
+    handleID: () => {},
+  }
 
   constructor(props) {
     super(props);
@@ -76,9 +82,20 @@ export default class MarkerLayer extends React.Component {
     }, {});
 
     this.layer = this.state.editorHolder.map(editor => editor.addMarkerLayer(options)).getOr(null);
+    this.props.handleID(this.getID());
   }
 
   getID() {
     return this.layer ? this.layer.id : undefined;
+  }
+}
+
+export default class MarkerLayer extends React.Component {
+  render() {
+    return (
+      <TextEditorContext.Consumer>
+        {editor => <WrappedMarkerLayer editor={editor} {...this.props} />}
+      </TextEditorContext.Consumer>
+    );
   }
 }

--- a/lib/atom/marker.js
+++ b/lib/atom/marker.js
@@ -6,6 +6,8 @@ import {Range, Point} from 'atom';
 import {autobind, extractProps} from '../helpers';
 import {RefHolderPropType} from '../prop-types';
 import RefHolder from '../models/ref-holder';
+import {TextEditorContext} from './atom-text-editor';
+import {MarkerLayerContext} from './marker-layer';
 
 const MarkablePropType = PropTypes.shape({
   markBufferRange: PropTypes.func.isRequired,
@@ -51,7 +53,7 @@ class WrappedMarker extends React.Component {
     autobind(this, 'createMarker');
 
     this.sub = new Disposable();
-    this.marker = null;
+    this.markerHolder = new RefHolder();
   }
 
   componentDidMount() {
@@ -69,9 +71,7 @@ class WrappedMarker extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.marker) {
-      this.marker.destroy();
-    }
+    this.markerHolder.map(marker => marker.destroy());
     this.sub.dispose();
   }
 
@@ -81,35 +81,33 @@ class WrappedMarker extends React.Component {
   }
 
   createMarker() {
-    if (this.marker) {
-      this.marker.destroy();
-    }
+    this.markerHolder.map(marker => marker.destroy());
 
     const options = extractProps(this.props, markerProps);
 
-    this.marker = this.props.markableHolder.map(markable => {
-      if (this.props.bufferRange) {
-        return markable.markBufferRange(this.props.bufferRange, options);
-      }
+    this.markerHolder.setter(
+      this.props.markableHolder.map(markable => {
+        if (this.props.bufferRange) {
+          return markable.markBufferRange(this.props.bufferRange, options);
+        }
 
-      if (this.props.screenRange) {
-        return markable.markScreenRange(this.props.screenRange, options);
-      }
+        if (this.props.screenRange) {
+          return markable.markScreenRange(this.props.screenRange, options);
+        }
 
-      if (this.props.bufferPosition) {
-        return markable.markBufferPosition(this.props.bufferPosition, options);
-      }
+        if (this.props.bufferPosition) {
+          return markable.markBufferPosition(this.props.bufferPosition, options);
+        }
 
-      if (this.props.screenPosition) {
-        return markable.markScreenPosition(this.props.screenPosition, options);
-      }
+        if (this.props.screenPosition) {
+          return markable.markScreenPosition(this.props.screenPosition, options);
+        }
 
-      throw new Error('Expected one of bufferRange, screenRange, bufferPosition, or screenPosition to be set');
-    }).getOr(null);
+        throw new Error('Expected one of bufferRange, screenRange, bufferPosition, or screenPosition to be set');
+      }).getOr(null),
+    );
 
-    if (this.marker) {
-      this.props.handleID(this.marker.id);
-    }
+    this.markerHolder.map(marker => this.props.handleID(marker.id));
   }
 }
 
@@ -141,9 +139,25 @@ export default class Marker extends React.Component {
 
   render() {
     if (!this.state.markableHolder.isEmpty()) {
-      return <WrappedMarker markableHolder={this.state.markableHolder} {...this.props} />;
+      return <WrappedMarker {...this.props} markableHolder={this.state.markableHolder} />;
     }
 
-    return <WrappedMarker {...this.props} />;
+    /* eslint-disable react/jsx-key */
+    return (
+      <MarkerLayerContext.Consumer>
+        {layerHolder => {
+          if (layerHolder) {
+            return <WrappedMarker {...this.props} markableHolder={layerHolder} />;
+          } else {
+            return (
+              <TextEditorContext.Consumer>
+                {editorHolder => <WrappedMarker {...this.props} markableHolder={editorHolder} />}
+              </TextEditorContext.Consumer>
+            );
+          }
+        }}
+      </MarkerLayerContext.Consumer>
+    );
+    /* eslint-enable react/jsx-key */
   }
 }

--- a/lib/atom/marker.js
+++ b/lib/atom/marker.js
@@ -1,0 +1,155 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Disposable} from 'event-kit';
+import {Range, Point} from 'atom';
+
+import {autobind} from '../helpers';
+import {RefHolderPropType} from '../prop-types';
+import RefHolder from '../models/ref-holder';
+
+const MarkablePropType = PropTypes.shape({
+  markBufferRange: PropTypes.func.isRequired,
+  markScreenRange: PropTypes.func.isRequired,
+  markBufferPosition: PropTypes.func.isRequired,
+  markScreenPosition: PropTypes.func.isRequired,
+});
+
+const RangePropType = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.instanceOf(Range),
+]);
+
+const PointPropType = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.instanceOf(Point),
+]);
+
+const markerProps = {
+  maintainHistory: PropTypes.bool,
+  reversed: PropTypes.bool,
+  invalidate: PropTypes.oneOf(['never', 'surround', 'overlap', 'inside', 'touch']),
+};
+
+class WrappedMarker extends React.Component {
+  static propTypes = {
+    ...markerProps,
+    bufferRange: RangePropType,
+    bufferPosition: PointPropType,
+    screenRange: RangePropType,
+    screenPosition: PointPropType,
+    markableHolder: RefHolderPropType,
+    children: PropTypes.element,
+    handleID: PropTypes.func,
+  }
+
+  static defaultProps = {
+    handleID: () => {},
+  }
+
+  constructor(props) {
+    super(props);
+
+    autobind(this, 'createMarker');
+
+    this.sub = new Disposable();
+    this.marker = null;
+  }
+
+  componentDidMount() {
+    this.observeMarkable();
+  }
+
+  render() {
+    return this.props.children || null;
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.markableHolder !== prevProps.markableHolder) {
+      this.observeMarkable();
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.marker) {
+      this.marker.destroy();
+    }
+    this.sub.dispose();
+  }
+
+  observeMarkable() {
+    this.sub.dispose();
+    this.sub = this.props.markableHolder.observe(this.createMarker);
+  }
+
+  createMarker() {
+    if (this.marker) {
+      this.marker.destroy();
+    }
+
+    const options = Object.keys(markerProps).reduce((opts, propName) => {
+      if (this.props[propName] !== undefined) {
+        opts[propName] = this.props[propName];
+      }
+      return opts;
+    }, {});
+
+    this.marker = this.props.markableHolder.map(markable => {
+      if (this.props.bufferRange) {
+        return markable.markBufferRange(this.props.bufferRange, options);
+      }
+
+      if (this.props.screenRange) {
+        return markable.markScreenRange(this.props.screenRange, options);
+      }
+
+      if (this.props.bufferPosition) {
+        return markable.markBufferPosition(this.props.bufferPosition, options);
+      }
+
+      if (this.props.screenPosition) {
+        return markable.markScreenPosition(this.props.screenPosition, options);
+      }
+
+      throw new Error('Expected one of bufferRange, screenRange, bufferPosition, or screenPosition to be set');
+    }).getOr(null);
+
+    if (this.marker) {
+      this.props.handleID(this.marker.id);
+    }
+  }
+}
+
+export default class Marker extends React.Component {
+  static propTypes = {
+    editor: MarkablePropType,
+    layer: MarkablePropType,
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      markableHolder: RefHolder.on(props.layer || props.editor),
+    };
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    const markable = props.layer || props.editor;
+
+    if (state.markableHolder.map(m => m === markable).getOr(markable === undefined)) {
+      return {};
+    }
+
+    return {
+      markableHolder: RefHolder.on(markable),
+    };
+  }
+
+  render() {
+    if (!this.state.markableHolder.isEmpty()) {
+      return <WrappedMarker markableHolder={this.state.markableHolder} {...this.props} />;
+    }
+
+    return <WrappedMarker {...this.props} />;
+  }
+}

--- a/lib/atom/marker.js
+++ b/lib/atom/marker.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Disposable} from 'event-kit';
 import {Range, Point} from 'atom';
 
-import {autobind} from '../helpers';
+import {autobind, extractProps} from '../helpers';
 import {RefHolderPropType} from '../prop-types';
 import RefHolder from '../models/ref-holder';
 
@@ -25,7 +25,6 @@ const PointPropType = PropTypes.oneOfType([
 ]);
 
 const markerProps = {
-  maintainHistory: PropTypes.bool,
   reversed: PropTypes.bool,
   invalidate: PropTypes.oneOf(['never', 'surround', 'overlap', 'inside', 'touch']),
 };
@@ -86,12 +85,7 @@ class WrappedMarker extends React.Component {
       this.marker.destroy();
     }
 
-    const options = Object.keys(markerProps).reduce((opts, propName) => {
-      if (this.props[propName] !== undefined) {
-        opts[propName] = this.props[propName];
-      }
-      return opts;
-    }, {});
+    const options = extractProps(this.props, markerProps);
 
     this.marker = this.props.markableHolder.map(markable => {
       if (this.props.bufferRange) {

--- a/lib/atom/marker.js
+++ b/lib/atom/marker.js
@@ -31,6 +31,8 @@ const markerProps = {
   invalidate: PropTypes.oneOf(['never', 'surround', 'overlap', 'inside', 'touch']),
 };
 
+export const MarkerContext = React.createContext();
+
 class WrappedMarker extends React.Component {
   static propTypes = {
     ...markerProps,
@@ -61,7 +63,11 @@ class WrappedMarker extends React.Component {
   }
 
   render() {
-    return this.props.children || null;
+    return (
+      <MarkerContext.Provider value={this.markerHolder}>
+        {this.props.children}
+      </MarkerContext.Provider>
+    );
   }
 
   componentDidUpdate(prevProps) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,6 +14,38 @@ export function autobind(self, ...methods) {
   }
 }
 
+// Extract a subset of props chosen from a propTypes object from a component's props to pass to a different API.
+//
+// Usage:
+//
+// ```js
+// const apiProps = {
+//   zero: PropTypes.number.isRequired,
+//   one: PropTypes.string,
+//   two: PropTypes.object,
+// };
+//
+// class Component extends React.Component {
+//   static propTypes = {
+//     ...apiProps,
+//     extra: PropTypes.func,
+//   }
+//
+//   action() {
+//     const options = extractProps(this.props, apiProps);
+//     // options contains zero, one, and two, but not extra
+//   }
+// }
+// ```
+export function extractProps(props, propTypes) {
+  return Object.keys(propTypes).reduce((opts, propName) => {
+    if (props[propName] !== undefined) {
+      opts[propName] = props[propName];
+    }
+    return opts;
+  }, {});
+}
+
 export function getPackageRoot() {
   const {resourcePath} = atom.getLoadSettings();
   const currentFileWasRequiredFromSnapshot = !path.isAbsolute(__dirname);

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "dedent-js": "1.0.1",
     "electron-devtools-installer": "2.2.4",
     "enzyme": "3.3.0",
-    "enzyme-adapter-react-16": "1.1.1",
+    "@smashwilson/enzyme-adapter-react-16": "1.0.2",
     "eslint": "4.19.1",
     "eslint-config-fbjs-opensource": "1.0.0",
     "hock": "1.3.2",

--- a/test/atom/decoration.test.js
+++ b/test/atom/decoration.test.js
@@ -3,6 +3,8 @@ import sinon from 'sinon';
 import {mount} from 'enzyme';
 
 import Decoration from '../../lib/atom/decoration';
+import AtomTextEditor from '../../lib/atom/atom-text-editor';
+import Marker from '../../lib/atom/marker';
 
 describe('Decoration', function() {
   let atomEnv, editor, marker;
@@ -110,5 +112,18 @@ describe('Decoration', function() {
     wrapper.unmount();
 
     assert.lengthOf(editor.getLineDecorations({class: 'whatever'}), 0);
+  });
+
+  it('decorates a parent Marker', function() {
+    const wrapper = mount(
+      <AtomTextEditor>
+        <Marker bufferRange={[[0, 0], [0, 0]]}>
+          <Decoration type="line" className="whatever" position="head" />
+        </Marker>
+      </AtomTextEditor>,
+    );
+    const theEditor = wrapper.instance().getModel();
+
+    assert.lengthOf(theEditor.getLineDecorations({position: 'head', class: 'whatever'}), 1);
   });
 });

--- a/test/atom/decoration.test.js
+++ b/test/atom/decoration.test.js
@@ -4,10 +4,10 @@ import {mount} from 'enzyme';
 
 import Decoration from '../../lib/atom/decoration';
 
-describe('Decoration', () => {
+describe('Decoration', function() {
   let atomEnv, editor, marker;
 
-  beforeEach(async () => {
+  beforeEach(async function() {
     atomEnv = global.buildAtomEnvironment();
     const workspace = atomEnv.workspace;
 
@@ -15,9 +15,11 @@ describe('Decoration', () => {
     marker = editor.markBufferRange([[2, 0], [6, 0]]);
   });
 
-  afterEach(() => atomEnv.destroy());
+  afterEach(function() {
+    atomEnv.destroy();
+  });
 
-  it('decorates its marker on render', () => {
+  it('decorates its marker on render', function() {
     const app = (
       <Decoration
         editor={editor}
@@ -32,12 +34,12 @@ describe('Decoration', () => {
     assert.lengthOf(editor.getLineDecorations({position: 'head', class: 'something'}), 1);
   });
 
-  describe('with a subtree', () => {
-    beforeEach(() => {
+  describe('with a subtree', function() {
+    beforeEach(function() {
       sinon.spy(editor, 'decorateMarker');
     });
 
-    it('creates a block decoration', () => {
+    it('creates a block decoration', function() {
       const app = (
         <Decoration editor={editor} marker={marker} type="block">
           <div className="decoration-subtree">
@@ -55,7 +57,7 @@ describe('Decoration', () => {
       assert.equal(child.textContent, 'This is a subtree');
     });
 
-    it('creates an overlay decoration', () => {
+    it('creates an overlay decoration', function() {
       const app = (
         <Decoration editor={editor} marker={marker} type="overlay">
           <div className="decoration-subtree">
@@ -73,7 +75,7 @@ describe('Decoration', () => {
       assert.equal(child.textContent, 'This is a subtree');
     });
 
-    it('creates a gutter decoration', () => {
+    it('creates a gutter decoration', function() {
       const app = (
         <Decoration editor={editor} marker={marker} type="gutter">
           <div className="decoration-subtree">
@@ -92,7 +94,7 @@ describe('Decoration', () => {
     });
   });
 
-  it('destroys its decoration on unmount', () => {
+  it('destroys its decoration on unmount', function() {
     const app = (
       <Decoration
         editor={editor}

--- a/test/atom/marker-layer.test.js
+++ b/test/atom/marker-layer.test.js
@@ -1,53 +1,52 @@
 import React from 'react';
-import {shallow, mount} from 'enzyme';
+import {mount} from 'enzyme';
 
 import MarkerLayer from '../../lib/atom/marker-layer';
 import AtomTextEditor from '../../lib/atom/atom-text-editor';
 
 describe('MarkerLayer', function() {
-  let atomEnv, editor;
+  let atomEnv, editor, layerID;
 
   beforeEach(async function() {
     atomEnv = global.buildAtomEnvironment();
     editor = await atomEnv.workspace.open(__filename);
   });
 
+  function setLayerID(id) {
+    layerID = id;
+  }
+
   it('adds its layer on mount', function() {
-    const app = (
+    mount(
       <MarkerLayer
         editor={editor}
         maintainHistory={true}
         persistent={true}
-      />
+        handleID={setLayerID}
+      />,
     );
-    const wrapper = shallow(app);
-    const id = wrapper.instance().getID();
 
-    const layer = editor.getMarkerLayer(id);
+    const layer = editor.getMarkerLayer(layerID);
     assert.isTrue(layer.bufferMarkerLayer.maintainHistory);
     assert.isTrue(layer.bufferMarkerLayer.persistent);
   });
 
   it('removes its layer on unmount', function() {
-    const app = <MarkerLayer editor={editor} />;
-    const wrapper = shallow(app);
-    const id = wrapper.instance().getID();
+    const wrapper = mount(<MarkerLayer editor={editor} handleID={setLayerID} />);
 
-    assert.isDefined(editor.getMarkerLayer(id));
+    assert.isDefined(editor.getMarkerLayer(layerID));
     wrapper.unmount();
-    assert.isUndefined(editor.getMarkerLayer(id));
+    assert.isUndefined(editor.getMarkerLayer(layerID));
   });
 
   it('inherits an editor from a parent node', function() {
-    const app = (
+    const wrapper = mount(
       <AtomTextEditor>
-        <MarkerLayer />
-      </AtomTextEditor>
+        <MarkerLayer handleID={setLayerID} />
+      </AtomTextEditor>,
     );
-    const wrapper = mount(app);
     const theEditor = wrapper.instance().getModel();
-    const id = wrapper.find('MarkerLayer').instance().getID();
 
-    assert.isDefined(theEditor.getMarkerLayer(id));
+    assert.isDefined(theEditor.getMarkerLayer(layerID));
   });
 });

--- a/test/atom/marker-layer.test.js
+++ b/test/atom/marker-layer.test.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+
+import MarkerLayer from '../../lib/atom/marker-layer';
+import AtomTextEditor from '../../lib/atom/atom-text-editor';
+
+describe('MarkerLayer', function() {
+  let atomEnv, editor;
+
+  beforeEach(async function() {
+    atomEnv = global.buildAtomEnvironment();
+    editor = await atomEnv.workspace.open(__filename);
+  });
+
+  it('adds its layer on mount', function() {
+    const app = (
+      <MarkerLayer
+        editor={editor}
+        maintainHistory={true}
+        persistent={true}
+      />
+    );
+    const wrapper = shallow(app);
+    const id = wrapper.instance().getID();
+
+    const layer = editor.getMarkerLayer(id);
+    assert.isTrue(layer.bufferMarkerLayer.maintainHistory);
+    assert.isTrue(layer.bufferMarkerLayer.persistent);
+  });
+
+  it('removes its layer on unmount', function() {
+    const app = <MarkerLayer editor={editor} />;
+    const wrapper = shallow(app);
+    const id = wrapper.instance().getID();
+
+    assert.isDefined(editor.getMarkerLayer(id));
+    wrapper.unmount();
+    assert.isUndefined(editor.getMarkerLayer(id));
+  });
+
+  it('inherits an editor from a parent node', function() {
+    const app = (
+      <AtomTextEditor>
+        <MarkerLayer />
+      </AtomTextEditor>
+    );
+    const wrapper = mount(app);
+    const theEditor = wrapper.instance().getModel();
+    const id = wrapper.find('MarkerLayer').instance().getID();
+
+    assert.isDefined(theEditor.getMarkerLayer(id));
+  });
+});

--- a/test/atom/marker-layer.test.js
+++ b/test/atom/marker-layer.test.js
@@ -12,6 +12,10 @@ describe('MarkerLayer', function() {
     editor = await atomEnv.workspace.open(__filename);
   });
 
+  afterEach(function() {
+    atomEnv.destroy();
+  });
+
   function setLayerID(id) {
     layerID = id;
   }

--- a/test/atom/marker.test.js
+++ b/test/atom/marker.test.js
@@ -12,6 +12,10 @@ describe('Marker', function() {
     editor = await atomEnv.workspace.open(__filename);
   });
 
+  afterEach(function() {
+    atomEnv.destroy();
+  });
+
   function setMarkerID(id) {
     markerID = id;
   }

--- a/test/atom/marker.test.js
+++ b/test/atom/marker.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import Marker from '../../lib/atom/marker';
+import AtomTextEditor from '../../lib/atom/atom-text-editor';
+
+describe('Marker', function() {
+  let atomEnv, editor, markerID;
+
+  beforeEach(async function() {
+    atomEnv = global.buildAtomEnvironment();
+    editor = await atomEnv.workspace.open(__filename);
+  });
+
+  function setMarkerID(id) {
+    markerID = id;
+  }
+
+  it('adds its marker on mount with default properties', function() {
+    mount(
+      <Marker editor={editor} bufferRange={[[0, 0], [10, 0]]} handleID={setMarkerID} />,
+    );
+
+    const marker = editor.getMarker(markerID);
+    assert.isTrue(marker.getBufferRange().isEqual([[0, 0], [10, 0]]));
+    assert.strictEqual(marker.bufferMarker.invalidate, 'overlap');
+    assert.isFalse(marker.isReversed());
+    assert.isFalse(marker.bufferMarker.layer.maintainHistory);
+  });
+
+  it('configures its marker');
+
+  it('prefers marking a MarkerLayer to a TextEditor');
+
+  it('removes its layer on unmount');
+
+  it('marks an editor from a parent node');
+
+  it('marks a marker layer from a parent node');
+});

--- a/test/atom/marker.test.js
+++ b/test/atom/marker.test.js
@@ -3,6 +3,7 @@ import {mount} from 'enzyme';
 
 import Marker from '../../lib/atom/marker';
 import AtomTextEditor from '../../lib/atom/atom-text-editor';
+import MarkerLayer from '../../lib/atom/marker-layer';
 
 describe('Marker', function() {
   let atomEnv, editor, markerID;
@@ -29,16 +30,75 @@ describe('Marker', function() {
     assert.isTrue(marker.getBufferRange().isEqual([[0, 0], [10, 0]]));
     assert.strictEqual(marker.bufferMarker.invalidate, 'overlap');
     assert.isFalse(marker.isReversed());
-    assert.isFalse(marker.bufferMarker.layer.maintainHistory);
   });
 
-  it('configures its marker');
+  it('configures its marker', function() {
+    mount(
+      <Marker
+        editor={editor}
+        handleID={setMarkerID}
+        screenRange={[[1, 2], [3, 4]]}
+        reversed={true}
+        invalidate={'never'}
+        exclusive={true}
+      />,
+    );
 
-  it('prefers marking a MarkerLayer to a TextEditor');
+    const marker = editor.getMarker(markerID);
+    assert.isTrue(marker.getScreenRange().isEqual([[1, 2], [3, 4]]));
+    assert.isTrue(marker.isReversed());
+    assert.strictEqual(marker.bufferMarker.invalidate, 'never');
+  });
 
-  it('removes its layer on unmount');
+  it('prefers marking a MarkerLayer to a TextEditor', function() {
+    const layer = editor.addMarkerLayer();
 
-  it('marks an editor from a parent node');
+    mount(
+      <Marker
+        editor={editor}
+        layer={layer}
+        handleID={setMarkerID}
+        bufferRange={[[0, 0], [1, 0]]}
+      />,
+    );
 
-  it('marks a marker layer from a parent node');
+    const marker = layer.getMarker(markerID);
+    assert.strictEqual(marker.layer, layer);
+  });
+
+  it('destroys its marker on unmount', function() {
+    const wrapper = mount(<Marker editor={editor} handleID={setMarkerID} bufferPosition={[0, 0]} />);
+
+    assert.isDefined(editor.getMarker(markerID));
+    wrapper.unmount();
+    assert.isUndefined(editor.getMarker(markerID));
+  });
+
+  it('marks an editor from a parent node', function() {
+    const wrapper = mount(
+      <AtomTextEditor>
+        <Marker handleID={setMarkerID} bufferRange={[[0, 0], [0, 0]]} />
+      </AtomTextEditor>,
+    );
+
+    const theEditor = wrapper.instance().getModel();
+    const marker = theEditor.getMarker(markerID);
+    assert.isTrue(marker.getBufferRange().isEqual([[0, 0], [0, 0]]));
+  });
+
+  it('marks a marker layer from a parent node', function() {
+    let layerID;
+    const wrapper = mount(
+      <AtomTextEditor>
+        <MarkerLayer handleID={id => { layerID = id; }}>
+          <Marker handleID={setMarkerID} bufferRange={[[0, 0], [0, 0]]} />
+        </MarkerLayer>
+      </AtomTextEditor>,
+    );
+
+    const theEditor = wrapper.instance().getModel();
+    const layer = theEditor.getMarkerLayer(layerID);
+    const marker = layer.getMarker(markerID);
+    assert.isTrue(marker.getBufferRange().isEqual([[0, 0], [0, 0]]));
+  });
 });

--- a/test/runner.js
+++ b/test/runner.js
@@ -17,7 +17,7 @@ module.exports = createRunner({
   overrideTestPaths: [/spec$/, /test/],
 }, mocha => {
   const Enzyme = require('enzyme');
-  const Adapter = require('enzyme-adapter-react-16');
+  const Adapter = require('@smashwilson/enzyme-adapter-react-16');
   Enzyme.configure({adapter: new Adapter()});
 
   require('mocha-stress');


### PR DESCRIPTION
Add bridge components to the :atom: MarkerLayer and Marker APIs with React components. My goal is to be able to manipulate markers with a React tree with something like:

```jsx
render() {
  return (
    <AtomTextEditor>
      <Marker range={[[11, 0], [12, 0]]}>
        <Decoration type='line' className='something' />
        <Decoration type='line-number' className='something-else' />
      </Marker>
      <MarkerLayer>
        <Marker range={[[0, 0], [10, 0]]} invalidate='never' />
        <Marker range={[[20, 0], [25, 6]]} invalidate='never' exclusive={true} />
        <Decoration type='overlay' position='head'>
           <div>
              What's up
           </div>
        </Decoration>
      </MarkerLayer>
    </AtomTextEditor>
  );
}
```

This will be really useful for implementing #1502.