### PR TITLE
Make entire component for push/pull tile in status bar clickable.

### DIFF
--- a/lib/views/push-pull-view.js
+++ b/lib/views/push-pull-view.js
@@ -195,18 +195,14 @@ export default class PushPullView extends React.Component {
       tileState = tileStates.detached;
     }
 
-    const Tag = tileState.onClick ? 'a' : 'span';
-
     return (
       <div
+        onClick={tileState.onClick}
         ref={this.refTileNode.setter}
         className={cx('github-PushPull', 'inline-block', {'github-branch-detached': isDetached})}>
         {tileState && (
           <Fragment>
-            <Tag
-              onClick={tileState.onClick}
-              className="push-pull-target"
-              key="push-pull-target">
+            <span>
               {tileState.secondaryText && (
                 <span className="secondary">
                   <span className={getIconClass(tileState.secondaryIcon)} />
@@ -215,14 +211,14 @@ export default class PushPullView extends React.Component {
               )}
               <span className={getIconClass(tileState.icon, tileState.iconAnimation)} />
               {tileState.text}
-            </Tag>
+            </span>
             <Tooltip
               key="tooltip"
               manager={this.props.tooltipManager}
               target={this.refTileNode}
               title={`<div style="text-align: left; line-height: 1.2em;">${tileState.tooltip}</div>`}
-              showDelay={atom.tooltips.hoverDefaults.delay.show}
-              hideDelay={atom.tooltips.hoverDefaults.delay.hide}
+              showDelay={200}
+              hideDelay={100}
             />
           </Fragment>
         )}

--- a/lib/views/push-pull-view.js
+++ b/lib/views/push-pull-view.js
@@ -221,8 +221,8 @@ export default class PushPullView extends React.Component {
               manager={this.props.tooltipManager}
               target={this.refTileNode}
               title={`<div style="text-align: left; line-height: 1.2em;">${tileState.tooltip}</div>`}
-              showDelay={200}
-              hideDelay={100}
+              showDelay={atom.tooltips.hoverDefaults.delay.show}
+              hideDelay={atom.tooltips.hoverDefaults.delay.hide}
             />
           </Fragment>
         )}

--- a/lib/views/push-pull-view.js
+++ b/lib/views/push-pull-view.js
@@ -217,8 +217,8 @@ export default class PushPullView extends React.Component {
               manager={this.props.tooltipManager}
               target={this.refTileNode}
               title={`<div style="text-align: left; line-height: 1.2em;">${tileState.tooltip}</div>`}
-              showDelay={200}
-              hideDelay={100}
+              showDelay={atom.tooltips.hoverDefaults.delay.show}
+              hideDelay={atom.tooltips.hoverDefaults.delay.hide}
             />
           </Fragment>
         )}

--- a/styles/push-pull-view.less
+++ b/styles/push-pull-view.less
@@ -2,6 +2,11 @@
 
 // Used in the status-bar
 
