### PR TITLE
Add support for nightly channel

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -30,10 +30,18 @@ export function getPackageRoot() {
   }
 }
 
+function getAtomAppName() {
+  const match = atom.getVersion().match(/beta|nightly/)
+  if (match) {
+    return `Atom ${match[0].charAt(0).toUpperCase() + match[0].slice(1)} Helper`
+  }
+
+  return 'Atom Helper'
+}
+
 export function getAtomHelperPath() {
   if (process.platform === 'darwin') {
-    const beta = atom.appVersion.match(/-beta/);
-    const appName = beta ? 'Atom Beta Helper' : 'Atom Helper';
+    const appName = getAtomAppName()
     return path.resolve(process.resourcesPath, '..', 'Frameworks',
       `${appName}.app`, 'Contents', 'MacOS', appName);
   } else {


### PR DESCRIPTION
### Description of the Change

This change adds support for the Atom Nightly release channel to (hopefully!  🤞) resolve test failures on Atom Nightly builds.  I'm doing this PR against 0.17-releases with the hope of shipping a quick 0.17.1 release as soon as the PR is merged.

### Applicable Issues

https://github.com/atom/atom/pull/17538
