### PR TITLE
Fix top border of the Git panel

### DIFF
--- a/styles/staging-view.less
+++ b/styles/staging-view.less
@@ -19,7 +19,7 @@
     border-top: 1px solid @panel-heading-border-color;
     border-bottom: 1px solid @panel-heading-border-color;
 
-    .github-StagingView-group:first-child & {
+    .github-UnstagedChanges > & {
       border-top: none;
     }
 


### PR DESCRIPTION
### Description of the Change

This removes the top border on "Unstaged Changes".

![screen shot 2018-06-19 at 5 05 02 pm](https://user-images.githubusercontent.com/378023/41584738-feeb0af2-73e2-11e8-917e-7c6dd7b2c52b.png)

### Alternate Designs

We could try to remove the two empty `<div>`s at the top, but not quite sure where they are coming from?

![screen shot 2018-06-19 at 5 06 25 pm](https://user-images.githubusercontent.com/378023/41584839-4a7514ae-73e3-11e8-8b9e-8682669a8588.png)

### Benefits

The tab looks more seamless.

### Possible Drawbacks

It's less flexible because we assume that "Unstaged Changes" is always shown first, which might change in the future.

### Applicable Issues

None