+// click target should take up the width of the container
+.push-pull-target {
+  display: inline-block;
+}
+
 .github-PushPull {
   &-icon.icon.icon.icon {
     margin-right: 0;

--- a/styles/push-pull-view.less
+++ b/styles/push-pull-view.less
@@ -2,11 +2,6 @@
 
 // Used in the status-bar
 
-// click target should take up the width of the container
-.push-pull-target {
-  display: inline-block;
-}
-
 .github-PushPull {
   &-icon.icon.icon.icon {
     margin-right: 0;

--- a/test/controllers/status-bar-tile-controller.test.js
+++ b/test/controllers/status-bar-tile-controller.test.js
@@ -321,7 +321,7 @@ describe('StatusBarTileController', function() {
         });
 
         it('pushes the current branch when clicked', function() {
-          statusBarTile.find('.push-pull-target').simulate('click');
+          statusBarTile.find('.github-PushPull').simulate('click');
           assert.isTrue(repository.push.called);
         });
 
@@ -329,7 +329,7 @@ describe('StatusBarTileController', function() {
           repository.getOperationStates().setPushInProgress(true);
           await assert.async.strictEqual(statusBarTile.update().find('.github-PushPull').text().trim(), 'Pushing');
 
-          statusBarTile.find('.push-pull-target').simulate('click');
+          statusBarTile.find('.github-PushPull').simulate('click');
           assert.isFalse(repository.fetch.called);
           assert.isFalse(repository.push.called);
           assert.isFalse(repository.pull.called);
@@ -356,7 +356,7 @@ describe('StatusBarTileController', function() {
         });
 
         it('fetches from remote when clicked', function() {
-          statusBarTile.find('.push-pull-target').simulate('click');
+          statusBarTile.find('.github-PushPull').simulate('click');
           assert.isTrue(repository.fetch.called);
         });
 
@@ -364,7 +364,7 @@ describe('StatusBarTileController', function() {
           repository.getOperationStates().setFetchInProgress(true);
           await assert.async.strictEqual(statusBarTile.update().find('.github-PushPull').text().trim(), 'Fetching');
 
-          statusBarTile.find('.push-pull-target').simulate('click');
+          statusBarTile.find('.github-PushPull').simulate('click');
           assert.isFalse(repository.fetch.called);
           assert.isFalse(repository.push.called);
           assert.isFalse(repository.pull.called);
@@ -392,7 +392,7 @@ describe('StatusBarTileController', function() {
         });
 
         it('pushes when clicked', function() {
-          statusBarTile.find('.push-pull-target').simulate('click');
+          statusBarTile.find('.github-PushPull').simulate('click');
           assert.isTrue(repository.push.called);
         });
 
@@ -400,7 +400,7 @@ describe('StatusBarTileController', function() {
           repository.getOperationStates().setPushInProgress(true);
           await assert.async.strictEqual(statusBarTile.find('.github-PushPull').text().trim(), 'Pushing');
 
-          statusBarTile.find('.push-pull-target').simulate('click');
+          statusBarTile.find('.github-PushPull').simulate('click');
           assert.isFalse(repository.fetch.called);
           assert.isFalse(repository.push.called);
           assert.isFalse(repository.pull.called);
@@ -428,7 +428,7 @@ describe('StatusBarTileController', function() {
         });
 
         it('pulls when clicked', function() {
-          statusBarTile.find('.push-pull-target').simulate('click');
+          statusBarTile.find('.github-PushPull').simulate('click');
           assert.isTrue(repository.pull.called);
         });
 
@@ -436,7 +436,7 @@ describe('StatusBarTileController', function() {
           repository.getOperationStates().setPullInProgress(true);
           await assert.async.strictEqual(statusBarTile.update().find('.github-PushPull').text().trim(), 'Pulling');
 
-          statusBarTile.find('.push-pull-target').simulate('click');
+          statusBarTile.find('.github-PushPull').simulate('click');
           assert.isFalse(repository.fetch.called);
           assert.isFalse(repository.push.called);
           assert.isFalse(repository.pull.called);
@@ -465,7 +465,7 @@ describe('StatusBarTileController', function() {
         });
 
         it('pulls when clicked', function() {
-          statusBarTile.find('.push-pull-target').simulate('click');
+          statusBarTile.find('.github-PushPull').simulate('click');
           assert.isTrue(repository.pull.called);
           assert.isFalse(repository.fetch.called);
           assert.isFalse(repository.push.called);
@@ -475,7 +475,7 @@ describe('StatusBarTileController', function() {
           repository.getOperationStates().setPullInProgress(true);
           await assert.async.strictEqual(statusBarTile.update().find('.github-PushPull').text().trim(), 'Pulling');
 
-          statusBarTile.find('.push-pull-target').simulate('click');
+          statusBarTile.find('.github-PushPull').simulate('click');
           assert.isFalse(repository.fetch.called);
           assert.isFalse(repository.push.called);
           assert.isFalse(repository.pull.called);
@@ -503,7 +503,7 @@ describe('StatusBarTileController', function() {
         });
 
         it('does nothing when clicked', function() {
-          statusBarTile.find('.push-pull-target').simulate('click');
+          statusBarTile.find('.github-PushPull').simulate('click');
           assert.equal(statusBarTile.find('.github-PushPull').text().trim(), 'Not on branch');
           assert.isFalse(repository.fetch.called);
           assert.isFalse(repository.push.called);
@@ -532,7 +532,7 @@ describe('StatusBarTileController', function() {
         });
 
         it('does nothing when clicked', function() {
-          statusBarTile.find('.push-pull-target').simulate('click');
+          statusBarTile.find('.github-PushPull').simulate('click');
           assert.equal(statusBarTile.find('.github-PushPull').text().trim(), 'No remote');
           assert.isFalse(repository.fetch.called);
           assert.isFalse(repository.push.called);


### PR DESCRIPTION
fixes https://github.com/atom/github/issues/1530 and https://github.com/atom/github/issues/1531

I don't know how to unit test this.  If we had Selenium tests, or something that actually fired up the UI, that might be possible. 

Test plan:
- test clicking on the non-text area of the status bar in dev mode
- test clicking on neighboring tiles to make sure they fire the expected actions.