### PR TITLE
Startup and focus management issues, round N+1

### DIFF
--- a/lib/atom/dock-item.js
+++ b/lib/atom/dock-item.js
@@ -81,13 +81,13 @@ export default class DockItem extends React.Component {
       stub.setRealItem(itemToAdd);
       this.dockItem = stub;
       if (this.props.activate) {
-        this.activate();
+        this.scheduleActivation();
       }
     } else {
       Promise.resolve(this.props.workspace.open(itemToAdd, {activatePane: false}))
         .then(item => {
           this.dockItem = item;
-          if (this.props.activate) { this.activate(); }
+          if (this.props.activate) { this.scheduleActivation(); }
         });
     }
 
@@ -117,23 +117,32 @@ export default class DockItem extends React.Component {
     return this.dockItem;
   }
 
-  activate() {
-    setTimeout(() => {
-      if (!this.dockItem || this.didCloseItem || this.props.workspace.isDestroyed()) {
-        return;
-      }
-
-      const pane = this.props.workspace.paneForItem(this.dockItem);
-      if (pane) {
-        pane.activateItem(this.dockItem);
-        const dock = this.props.workspace.getPaneContainers()
-          .find(container => container.getPanes().find(p => p.getItems().includes(this.dockItem)));
-        if (dock && dock.show) {
-          dock.show();
+  scheduleActivation() {
+    this.subscriptions.add(
+      this.props.workspace.onDidAddPaneItem(({item}) => {
+        if (item === this.dockItem) {
+          this.activate();
         }
-      } else if (this.dockItem && !this.didCloseItem) {
-        throw new Error('Could not find pane for a non-destroyed DockItem');
+      }),
+    );
+  }
+
+  activate() {
+    if (!this.dockItem || this.didCloseItem || this.props.workspace.isDestroyed()) {
+      return;
+    }
+
+    const pane = this.props.workspace.paneForItem(this.dockItem);
+    if (pane) {
+      pane.activateItem(this.dockItem);
+      const dock = this.props.workspace.getPaneContainers()
+        .find(container => container.getPanes().find(p => p.getItems().includes(this.dockItem)));
+      if (dock && dock.show) {
+        dock.show();
       }
-    });
+    } else if (this.dockItem && !this.didCloseItem) {
+      debugger;
+      throw new Error('Could not find pane for a non-destroyed DockItem');
+    }
   }
 }

--- a/lib/atom/dock-item.js
+++ b/lib/atom/dock-item.js
@@ -141,7 +141,6 @@ export default class DockItem extends React.Component {
         dock.show();
       }
     } else if (this.dockItem && !this.didCloseItem) {
-      debugger;
       throw new Error('Could not find pane for a non-destroyed DockItem');
     }
   }

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -47,7 +47,7 @@ export default class RootController extends React.Component {
     resolutionProgress: PropTypes.object.isRequired,
     statusBar: PropTypes.object,
     switchboard: PropTypes.instanceOf(Switchboard),
-    startOpen: PropTypes.bool,
+    startRevealed: PropTypes.bool,
     gitTabStubItem: PropTypes.object,
     githubTabStubItem: PropTypes.object,
     destroyGitTabItem: PropTypes.func.isRequired,
@@ -57,7 +57,7 @@ export default class RootController extends React.Component {
 
   static defaultProps = {
     switchboard: new Switchboard(),
-    startOpen: true,
+    startRevealed: false,
   }
 
   constructor(props, context) {
@@ -181,7 +181,7 @@ export default class RootController extends React.Component {
             onDidCloseItem={this.props.destroyGitTabItem}
             stubItem={this.props.gitTabStubItem}
             itemHolder={this.refGitTabItem}
-            activate={this.props.startOpen}>
+            activate={this.props.startRevealed}>
             <GitTabItem
               ref={this.refGitTabItem.setter}
               workspace={this.props.workspace}

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -26,8 +26,12 @@ const defaultState = {
 };
 
 export default class GithubPackage {
-  constructor(workspace, project, commandRegistry, notificationManager, tooltips, styles, grammars, confirm, config,
-    deserializers, configDirPath, getLoadSettings) {
+  constructor({
+    workspace, project, commandRegistry, notificationManager, tooltips, styles, grammars, config, deserializers,
+    confirm, getLoadSettings,
+    configDirPath,
+    renderFn,
+  }) {
     autobind(
       this,
       'consumeStatusBar', 'createGitTimingsView', 'createIssueishPaneItemStub', 'createDockItemStub',
@@ -70,6 +74,10 @@ export default class GithubPackage {
     });
 
     this.switchboard = new Switchboard();
+
+    this.renderFn = renderFn || ((component, node, callback) => {
+      return ReactDom.render(component, node, callback);
+    });
 
     // Handle events from all resident contexts.
     this.subscriptions = new CompositeDisposable(
@@ -264,7 +272,7 @@ export default class GithubPackage {
       }));
     }
 
-    ReactDom.render(
+    this.renderFn(
       <RootController
         ref={c => { this.controller = c; }}
         workspace={this.workspace}

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -23,6 +23,7 @@ import WorkerManager from './worker-manager';
 import getRepoPipelineManager from './get-repo-pipeline-manager';
 
 const defaultState = {
+  newProject: true,
 };
 
 export default class GithubPackage {
@@ -155,7 +156,11 @@ export default class GithubPackage {
     this.savedState = {...defaultState, ...state};
 
     const firstRun = !await fileExists(this.configPath);
-    this.startOpen = firstRun && !this.config.get('welcome.showOnStartup');
+    const newProject = this.savedState.newProject || this.savedState.firstRun;
+
+    this.startOpen = firstRun || newProject;
+    this.startRevealed = this.startOpen && !this.config.get('welcome.showOnStartup');
+
     if (firstRun) {
       await fs.writeFile(this.configPath, '# Store non-visible GitHub package state.\n', {encoding: 'utf8'});
     }
@@ -240,6 +245,12 @@ export default class GithubPackage {
       }),
     );
 
+    if (this.startOpen) {
+      for (const uri of ['atom-github://dock-item/git', 'atom-github://dock-item/github']) {
+        this.workspace.open(uri);
+      }
+    }
+
     this.activated = true;
     this.scheduleActiveContextUpdate(this.savedState);
     this.rerender();
@@ -251,7 +262,7 @@ export default class GithubPackage {
 
     return {
       activeRepositoryPath,
-      firstRun: false,
+      newProject: false,
     };
   }
 
@@ -290,7 +301,7 @@ export default class GithubPackage {
         createRepositoryForProjectPath={this.createRepositoryForProjectPath}
         cloneRepositoryForProjectPath={this.cloneRepositoryForProjectPath}
         switchboard={this.switchboard}
-        startOpen={this.startOpen}
+        startRevealed={this.startRevealed}
         gitTabStubItem={this.gitTabStubItem}
         githubTabStubItem={this.githubTabStubItem}
         destroyGitTabItem={this.destroyGitTabItem}

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,11 +3,22 @@ import GithubPackage from './github-package';
 let pack;
 const entry = {
   initialize() {
-    pack = new GithubPackage(
-      atom.workspace, atom.project, atom.commands, atom.notifications, atom.tooltips,
-      atom.styles, atom.grammars, atom.confirm.bind(atom), atom.config, atom.deserializers, atom.getConfigDirPath(),
-      atom.getLoadSettings.bind(atom),
-    );
+    pack = new GithubPackage({
+      workspace: atom.workspace,
+      project: atom.project,
+      commandRegistry: atom.commands,
+      notificationManager: atom.notificationManager,
+      tooltips: atom.tooltips,
+      styles: atom.styles,
+      grammars: atom.grammars,
+      config: atom.config,
+      deserializers: atom.deserializers,
+
+      confirm: atom.confirm.bind(atom),
+      getLoadSettings: atom.getLoadSettings.bind(atom),
+
+      configDirPath: atom.getConfigDirPath(),
+    });
   },
 };
 

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -80,11 +80,11 @@ describe('RootController', function() {
       };
     });
 
-    it('is rendered but not activated when startOpen prop is false', async function() {
+    it('does not reveal the dock when startRevealed prop is false', async function() {
       const workdirPath = await cloneRepository('multiple-commits');
       const repository = await buildRepository(workdirPath);
 
-      app = React.cloneElement(app, {repository, gitTabStubItem, githubTabStubItem, startOpen: false});
+      app = React.cloneElement(app, {repository, gitTabStubItem, githubTabStubItem, startRevealed: false});
       const wrapper = shallow(app);
 
       const gitDockItem = wrapper.find('DockItem').find({stubItem: gitTabStubItem});
@@ -96,11 +96,11 @@ describe('RootController', function() {
       assert.isNotTrue(githubDockItem.prop('activate'));
     });
 
-    it('is initially activated when the startOpen prop is true', async function() {
+    it('is initially activated when the startRevealed prop is true', async function() {
       const workdirPath = await cloneRepository('multiple-commits');
       const repository = await buildRepository(workdirPath);
 
-      app = React.cloneElement(app, {repository, gitTabStubItem, githubTabStubItem, startOpen: true});
+      app = React.cloneElement(app, {repository, gitTabStubItem, githubTabStubItem, startRevealed: true});
       const wrapper = shallow(app);
 
       const gitDockItem = wrapper.find('DockItem').find({stubItem: gitTabStubItem});

--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -33,7 +33,7 @@ describe('GithubPackage', function() {
       workspace, project, commandRegistry, notificationManager, tooltips, styles, grammars, config, deserializers,
       confirm, getLoadSettings,
       configDirPath,
-      renderFn: sinon.stub().callsFake(callback => {
+      renderFn: sinon.stub().callsFake((component, element, callback) => {
         if (callback) {
           process.nextTick(callback);
         }

--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -29,15 +29,15 @@ describe('GithubPackage', function() {
     getLoadSettings = atomEnv.getLoadSettings.bind(atomEnv);
     configDirPath = path.join(__dirname, 'fixtures', 'atomenv-config');
 
-    githubPackage = new GithubPackage(
-      workspace, project, commandRegistry, notificationManager, tooltips, styles, grammars, confirm, config,
-      deserializers, configDirPath, getLoadSettings,
-    );
-
-    sinon.stub(githubPackage, 'rerender').callsFake(callback => {
-      if (callback) {
-        process.nextTick(callback);
-      }
+    githubPackage = new GithubPackage({
+      workspace, project, commandRegistry, notificationManager, tooltips, styles, grammars, config, deserializers,
+      confirm, getLoadSettings,
+      configDirPath,
+      renderFn: sinon.stub().callsFake(callback => {
+        if (callback) {
+          process.nextTick(callback);
+        }
+      }),
     });
 
     contextPool = githubPackage.getContextPool();
@@ -72,10 +72,11 @@ describe('GithubPackage', function() {
       project.setPaths(realProjectPaths);
       const getLoadSettings1 = () => ({initialPaths});
 
-      githubPackage1 = new GithubPackage(
-        workspace, project, commandRegistry, notificationManager, tooltips, styles, grammars, confirm, config,
-        deserializers, configDirPath, getLoadSettings1,
-      );
+      githubPackage1 = new GithubPackage({
+        workspace, project, commandRegistry, notificationManager, tooltips, styles, grammars, config, deserializers,
+        confirm, getLoadSettings1,
+        configDirPath,
+      });
     }
 
     function assertAbsentLike() {

--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -74,7 +74,7 @@ describe('GithubPackage', function() {
 
       githubPackage1 = new GithubPackage({
         workspace, project, commandRegistry, notificationManager, tooltips, styles, grammars, config, deserializers,
-        confirm, getLoadSettings1,
+        confirm, getLoadSettings: getLoadSettings1,
         configDirPath,
       });
     }

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -1,0 +1,63 @@
+import {mount} from 'enzyme';
+
+import GithubPackage from '../../lib/github-package';
+
+/**
+ * Perform shared setup for integration tests.
+ *
+ * Usage:
+ * ```js
+ * beforeEach(function() {
+ *   context = setup(this.currentTest);
+ *   wrapper = context.wrapper;
+ * })
+ *
+ * afterEach(function() {
+ *   teardown(context)
+ * })
+ * ```
+ *
+ */
+export function setup(currentTest) {
+  const atomEnv = global.buildAtomEnvironment();
+
+  let domRoot = null;
+  let wrapper = null;
+
+  const githubPackage = new GithubPackage({
+    workspace: atomEnv.workspace,
+    project: atomEnv.projects,
+    commandRegistry: atomEnv.commands,
+    notificationManager: atomEnv.notifications,
+    tooltips: atomEnv.tooltips,
+    styles: atomEnv.styles,
+    grammars: atomEnv.grammars,
+    config: atomEnv.config,
+    deserializers: atomEnv.deserializers,
+    confirm: atomEnv.confirm.bind(atomEnv),
+    getLoadSettings: atom.getLoadSettings.bind(atomEnv),
+    configDirPath: atom.getConfigDirPath(),
+    renderFn: (component, node, callback) => {
+      if (!domRoot && node) {
+        domRoot = node;
+      }
+      wrapper = mount(component, {
+        attachTo: node,
+      });
+      process.nextTick(callback);
+    },
+  });
+
+  return {
+    atomEnv,
+    githubPackage,
+    wrapper,
+    domRoot,
+  };
+}
+
+export async function teardown(context) {
+  context.atomEnv.destroy();
+
+  await context.githubPackage.deactivate();
+}

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -1,32 +1,70 @@
 import {mount} from 'enzyme';
 
+import {getTempDir} from '../../lib/helpers';
+import {cloneRepository} from '../helpers';
 import GithubPackage from '../../lib/github-package';
+import metadata from '../../package.json';
 
 /**
  * Perform shared setup for integration tests.
  *
  * Usage:
  * ```js
- * beforeEach(function() {
- *   context = setup(this.currentTest);
+ * beforeEach(async function() {
+ *   context = await setup(this.currentTest);
  *   wrapper = context.wrapper;
  * })
  *
- * afterEach(function() {
- *   teardown(context)
+ * afterEach(async function() {
+ *   await teardown(context)
  * })
  * ```
  *
+ * Options:
+ * * initialRoots - Describe the root folders that should be open in the Atom environment's project before the package
+ *     is initialized. Array elements are passed to `cloneRepository` directly.
+ * * initAtomEnv - Callback invoked with the Atom environment before the package is created.
+ * * initConfigDir - Callback invoked with the config dir path for this Atom environment.
+ * * isolateConfigDir - Use a temporary directory for the package configDir used by this test. Implied if initConfigDir
+ *     is defined.
+ * * state - Simulate package state serialized by a previous Atom run.
  */
-export function setup(currentTest) {
+export async function setup(currentTest, options = {}) {
+  const opts = {
+    initialRoots: [],
+    isolateConfigDir: options.initAtomEnv !== undefined,
+    initConfigDir: () => Promise.resolve(),
+    initAtomEnv: () => Promise.resolve(),
+    state: {},
+    ...options,
+  };
+
   const atomEnv = global.buildAtomEnvironment();
+
+  await opts.initAtomEnv(atomEnv);
+
+  const projectDirs = await Promise.all(
+    opts.initialRoots.map(fixture => {
+      return cloneRepository(fixture);
+    }),
+  );
+
+  atomEnv.project.setPaths(projectDirs, {mustExist: true, exact: true});
+
+  let configDirPath = null;
+  if (opts.isolateConfigDir) {
+    configDirPath = await getTempDir();
+  } else {
+    configDirPath = atomEnv.getConfigDirPath();
+  }
+  await opts.initConfigDir(configDirPath);
 
   let domRoot = null;
   let wrapper = null;
 
   const githubPackage = new GithubPackage({
     workspace: atomEnv.workspace,
-    project: atomEnv.projects,
+    project: atomEnv.project,
     commandRegistry: atomEnv.commands,
     notificationManager: atomEnv.notifications,
     tooltips: atomEnv.tooltips,
@@ -35,18 +73,34 @@ export function setup(currentTest) {
     config: atomEnv.config,
     deserializers: atomEnv.deserializers,
     confirm: atomEnv.confirm.bind(atomEnv),
-    getLoadSettings: atom.getLoadSettings.bind(atomEnv),
-    configDirPath: atom.getConfigDirPath(),
+    getLoadSettings: atomEnv.getLoadSettings.bind(atomEnv),
+    configDirPath,
     renderFn: (component, node, callback) => {
       if (!domRoot && node) {
         domRoot = node;
       }
-      wrapper = mount(component, {
-        attachTo: node,
-      });
-      process.nextTick(callback);
+      if (!wrapper) {
+        wrapper = mount(component, {
+          attachTo: node,
+        });
+      } else {
+        wrapper.setProps(component.props);
+      }
+      if (callback) {
+        process.nextTick(callback);
+      }
     },
   });
+
+  for (const deserializerName in metadata.deserializers) {
+    const methodName = metadata.deserializers[deserializerName];
+    atomEnv.deserializers.add({
+      name: deserializerName,
+      deserialize: githubPackage[methodName],
+    });
+  }
+
+  await githubPackage.activate(opts.state);
 
   return {
     atomEnv,
@@ -57,7 +111,7 @@ export function setup(currentTest) {
 }
 
 export async function teardown(context) {
-  context.atomEnv.destroy();
-
   await context.githubPackage.deactivate();
+
+  context.atomEnv.destroy();
 }

--- a/test/integration/launch.test.js
+++ b/test/integration/launch.test.js
@@ -1,51 +1,147 @@
+import fs from 'fs-extra';
+import path from 'path';
+
 import {setup, teardown} from './helpers';
 
 describe('Package initialization', function() {
-  let context, wrapper, atom;
-
-  beforeEach(function() {
-    context = setup(this.currentTest);
-    wrapper = context.wrapper;
-    atom = context.atom;
-  });
+  let context, atomEnv;
 
   afterEach(async function() {
-    await teardown(this.currentTest);
+    context && await teardown(context);
   });
+
+  // beforeEach helpers
+  // Pass these to the initAtomEnv or initConfigDir arguments of setup() to assert a common pre-launch state.
+
+  function welcomePackageActive(env) {
+    env.config.set('welcome.showOnStartup', true);
+  }
+
+  function welcomePackageDismissed(env) {
+    env.config.set('welcome.showOnStartup', false);
+  }
+
+  async function onFirstRun(configDirPath) {
+    await fs.remove(path.join(configDirPath, 'github.cson'));
+  }
+
+  async function onLaterRuns(configDirPath) {
+    await fs.writeFile(path.join(configDirPath, 'github.cson'), '#');
+  }
+
+  // test body helpers
+
+  function placesGitAndGitHubTabsIntoRightDock() {
+    const paneItemURIs = atomEnv.workspace.getRightDock().getPaneItems().map(paneItem => {
+      return (typeof paneItem.getURI === 'function') ? paneItem.getURI() : null;
+    });
+
+    assert.includeMembers(
+      paneItemURIs, ['atom-github://dock-item/git', 'atom-github://dock-item/github'],
+      'Git and GitHub pane items present in the right dock',
+    );
+  }
+
+  function hidesRightDock() {
+    assert.isFalse(atomEnv.workspace.getRightDock().isVisible());
+  }
+
+  function revealsRightDock() {
+    assert.isTrue(atomEnv.workspace.getRightDock().isVisible());
+  }
+
+  async function keepsPreviouslyClosedGitAndGitHubTabsClosed() {
+    const prevContext = await setup(this.currentTest);
+    for (const uri of ['atom-github://dock-item/git', 'atom-github://dock-item/github']) {
+      prevContext.atomEnv.workspace.hide(uri);
+    }
+    const prevState = prevContext.atomEnv.serialize();
+    await teardown(prevContext);
+
+    context = await setup(this.currentTest, {
+      initAtomEnv: env => env.deserialize(prevState),
+    });
+
+    const paneItems = context.atomEnv.workspace.getRightDock().getPaneItems();
+    assert.lengthOf(paneItems, 0);
+
+    const paneItemURIs = context.atomEnv.workspace.getPaneItems().map(paneItem => {
+      return (typeof paneItem.getURI === 'function') ? paneItem.getURI() : null;
+    });
+
+    for (const uri of ['atom-github://dock-item/git', 'atom-github://dock-item/github']) {
+      assert.notInclude(paneItemURIs, uri, `Tab ${uri} should not be present`);
+    }
+  }
+
+  async function keepsPreviouslyOpenGitAndGitHubTabsOpened() {
+    const prevContext = await setup(this.currentTest);
+    await prevContext.atomEnv.workspace.open('atom-github://dock-item/git', {searchAllPanes: true});
+    await prevContext.atomEnv.workspace.open('atom-github://dock-item/github', {searchAllPanes: true});
+    const prevState = prevContext.atomEnv.serialize();
+    await teardown(prevContext);
+
+    context = await setup(this.currentTest);
+    atomEnv = context.atomEnv;
+    await atomEnv.deserialize(prevState);
+
+    placesGitAndGitHubTabsIntoRightDock();
+  }
 
   describe('on the very first run with the GitHub package present', function() {
     describe('with no serialized project state', function() {
       describe('with the welcome package active', function() {
-        it('places the git and github tabs into the right dock');
+        beforeEach(async function() {
+          context = await setup(this.currentTest, {
+            initAtomEnv: welcomePackageActive,
+            initConfigDir: onFirstRun,
+          });
+          atomEnv = context.atomEnv;
+        });
 
-        it('hides the right dock');
+        it('places the git and github tabs into the right dock', placesGitAndGitHubTabsIntoRightDock);
+
+        it('hides the right dock', hidesRightDock);
       });
 
       describe('with the welcome package dismissed', function() {
-        it('places the git and github tabs into the right dock');
+        beforeEach(async function() {
+          context = await setup(this.currentTest, {
+            initAtomEnv: welcomePackageDismissed,
+            initConfigDir: onFirstRun,
+          });
+          atomEnv = context.atomEnv;
+        });
 
-        it('reveals the right dock');
+        it('places the git and github tabs into the right dock', placesGitAndGitHubTabsIntoRightDock);
+
+        it('reveals the right dock', revealsRightDock);
       });
     });
 
     describe('with serialized project state', function() {
-      it('keeps previously closed git and github tabs closed');
-
-      it('keeps previously open git and github tabs opened');
+      //
     });
   });
 
   describe('on a run when the GitHub package was present before', function() {
     describe('with no serialized project state', function() {
-      it('places the git and github tabs into the right dock');
+      beforeEach(async function() {
+        context = await setup(this.currentTest, {
+          initConfigDir: onLaterRuns,
+        });
+        atomEnv = context.atomEnv;
+      });
 
-      it('hides the right dock');
+      it('places the git and github tabs into the right dock', placesGitAndGitHubTabsIntoRightDock);
+
+      it('hides the right dock', hidesRightDock);
     });
 
     describe('with serialized project state', function() {
-      it('keeps previously closed git and github tabs closed');
+      it('keeps previously closed git and github tabs closed', keepsPreviouslyClosedGitAndGitHubTabsClosed);
 
-      it('keeps previously open git and github tabs opened');
+      it('keeps previously open git and github tabs opened', keepsPreviouslyOpenGitAndGitHubTabsOpened);
     });
   });
 });

--- a/test/integration/launch.test.js
+++ b/test/integration/launch.test.js
@@ -1,0 +1,51 @@
+import {setup, teardown} from './helpers';
+
+describe('Package initialization', function() {
+  let context, wrapper, atom;
+
+  beforeEach(function() {
+    context = setup(this.currentTest);
+    wrapper = context.wrapper;
+    atom = context.atom;
+  });
+
+  afterEach(async function() {
+    await teardown(this.currentTest);
+  });
+
+  describe('on the very first run with the GitHub package present', function() {
+    describe('with no serialized project state', function() {
+      describe('with the welcome package active', function() {
+        it('places the git and github tabs into the right dock');
+
+        it('hides the right dock');
+      });
+
+      describe('with the welcome package dismissed', function() {
+        it('places the git and github tabs into the right dock');
+
+        it('reveals the right dock');
+      });
+    });
+
+    describe('with serialized project state', function() {
+      it('keeps previously closed git and github tabs closed');
+
+      it('keeps previously open git and github tabs opened');
+    });
+  });
+
+  describe('on a run when the GitHub package was present before', function() {
+    describe('with no serialized project state', function() {
+      it('places the git and github tabs into the right dock');
+
+      it('hides the right dock');
+    });
+
+    describe('with serialized project state', function() {
+      it('keeps previously closed git and github tabs closed');
+
+      it('keeps previously open git and github tabs opened');
+    });
+  });
+});


### PR DESCRIPTION
While I was working on developing a test plan for #1547, I noticed that a lot of things about our first-launch and our focus management code are not behaving the way that I expected them to on master. After some reflection I decided that this is a decent opportunity to lay some groundwork for the integration tests I was describing in #1542.

- [ ] Bootstrap integration test support code
- [ ] Create integration tests for startup and focus management workflows
- [ ] Get those tests passing
- [ ] Write a `tests/integration/README.md` to describe the integration test organization and philosophy
