### PR TITLE
Make CommitView use the Command component

### DIFF
--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -7,6 +7,7 @@ import Select from 'react-select';
 import Tooltip from '../atom/tooltip';
 import AtomTextEditor from '../atom/atom-text-editor';
 import CoAuthorForm from './co-author-form';
+import Commands, {Command} from '../atom/commands';
 import RefHolder from '../models/ref-holder';
 import Author from '../models/author';
 import ObserveModel from './observe-model';
@@ -116,25 +117,6 @@ export default class CommitView extends React.Component {
     this.scheduleShowWorking(this.props);
 
     this.subscriptions = new CompositeDisposable(
-      this.props.commandRegistry.add('atom-workspace', {
-        'github:commit': this.commit,
-        'github:amend-last-commit': this.amendLastCommit,
-        'github:toggle-expanded-commit-message-editor': this.toggleExpandedCommitMessageEditor,
-      }),
-      this.props.commandRegistry.add('.github-CommitView-coAuthorEditor', {
-        'github:co-author:down': this.proxyKeyCode(40),
-        'github:co-author:up': this.proxyKeyCode(38),
-        'github:co-author:enter': this.proxyKeyCode(13),
-        'github:co-author:tab': this.proxyKeyCode(9),
-        'github:co-author:backspace': this.proxyKeyCode(8),
-        'github:co-author:pageup': this.proxyKeyCode(33),
-        'github:co-author:pagedown': this.proxyKeyCode(34),
-        'github:co-author:end': this.proxyKeyCode(35),
-        'github:co-author:home': this.proxyKeyCode(36),
-        'github:co-author:delete': this.proxyKeyCode(46),
-        'github:co-author:escape': this.proxyKeyCode(27),
-        'github:co-author-exclude': this.excludeCoAuthor,
-      }),
       this.props.config.onDidChange('github.automaticCommitMessageWrapping', () => this.forceUpdate()),
     );
   }
@@ -154,6 +136,27 @@ export default class CommitView extends React.Component {
 
     return (
       <div className="github-CommitView">
+        <Commands registry={this.props.commandRegistry} target="atom-workspace">
+          <Command command="github:commit" callback={this.commit} />
+          <Command command="github:amend-last-commit" callback={this.amendLastCommit} />
+          <Command command="github:toggle-expanded-commit-message-editor"
+            callback={this.toggleExpandedCommitMessageEditor}
+          />
+        </Commands>
+        <Commands registry={this.props.commandRegistry} target="github-CommitView-coAuthorEditor">
+          <Command command="github:co-author:down" callback={this.proxyKeyCode(40)} />
+          <Command command="github:co-author:up" callback={this.proxyKeyCode(38)} />
+          <Command command="github:co-author:enter" callback={this.proxyKeyCode(13)} />
+          <Command command="github:co-author:tab" callback={this.proxyKeyCode(9)} />
+          <Command command="github:co-author:backspace" callback={this.proxyKeyCode(8)} />
+          <Command command="github:co-author:pageup" callback={this.proxyKeyCode(33)} />
+          <Command command="github:co-author:pagedown" callback={this.proxyKeyCode(34)} />
+          <Command command="github:co-author:end" callback={this.proxyKeyCode(35)} />
+          <Command command="github:co-author:home" callback={this.proxyKeyCode(36)} />
+          <Command command="github:co-author:delete" callback={this.proxyKeyCode(46)} />
+          <Command command="github:co-author:escape" callback={this.proxyKeyCode(27)} />
+          <Command command="github:co-author-exclude" callback={this.excludeCoAuthor} />
+        </Commands>
         <div className={cx('github-CommitView-editor', {'is-expanded': this.props.deactivateCommitBox})}>
           <AtomTextEditor
             ref={this.refEditor.setter}


### PR DESCRIPTION
As per https://github.com/atom/github/issues/1404 we should be using the `Command` component instead of registering commands directly.  I believe this is the last place where we're not doing so.

manual testing performed:
- making a new commit
- amending the most recent commit commit
- toggling the expanded commit editor
- adding a new co author (including tabbing between fields, and using escape to close the dialog)

Also, ran all the unit tests to ensure they passed.

I found some bugs with the co author flow while doing this manual testing, but these bugs were reproducible on a clean build synced to `master` and thus are unrelated to these changes.  I filed them as separate issues.