### PR TITLE
Integrate metrics

### DIFF
--- a/lib/containers/remote-container.js
+++ b/lib/containers/remote-container.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {QueryRenderer, graphql} from 'react-relay';
 
+import {incrementCounter} from '../reporter-proxy';
 import {autobind} from '../helpers';
 import {RemotePropType, BranchSetPropType, OperationStateObserverPropType} from '../prop-types';
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
@@ -132,10 +133,12 @@ export default class RemoteContainer extends React.Component {
   }
 
   handleLogin(token) {
+    incrementCounter('github-login');
     this.props.loginModel.setToken(this.props.host, token);
   }
 
   handleLogout() {
+    incrementCounter('github-logout');
     this.props.loginModel.removeToken(this.props.host);
   }
 }

--- a/lib/controllers/remote-controller.js
+++ b/lib/controllers/remote-controller.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {shell} from 'electron';
 
 import {autobind} from '../helpers';
+import {incrementCounter} from '../reporter-proxy';
 import {RemotePropType, BranchSetPropType, OperationStateObserverPropType} from '../prop-types';
 import IssueishSearchesController from './issueish-searches-controller';
 
@@ -69,10 +70,13 @@ export default class RemoteController extends React.Component {
     createPrUrl += '/compare/' + encodeURIComponent(currentBranch.getName());
     createPrUrl += '?expand=1';
 
-    return new Promise((resolve, reject) => {
-      shell.openExternal(createPrUrl, {}, err => {
-        if (err) { reject(err); } else { resolve(); }
-      });
-    });
+    let returnPromise;
+    try {
+      returnPromise = await shell.openExternal(createPrUrl);
+      incrementCounter('create-pull-request');
+    } catch (err) {
+      returnPromise = Promise.reject(err);
+    }
+    return returnPromise;
   }
 }

--- a/lib/controllers/remote-controller.js
+++ b/lib/controllers/remote-controller.js
@@ -70,13 +70,15 @@ export default class RemoteController extends React.Component {
     createPrUrl += '/compare/' + encodeURIComponent(currentBranch.getName());
     createPrUrl += '?expand=1';
 
-    let returnPromise;
-    try {
-      returnPromise = await shell.openExternal(createPrUrl);
-      incrementCounter('create-pull-request');
-    } catch (err) {
-      returnPromise = Promise.reject(err);
-    }
-    return returnPromise;
+    return new Promise((resolve, reject) => {
+      shell.openExternal(createPrUrl, {}, err => {
+        if (err) {
+          reject(err);
+        } else {
+          incrementCounter('create-pull-request');
+          resolve();
+        }
+      });
+    });
   }
 }

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -26,6 +26,7 @@ import Conflict from '../models/conflicts/conflict';
 import Switchboard from '../switchboard';
 import {destroyFilePatchPaneItems, destroyEmptyFilePatchPaneItems, autobind} from '../helpers';
 import {GitError} from '../git-shell-out-strategy';
+import {incrementCounter} from '../reporter-proxy';
 
 export default class RootController extends React.Component {
   static propTypes = {
@@ -788,10 +789,12 @@ class TabTracker {
   }
 
   reveal() {
+    incrementCounter(`${this.name}-tab-open`);
     return this.getWorkspace().open(this.uri, {searchAllPanes: true, activateItem: true, activatePane: true});
   }
 
   hide() {
+    incrementCounter(`${this.name}-tab-close`);
     return this.getWorkspace().hide(this.uri);
   }
 

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -13,7 +13,7 @@ import {parse as parseStatus} from 'what-the-status';
 import GitPromptServer from './git-prompt-server';
 import GitTempDir from './git-temp-dir';
 import AsyncQueue from './async-queue';
-import {addEvent, incrementCounter} from './reporter-proxy';
+import {incrementCounter} from './reporter-proxy';
 import {
   getDugitePath, getSharedModulePath, getAtomHelperPath,
   extractCoAuthorsAndRawCommitMessage, fileExists, isFileExecutable, isFileSymlink, isBinary,
@@ -482,10 +482,7 @@ export default class GitShellOutStrategy {
 
     if (amend) { args.push('--amend'); }
     if (allowEmpty) { args.push('--allow-empty'); }
-    const returnValue = await this.gpgExec(args, {writeOperation: true});
-    // todo: if the commit fails for some reason, don't increment the counter here.
-    addEvent('commit', {coAuthors: coAuthors && coAuthors.length || 0});
-    return returnValue;
+    return await this.gpgExec(args, {writeOperation: true});
   }
 
   addCoAuthorsToMessage(message, coAuthors = []) {

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -13,7 +13,7 @@ import {parse as parseStatus} from 'what-the-status';
 import GitPromptServer from './git-prompt-server';
 import GitTempDir from './git-temp-dir';
 import AsyncQueue from './async-queue';
-import {addEvent} from './reporter-proxy';
+import {addEvent, incrementCounter} from './reporter-proxy';
 import {
   getDugitePath, getSharedModulePath, getAtomHelperPath,
   extractCoAuthorsAndRawCommitMessage, fileExists, isFileExecutable, isFileSymlink, isBinary,
@@ -42,6 +42,9 @@ export class LargeRepoError extends Error {
     this.stack = new Error().stack;
   }
 }
+
+// ignored for the purposes of usage metrics tracking because they're noisy
+const IGNORED_GIT_COMMANDS = ['cat-file', 'config', 'diff', 'for-each-ref', 'log', 'rev-parse', 'status'];
 
 const DISABLE_COLOR_FLAGS = [
   'branch', 'diff', 'showBranch', 'status', 'ui',
@@ -90,6 +93,7 @@ export default class GitShellOutStrategy {
   async exec(args, options = GitShellOutStrategy.defaultExecArgs) {
     /* eslint-disable no-console,no-control-regex */
     const {stdin, useGitPromptServer, useGpgWrapper, useGpgAtomPrompt, writeOperation} = options;
+    const commandName = args[0];
     const subscriptions = new CompositeDisposable();
     const diagnosticsEnabled = process.env.ATOM_GITHUB_GIT_DIAGNOSTICS || atom.config.get('github.gitDiagnostics');
 
@@ -311,6 +315,10 @@ export default class GitShellOutStrategy {
           err.stdOut = stdout;
           err.command = formattedArgs;
           reject(err);
+        }
+
+        if (!IGNORED_GIT_COMMANDS.includes(commandName)) {
+          incrementCounter(commandName);
         }
         resolve(stdout);
       });

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -482,7 +482,7 @@ export default class GitShellOutStrategy {
 
     if (amend) { args.push('--amend'); }
     if (allowEmpty) { args.push('--allow-empty'); }
-    return await this.gpgExec(args, {writeOperation: true});
+    return this.gpgExec(args, {writeOperation: true});
   }
 
   addCoAuthorsToMessage(message, coAuthors = []) {

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -13,6 +13,7 @@ import {parse as parseStatus} from 'what-the-status';
 import GitPromptServer from './git-prompt-server';
 import GitTempDir from './git-temp-dir';
 import AsyncQueue from './async-queue';
+import {addEvent} from './reporter-proxy';
 import {
   getDugitePath, getSharedModulePath, getAtomHelperPath,
   extractCoAuthorsAndRawCommitMessage, fileExists, isFileExecutable, isFileSymlink, isBinary,
@@ -473,7 +474,10 @@ export default class GitShellOutStrategy {
 
     if (amend) { args.push('--amend'); }
     if (allowEmpty) { args.push('--allow-empty'); }
-    return this.gpgExec(args, {writeOperation: true});
+    const returnValue = await this.gpgExec(args, {writeOperation: true});
+    // todo: if the commit fails for some reason, don't increment the counter here.
+    addEvent('commit', {coAuthors: coAuthors && coAuthors.length || 0});
+    return returnValue;
   }
 
   addCoAuthorsToMessage(message, coAuthors = []) {

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -21,6 +21,7 @@ import ContextMenuInterceptor from './context-menu-interceptor';
 import AsyncQueue from './async-queue';
 import WorkerManager from './worker-manager';
 import getRepoPipelineManager from './get-repo-pipeline-manager';
+import {reporterProxy} from './reporter-proxy';
 
 const defaultState = {
   newProject: true,
@@ -308,6 +309,10 @@ export default class GithubPackage {
   consumeStatusBar(statusBar) {
     this.statusBar = statusBar;
     this.rerender();
+  }
+
+  consumeReporter(reporter) {
+    reporterProxy.setReporter(reporter);
   }
 
   createGitTimingsView() {

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -1,11 +1,10 @@
 const pjson = require('../package.json');
 
+export const FIVE_MINUTES_IN_MILLISECONDS = 1000 * 60 * 5;
+
 // this class allows us to call reporter methods
 // before the reporter is actually loaded, since we don't want to
 // assume that the metrics package will load before the GitHub package.
-
-// maybe this should be an object instead of a class.
-// IDK.
 class ReporterProxy {
   constructor() {
     this.reporter = null;
@@ -13,6 +12,18 @@ class ReporterProxy {
     this.timings = [];
     this.counters = [];
     this.gitHubPackageVersion = pjson.version;
+
+    // if for some reason a user disables the metrics package, we don't want to
+    // just keep accumulating events in memory until the heat death of the universe.
+    // Use a no-op class, clear all queues, move on with our lives.
+    setTimeout(FIVE_MINUTES_IN_MILLISECONDS, () => {
+      if (this.reporter === null) {
+        this.setReporter(new FakeReporter());
+        this.events = [];
+        this.timings = [];
+        this.counters = [];
+      }
+    });
   }
 
   // function that is called after the reporter is actually loaded, to
@@ -35,6 +46,14 @@ class ReporterProxy {
 }
 
 export const reporterProxy = new ReporterProxy();
+
+export class FakeReporter {
+  addCustomEvent() {}
+
+  addTiming() {}
+
+  incrementCounter() {}
+}
 
 export const incrementCounter = function(counterName) {
   if (reporterProxy.reporter) {

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -21,11 +21,11 @@ class ReporterProxy {
     this.reporter = reporter;
 
     this.events.forEach((customEvent) => {
-      this.reporter.addCustomEvent(...customEvent);
+      this.reporter.addCustomEvent(customEvent.eventType, customEvent.event);
     });
 
     this.timings.forEach((timing) => {
-      this.reporter.addTiming(...timing);
+      this.reporter.addTiming(timing.eventType, timing.durationInMilliseconds, timing.metadata);
     });
 
     this.counters.forEach((counterName) => {

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -1,0 +1,59 @@
+// this class allows us to call reporter methods
+// before the reporter is actually loaded, since we don't want to
+// assume that the metrics package will load before the GitHub package.
+
+// maybe this should be an object instead of a class.
+// IDK.
+class ReporterProxy {
+  constructor() {
+    this.reporter = null;
+    this.events = [];
+    this.timings = [];
+    this.counters = [];
+  }
+
+  // function that is called after the reporter is actually loaded, to
+  // set the reporter and send anydata that have accumulated while it was loading.
+  setReporter(reporter) {
+    this.reporter = reporter;
+
+    this.events.forEach((customEvent) => {
+      this.reporter.addCustomEvent(...customEvent);
+    });
+
+    this.timings.forEach((timing) => {
+      this.reporter.addTiming(...timing);
+    });
+
+    this.counters.forEach((counterName) => {
+      this.reporter.incrementCounter(counterName);
+    });
+  }
+}
+
+export const reporterProxy = new ReporterProxy();
+
+export const incrementCounter = function(counterName) {
+  if (reporterProxy.reporter) {
+    reporterProxy.reporter.incrementCounter(counterName);
+  }
+  else {
+    reporterProxy.counters.push(counterName);
+  }
+}
+
+export const addTiming = function(eventType, durationInMilliseconds, metadata = {}) {
+  if (reporterProxy.reporter) {
+    reporterProxy.reporter.addTiming(eventType, durationInMilliseconds, metadata);
+  } else {
+    reporterProxy.timings.push({ eventType, durationInMilliseconds, metadata});
+  }
+}
+
+export const addEvent = function(eventType, event) {
+  if (reporterProxy.reporter) {
+    reporterProxy.reporter.addCustomEvent(eventType, event);
+  } else {
+    reporterProxy.events.push({ eventType, event });
+  }
+}

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -16,7 +16,7 @@ class ReporterProxy {
   }
 
   // function that is called after the reporter is actually loaded, to
-  // set the reporter and send anydata that have accumulated while it was loading.
+  // set the reporter and send any data that have accumulated while it was loading.
   setReporter(reporter) {
     this.reporter = reporter;
 

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -55,28 +55,28 @@ export class FakeReporter {
   incrementCounter() {}
 }
 
-export const incrementCounter = function(counterName) {
+export function incrementCounter(counterName) {
   if (reporterProxy.reporter) {
     reporterProxy.reporter.incrementCounter(counterName);
   } else {
     reporterProxy.counters.push(counterName);
   }
-};
+}
 
-export const addTiming = function(eventType, durationInMilliseconds, metadata = {}) {
+export function addTiming(eventType, durationInMilliseconds, metadata = {}) {
   metadata.gitHubPackageVersion = reporterProxy.gitHubPackageVersion;
   if (reporterProxy.reporter) {
     reporterProxy.reporter.addTiming(eventType, durationInMilliseconds, metadata);
   } else {
     reporterProxy.timings.push({eventType, durationInMilliseconds, metadata});
   }
-};
+}
 
-export const addEvent = function(eventType, event) {
+export function addEvent(eventType, event) {
   event.gitHubPackageVersion = reporterProxy.gitHubPackageVersion;
   if (reporterProxy.reporter) {
     reporterProxy.reporter.addCustomEvent(eventType, event);
   } else {
     reporterProxy.events.push({eventType, event});
   }
-};
+}

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -1,3 +1,5 @@
+const pjson = require('../package.json');
+
 // this class allows us to call reporter methods
 // before the reporter is actually loaded, since we don't want to
 // assume that the metrics package will load before the GitHub package.
@@ -10,6 +12,7 @@ class ReporterProxy {
     this.events = [];
     this.timings = [];
     this.counters = [];
+    this.gitHubPackageVersion = pjson.version;
   }
 
   // function that is called after the reporter is actually loaded, to
@@ -43,6 +46,7 @@ export const incrementCounter = function(counterName) {
 }
 
 export const addTiming = function(eventType, durationInMilliseconds, metadata = {}) {
+  metadata.gitHubPackageVersion = reporterProxy.gitHubPackageVersion;
   if (reporterProxy.reporter) {
     reporterProxy.reporter.addTiming(eventType, durationInMilliseconds, metadata);
   } else {
@@ -51,6 +55,7 @@ export const addTiming = function(eventType, durationInMilliseconds, metadata = 
 }
 
 export const addEvent = function(eventType, event) {
+  event.gitHubPackageVersion = reporterProxy.gitHubPackageVersion;
   if (reporterProxy.reporter) {
     reporterProxy.reporter.addCustomEvent(eventType, event);
   } else {

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -20,15 +20,15 @@ class ReporterProxy {
   setReporter(reporter) {
     this.reporter = reporter;
 
-    this.events.forEach((customEvent) => {
+    this.events.forEach(customEvent => {
       this.reporter.addCustomEvent(customEvent.eventType, customEvent.event);
     });
 
-    this.timings.forEach((timing) => {
+    this.timings.forEach(timing => {
       this.reporter.addTiming(timing.eventType, timing.durationInMilliseconds, timing.metadata);
     });
 
-    this.counters.forEach((counterName) => {
+    this.counters.forEach(counterName => {
       this.reporter.incrementCounter(counterName);
     });
   }
@@ -39,26 +39,25 @@ export const reporterProxy = new ReporterProxy();
 export const incrementCounter = function(counterName) {
   if (reporterProxy.reporter) {
     reporterProxy.reporter.incrementCounter(counterName);
-  }
-  else {
+  } else {
     reporterProxy.counters.push(counterName);
   }
-}
+};
 
 export const addTiming = function(eventType, durationInMilliseconds, metadata = {}) {
   metadata.gitHubPackageVersion = reporterProxy.gitHubPackageVersion;
   if (reporterProxy.reporter) {
     reporterProxy.reporter.addTiming(eventType, durationInMilliseconds, metadata);
   } else {
-    reporterProxy.timings.push({ eventType, durationInMilliseconds, metadata});
+    reporterProxy.timings.push({eventType, durationInMilliseconds, metadata});
   }
-}
+};
 
 export const addEvent = function(eventType, event) {
   event.gitHubPackageVersion = reporterProxy.gitHubPackageVersion;
   if (reporterProxy.reporter) {
     reporterProxy.reporter.addCustomEvent(eventType, event);
   } else {
-    reporterProxy.events.push({ eventType, event });
+    reporterProxy.events.push({eventType, event});
   }
-}
+};

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -385,10 +385,12 @@ export default class CommitView extends React.Component {
       showCoAuthorInput: !this.state.showCoAuthorInput,
     }, () => {
       if (this.state.showCoAuthorInput) {
+        incrementCounter('show-co-author-input');
         this.refCoAuthorSelect.map(c => c.focus());
       } else {
         // if input is closed, remove all co-authors
         this.props.updateSelectedCoAuthors([]);
+        incrementCounter('hide-co-author-input');
       }
     });
   }
@@ -537,6 +539,7 @@ export default class CommitView extends React.Component {
   }
 
   onSelectedCoAuthorsChanged(selectedCoAuthors) {
+    incrementCounter('selected-co-authors-changed');
     const newAuthor = selectedCoAuthors.find(author => author.isNew());
 
     if (newAuthor) {

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -13,6 +13,7 @@ import Author from '../models/author';
 import ObserveModel from './observe-model';
 import {LINE_ENDING_REGEX, autobind} from '../helpers';
 import {AuthorPropType, UserStorePropType} from '../prop-types';
+import {incrementCounter} from '../reporter-proxy';
 
 const TOOLTIP_DELAY = 200;
 
@@ -426,6 +427,7 @@ export default class CommitView extends React.Component {
   }
 
   amendLastCommit() {
+    incrementCounter('amend');
     this.commit(null, true);
   }
 

--- a/package.json
+++ b/package.json
@@ -13,13 +13,6 @@
     "fetch-schema": "node script/fetch-schema",
     "relay": "relay-compiler --src ./lib --schema graphql/schema.graphql"
   },
-  "consumedServices": {
-    "metrics-reporter": {
-      "versions": {
-        "^1.1.0": "consumeReporter"
-      }
-    }
-  },
   "engines": {
     "atom": ">=1.18.0"
   },
@@ -102,6 +95,11 @@
     "status-bar": {
       "versions": {
         "^1.0.0": "consumeStatusBar"
+      }
+    },
+    "metrics-reporter": {
+      "versions": {
+        "^1.1.0": "consumeReporter"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,13 @@
     "fetch-schema": "node script/fetch-schema",
     "relay": "relay-compiler --src ./lib --schema graphql/schema.graphql"
   },
+  "consumedServices": {
+    "metrics-reporter": {
+      "versions": {
+        "^1.1.0": "consumeReporter"
+      }
+    }
+  },
   "engines": {
     "atom": ">=1.18.0"
   },

--- a/test/containers/remote-container.test.js
+++ b/test/containers/remote-container.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 
+import * as reporterProxy from '../../lib/reporter-proxy';
 import {createRepositoryResult} from '../fixtures/factories/repository-result';
 import Remote from '../../lib/models/remote';
 import Branch, {nullBranch} from '../../lib/models/branch';
@@ -129,6 +130,28 @@ describe('RemoteContainer', function() {
 
     const qev = wrapper.find('QueryErrorView');
     assert.strictEqual(qev.prop('error'), e);
+  });
+
+  it('increments a counter on login', async function() {
+    const token = '1234';
+    sinon.stub(model, 'getScopes').resolves(GithubLoginModel.REQUIRED_SCOPES);
+    const incrementCounterStub = sinon.stub(reporterProxy, 'incrementCounter');
+
+    const wrapper = mount(buildApp());
+    wrapper.instance().handleLogin(token);
+    assert.isTrue(incrementCounterStub.calledOnceWith('github-login'));
+  });
+
+  it('increments a counter on logout', async function() {
+    const token = '1234';
+    sinon.stub(model, 'getScopes').resolves(GithubLoginModel.REQUIRED_SCOPES);
+
+    const wrapper = mount(buildApp());
+    wrapper.instance().handleLogin(token);
+
+    const incrementCounterStub = sinon.stub(reporterProxy, 'incrementCounter');
+    wrapper.instance().handleLogout();
+    assert.isTrue(incrementCounterStub.calledOnceWith('github-logout'));
   });
 
   it('renders the controller once results have arrived', async function() {

--- a/test/containers/remote-container.test.js
+++ b/test/containers/remote-container.test.js
@@ -132,7 +132,7 @@ describe('RemoteContainer', function() {
     assert.strictEqual(qev.prop('error'), e);
   });
 
-  it('increments a counter on login', async function() {
+  it('increments a counter on login', function() {
     const token = '1234';
     sinon.stub(model, 'getScopes').resolves(GithubLoginModel.REQUIRED_SCOPES);
     const incrementCounterStub = sinon.stub(reporterProxy, 'incrementCounter');
@@ -142,7 +142,7 @@ describe('RemoteContainer', function() {
     assert.isTrue(incrementCounterStub.calledOnceWith('github-login'));
   });
 
-  it('increments a counter on logout', async function() {
+  it('increments a counter on logout', function() {
     const token = '1234';
     sinon.stub(model, 'getScopes').resolves(GithubLoginModel.REQUIRED_SCOPES);
 

--- a/test/controllers/remote-controller.test.js
+++ b/test/controllers/remote-controller.test.js
@@ -9,7 +9,7 @@ import {nullOperationStateObserver} from '../../lib/models/operation-state-obser
 import RemoteController from '../../lib/controllers/remote-controller';
 import * as reporterProxy from '../../lib/reporter-proxy';
 
-describe('RemoteController', async function() {
+describe('RemoteController', function() {
   let atomEnv, remote, branchSet, currentBranch;
 
   beforeEach(function() {

--- a/test/controllers/remote-controller.test.js
+++ b/test/controllers/remote-controller.test.js
@@ -53,7 +53,7 @@ describe('RemoteController', function() {
 
   it('increments a counter when onCreatePr is called', async function() {
     const wrapper = shallow(createApp());
-    sinon.stub(shell, 'openExternal').resolves();
+    sinon.stub(shell, 'openExternal').callsArg(2);
     sinon.stub(reporterProxy, 'incrementCounter');
 
     await wrapper.instance().onCreatePr();
@@ -63,7 +63,7 @@ describe('RemoteController', function() {
 
   it('handles error when onCreatePr fails', async function() {
     const wrapper = shallow(createApp());
-    sinon.stub(shell, 'openExternal').rejects(new Error('oh noes'));
+    sinon.stub(shell, 'openExternal').callsArgWith(2, new Error('oh noes'));
     sinon.stub(reporterProxy, 'incrementCounter');
 
     try {

--- a/test/controllers/remote-controller.test.js
+++ b/test/controllers/remote-controller.test.js
@@ -9,7 +9,7 @@ import {nullOperationStateObserver} from '../../lib/models/operation-state-obser
 import RemoteController from '../../lib/controllers/remote-controller';
 import * as reporterProxy from '../../lib/reporter-proxy';
 
-describe.only('RemoteController', async function() {
+describe('RemoteController', async function() {
   let atomEnv, remote, branchSet, currentBranch;
 
   beforeEach(function() {

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -11,6 +11,7 @@ import Repository from '../../lib/models/repository';
 import GitTabItem from '../../lib/items/git-tab-item';
 import GithubTabController from '../../lib/controllers/github-tab-controller';
 import ResolutionProgress from '../../lib/models/conflicts/resolution-progress';
+import * as reporterProxy from '../../lib/reporter-proxy';
 
 import RootController from '../../lib/controllers/root-controller';
 
@@ -120,6 +121,14 @@ describe('RootController', function() {
             {searchAllPanes: true, activateItem: true, activatePane: true},
           ]);
         });
+        it('increments counter with correct name', function() {
+          sinon.stub(workspace, 'open');
+          const incrementCounterStub = sinon.stub(reporterProxy, 'incrementCounter');
+
+          tabTracker.reveal();
+          assert.equal(incrementCounterStub.callCount, 1);
+          assert.deepEqual(incrementCounterStub.lastCall.args, [`${tabName}-tab-open`]);
+        });
       });
 
       describe('hide', function() {
@@ -131,6 +140,14 @@ describe('RootController', function() {
           assert.deepEqual(workspace.hide.args[0], [
             `atom-github://dock-item/${tabName}`,
           ]);
+        });
+        it('increments counter with correct name', function() {
+          sinon.stub(workspace, 'hide');
+          const incrementCounterStub = sinon.stub(reporterProxy, 'incrementCounter');
+
+          tabTracker.hide();
+          assert.equal(incrementCounterStub.callCount, 1);
+          assert.deepEqual(incrementCounterStub.lastCall.args, [`${tabName}-tab-close`]);
         });
       });
 

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -13,6 +13,7 @@ import WorkerManager from '../lib/worker-manager';
 
 import {cloneRepository, initRepository, assertDeepPropertyVals} from './helpers';
 import {normalizeGitHelperPath, getTempDir} from '../lib/helpers';
+import * as reporterProxy from '../lib/reporter-proxy';
 
 /**
  * KU Thoughts: The GitShellOutStrategy methods are tested in Repository tests for the most part
@@ -1298,7 +1299,25 @@ import {normalizeGitHelperPath, getTempDir} from '../lib/helpers';
         });
       });
     });
+    describe('exec', function() {
+      let workingDirPath, git, incrementCounterStub;
+      beforeEach(async function() {
+        workingDirPath = await cloneRepository('three-files');
+        git = createTestStrategy(workingDirPath);
+        incrementCounterStub = sinon.stub(reporterProxy, 'incrementCounter');
+        // sinon.stub(GitProcess, 'exec').resolves('yay');
+      });
+      it('does not call incrementCounter when git command is on the ignore list', async function() {
+        await git.exec(['status']);
+        assert.equal(incrementCounterStub.callCount, 0);
+      });
+      it('does call incrementCounter when git command is NOT on the ignore list', async function() {
+        await git.exec(['commit', '--allow-empty', '-m', 'make an empty commit']);
 
+        assert.equal(incrementCounterStub.callCount, 1);
+        assert.deepEqual(incrementCounterStub.lastCall.args, ['commit']);
+      });
+    });
     describe('executeGitCommand', function() {
       it('shells out in process until WorkerManager instance is ready', async function() {
         if (process.env.ATOM_GITHUB_INLINE_GIT_EXEC) {

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -1305,7 +1305,6 @@ import * as reporterProxy from '../lib/reporter-proxy';
         workingDirPath = await cloneRepository('three-files');
         git = createTestStrategy(workingDirPath);
         incrementCounterStub = sinon.stub(reporterProxy, 'incrementCounter');
-        // sinon.stub(GitProcess, 'exec').resolves('yay');
       });
       it('does not call incrementCounter when git command is on the ignore list', async function() {
         await git.exec(['status']);

--- a/test/reporter-proxy.test.js
+++ b/test/reporter-proxy.test.js
@@ -5,7 +5,7 @@ const version = pjson.version;
 
 const fakeReporter = new FakeReporter();
 
-describe.only('reporterProxy', function() {
+describe('reporterProxy', function() {
   const event = {coAuthorCount: 2};
   const eventType = 'commits';
 

--- a/test/reporter-proxy.test.js
+++ b/test/reporter-proxy.test.js
@@ -21,7 +21,7 @@ describe('reporterProxy', function() {
   const durationInMilliseconds = 42;
 
   const counterName = 'push';
-  afterEach(function() {
+  beforeEach(function() {
     // let's not leak state between tests, dawg.
     reporterProxy.events = [];
     reporterProxy.timings = [];

--- a/test/reporter-proxy.test.js
+++ b/test/reporter-proxy.test.js
@@ -3,12 +3,33 @@ const pjson = require('../package.json');
 
 const version = pjson.version;
 
+class FakeReporter {
+  addCustomEvent() {}
+
+  addTiming() {}
+
+  incrementCounter() {}
+}
+
+const fakeReporter = new FakeReporter();
+
 describe('reporterProxy', function() {
+  const event = {coAuthorCount: 2};
+  const eventType = 'commits';
+
+  const timingEventType = 'load';
+  const durationInMilliseconds = 42;
+
+  const counterName = 'push';
+  afterEach(function() {
+    // let's not leak state between tests, dawg.
+    reporterProxy.events = [];
+    reporterProxy.timings = [];
+    reporterProxy.counters = [];
+  })
+
   describe('before reporter has been set', function() {
     it('adds event to queue when addEvent is called', function() {
-      const event = {coAuthorCount: 2};
-      const eventType = 'commits';
-      const expectedEvent = { eventType, event };
       addEvent(eventType, event);
 
       const events = reporterProxy.events;
@@ -19,26 +40,89 @@ describe('reporterProxy', function() {
     });
 
     it('adds timing to queue when addTiming is called', function() {
-      const eventType = 'load';
-      const durationInMilliseconds = 42;
-      addTiming(eventType, durationInMilliseconds);
+      addTiming(timingEventType, durationInMilliseconds);
 
       const timings = reporterProxy.timings;
       assert.deepEqual(timings.length, 1);
       const timing = timings[0];
-      assert.deepEqual(timing.eventType, eventType);
+
+      assert.deepEqual(timing.eventType, timingEventType);
       assert.deepEqual(timing.durationInMilliseconds, durationInMilliseconds);
-      console.log(timing.metadata);
       assert.deepEqual(timing.metadata, { gitHubPackageVersion: version });
     })
 
     it('adds counter to queue when incrementCounter is called', function() {
-      const counterName = "commits";
       incrementCounter(counterName);
 
       const counters = reporterProxy.counters;
       assert.deepEqual(counters.length, 1);
       assert.deepEqual(counters[0], counterName);
+    });
+  });
+  describe('after reporter has been set', function() {
+    let addCustomEventStub, addTimingStub, incrementCounterStub;
+    beforeEach(function() {
+      addCustomEventStub = sinon.stub(fakeReporter, 'addCustomEvent');
+      addTimingStub = sinon.stub(fakeReporter, 'addTiming');
+      incrementCounterStub = sinon.stub(fakeReporter, 'incrementCounter');
+    })
+    it('empties all queues', function() {
+      addEvent(eventType, event);
+      addTiming(timingEventType, durationInMilliseconds);
+      incrementCounter(counterName);
+
+      assert.isFalse(addCustomEventStub.called);
+      assert.isFalse(addTimingStub.called);
+      assert.isFalse(incrementCounterStub.called);
+
+      assert.deepEqual(reporterProxy.events.length, 1);
+      assert.deepEqual(reporterProxy.timings.length, 1);
+      assert.deepEqual(reporterProxy.counters.length, 1);
+
+      reporterProxy.setReporter(fakeReporter);
+
+      const addCustomEventArgs = addCustomEventStub.lastCall.args;
+      assert.deepEqual(addCustomEventArgs[0], eventType);
+      assert.deepEqual(addCustomEventArgs[1], {coAuthorCount: 2, gitHubPackageVersion: version});
+
+      const addTimingArgs = addTimingStub.lastCall.args;
+      assert.deepEqual(addTimingArgs[0], timingEventType);
+      assert.deepEqual(addTimingArgs[1], durationInMilliseconds);
+      assert.deepEqual(addTimingArgs[2], { gitHubPackageVersion: version });
+
+      assert.deepEqual(incrementCounterStub.lastCall.args, [counterName]);
+    });
+    it('calls addCustomEvent directly, bypassing queue', function() {
+      assert.isFalse(addCustomEventStub.called);
+      reporterProxy.setReporter(fakeReporter);
+
+      addEvent(eventType, event);
+      assert.deepEqual(reporterProxy.events.length, 0);
+
+      const addCustomEventArgs = addCustomEventStub.lastCall.args;
+      assert.deepEqual(addCustomEventArgs[0], eventType);
+      assert.deepEqual(addCustomEventArgs[1], {coAuthorCount: 2, gitHubPackageVersion: version});
+    });
+    it('calls addTiming directly, bypassing queue', function() {
+      assert.isFalse(addTimingStub.called);
+      reporterProxy.setReporter(fakeReporter);
+
+      addTiming(timingEventType, durationInMilliseconds);
+      assert.deepEqual(reporterProxy.timings.length, 0);
+
+      const addTimingArgs = addTimingStub.lastCall.args;
+      assert.deepEqual(addTimingArgs[0], timingEventType);
+      assert.deepEqual(addTimingArgs[1], durationInMilliseconds);
+      assert.deepEqual(addTimingArgs[2], { gitHubPackageVersion: version });
+    });
+    it('calls incrementCounter directly, bypassing queue', function() {
+      assert.isFalse(incrementCounterStub.called);
+      reporterProxy.setReporter(fakeReporter);
+
+      incrementCounter(counterName);
+      assert.deepEqual(reporterProxy.counters.length, 0);
+
+      assert.deepEqual(incrementCounterStub.lastCall.args, [counterName]);
     });
   });
 });

--- a/test/reporter-proxy.test.js
+++ b/test/reporter-proxy.test.js
@@ -1,0 +1,44 @@
+import {addEvent, addTiming, incrementCounter, reporterProxy} from '../lib/reporter-proxy';
+const pjson = require('../package.json');
+
+const version = pjson.version;
+
+describe('reporterProxy', function() {
+  describe('before reporter has been set', function() {
+    it('adds event to queue when addEvent is called', function() {
+      const event = {coAuthorCount: 2};
+      const eventType = 'commits';
+      const expectedEvent = { eventType, event };
+      addEvent(eventType, event);
+
+      const events = reporterProxy.events;
+      assert.deepEqual(events.length, 1);
+      const actualEvent = events[0]
+      assert.deepEqual(actualEvent.eventType, eventType);
+      assert.deepEqual(actualEvent.event, { coAuthorCount: 2, gitHubPackageVersion: version});
+    });
+
+    it('adds timing to queue when addTiming is called', function() {
+      const eventType = 'load';
+      const durationInMilliseconds = 42;
+      addTiming(eventType, durationInMilliseconds);
+
+      const timings = reporterProxy.timings;
+      assert.deepEqual(timings.length, 1);
+      const timing = timings[0];
+      assert.deepEqual(timing.eventType, eventType);
+      assert.deepEqual(timing.durationInMilliseconds, durationInMilliseconds);
+      console.log(timing.metadata);
+      assert.deepEqual(timing.metadata, { gitHubPackageVersion: version });
+    })
+
+    it('adds counter to queue when incrementCounter is called', function() {
+      const counterName = "commits";
+      incrementCounter(counterName);
+
+      const counters = reporterProxy.counters;
+      assert.deepEqual(counters.length, 1);
+      assert.deepEqual(counters[0], counterName);
+    });
+  });
+});

--- a/test/reporter-proxy.test.js
+++ b/test/reporter-proxy.test.js
@@ -26,7 +26,7 @@ describe('reporterProxy', function() {
     reporterProxy.events = [];
     reporterProxy.timings = [];
     reporterProxy.counters = [];
-  })
+  });
 
   describe('before reporter has been set', function() {
     it('adds event to queue when addEvent is called', function() {
@@ -34,9 +34,9 @@ describe('reporterProxy', function() {
 
       const events = reporterProxy.events;
       assert.deepEqual(events.length, 1);
-      const actualEvent = events[0]
+      const actualEvent = events[0];
       assert.deepEqual(actualEvent.eventType, eventType);
-      assert.deepEqual(actualEvent.event, { coAuthorCount: 2, gitHubPackageVersion: version});
+      assert.deepEqual(actualEvent.event, {coAuthorCount: 2, gitHubPackageVersion: version});
     });
 
     it('adds timing to queue when addTiming is called', function() {
@@ -48,8 +48,8 @@ describe('reporterProxy', function() {
 
       assert.deepEqual(timing.eventType, timingEventType);
       assert.deepEqual(timing.durationInMilliseconds, durationInMilliseconds);
-      assert.deepEqual(timing.metadata, { gitHubPackageVersion: version });
-    })
+      assert.deepEqual(timing.metadata, {gitHubPackageVersion: version});
+    });
 
     it('adds counter to queue when incrementCounter is called', function() {
       incrementCounter(counterName);
@@ -65,7 +65,7 @@ describe('reporterProxy', function() {
       addCustomEventStub = sinon.stub(fakeReporter, 'addCustomEvent');
       addTimingStub = sinon.stub(fakeReporter, 'addTiming');
       incrementCounterStub = sinon.stub(fakeReporter, 'incrementCounter');
-    })
+    });
     it('empties all queues', function() {
       addEvent(eventType, event);
       addTiming(timingEventType, durationInMilliseconds);
@@ -88,7 +88,7 @@ describe('reporterProxy', function() {
       const addTimingArgs = addTimingStub.lastCall.args;
       assert.deepEqual(addTimingArgs[0], timingEventType);
       assert.deepEqual(addTimingArgs[1], durationInMilliseconds);
-      assert.deepEqual(addTimingArgs[2], { gitHubPackageVersion: version });
+      assert.deepEqual(addTimingArgs[2], {gitHubPackageVersion: version});
 
       assert.deepEqual(incrementCounterStub.lastCall.args, [counterName]);
     });
@@ -113,7 +113,7 @@ describe('reporterProxy', function() {
       const addTimingArgs = addTimingStub.lastCall.args;
       assert.deepEqual(addTimingArgs[0], timingEventType);
       assert.deepEqual(addTimingArgs[1], durationInMilliseconds);
-      assert.deepEqual(addTimingArgs[2], { gitHubPackageVersion: version });
+      assert.deepEqual(addTimingArgs[2], {gitHubPackageVersion: version});
     });
     it('calls incrementCounter directly, bypassing queue', function() {
       assert.isFalse(incrementCounterStub.called);

--- a/test/views/commit-view.test.js
+++ b/test/views/commit-view.test.js
@@ -9,6 +9,7 @@ import Branch, {nullBranch} from '../../lib/models/branch';
 import ObserveModel from '../../lib/views/observe-model';
 import UserStore from '../../lib/models/user-store';
 import CommitView from '../../lib/views/commit-view';
+import * as reporterProxy from '../../lib/reporter-proxy';
 
 describe('CommitView', function() {
   let atomEnv, commandRegistry, tooltips, config, lastCommit;
@@ -52,6 +53,16 @@ describe('CommitView', function() {
 
   afterEach(function() {
     atomEnv.destroy();
+  });
+  describe('amend', function() {
+    it('increments a counter when amend is called', function() {
+      const wrapper = shallow(app);
+      wrapper.setProps({message: 'yo dawg I heard you like amending'});
+      sinon.stub(reporterProxy, 'incrementCounter');
+      wrapper.instance().amendLastCommit();
+
+      assert.equal(reporterProxy.incrementCounter.callCount, 1);
+    });
   });
 
   describe('coauthor stuff', function() {

--- a/test/views/commit-view.test.js
+++ b/test/views/commit-view.test.js
@@ -66,9 +66,10 @@ describe('CommitView', function() {
   });
 
   describe('coauthor stuff', function() {
-    let wrapper;
+    let wrapper, incrementCounterStub;
     beforeEach(function() {
       wrapper = shallow(app);
+      incrementCounterStub = sinon.stub(reporterProxy, 'incrementCounter');
     });
     it('on initial load, renders co-author toggle but not input or form', function() {
       const coAuthorButton = wrapper.find('.github-CommitView-coAuthorToggle');
@@ -80,6 +81,8 @@ describe('CommitView', function() {
 
       const coAuthorForm = wrapper.find(CoAuthorForm);
       assert.deepEqual(coAuthorForm.length, 0);
+
+      assert.isFalse(incrementCounterStub.called);
     });
     it('renders co-author input when toggle is clicked', function() {
       const coAuthorButton = wrapper.find('.github-CommitView-coAuthorToggle');
@@ -87,6 +90,18 @@ describe('CommitView', function() {
 
       const coAuthorInput = wrapper.find(ObserveModel);
       assert.deepEqual(coAuthorInput.length, 1);
+      assert.isTrue(incrementCounterStub.calledOnce);
+      assert.deepEqual(incrementCounterStub.lastCall.args, ['show-co-author-input']);
+    });
+    it('hides co-author input when toggle is clicked twice', function() {
+      const coAuthorButton = wrapper.find('.github-CommitView-coAuthorToggle');
+      coAuthorButton.simulate('click');
+      coAuthorButton.simulate('click');
+
+      const coAuthorInput = wrapper.find(ObserveModel);
+      assert.deepEqual(coAuthorInput.length, 0);
+      assert.isTrue(incrementCounterStub.calledTwice);
+      assert.deepEqual(incrementCounterStub.lastCall.args, ['hide-co-author-input']);
     });
     it('renders co-author form when a new co-author is added', function() {
       const coAuthorButton = wrapper.find('.github-CommitView-coAuthorToggle');
@@ -98,6 +113,9 @@ describe('CommitView', function() {
 
       const coAuthorForm = wrapper.find(CoAuthorForm);
       assert.deepEqual(coAuthorForm.length, 1);
+
+      assert.isTrue(incrementCounterStub.calledTwice);
+      assert.deepEqual(incrementCounterStub.lastCall.args, ['selected-co-authors-changed']);
     });
 
   });


### PR DESCRIPTION
Addresses https://github.com/atom/github/issues/1546

This pull request adds the ability to send 3 types of usage metrics from the GitHub package to GitHub's internal analytics pipeline:

events (for whatever we want)
counters (for incrementing every time a thing happens)
timers (for latency events)

### Approach
- Added a `ReporterProxy` class.  This is necessary because we can't use the real reporter until the `metrics` package has loaded, and there's no guarantee that will happen before the GitHub package loads. 

- Export functions to add metrics.  Functions can be conveniently imported/used at any layer of our codebase.

- Since we can put metrics instrumentation at multiple levels of the codebase, where should we track?  It depends on the question you're trying to answer with the data.
  - if the question is "how many times is x button clicked?" instrument the UI.
  - If the question is "how many times is this action performed" instrument as close to the API as possible (where we shell out to git, where we call graphql.)

### Metrics to track

- [x] All Git operations (excluding noisy ones that don't give us much info in terms of user behavior)
- [x] Co author functionality
- [x] Authentication requests made for the GitHub package
- [x] GitHub package version
- [x] Amend actions
- [x] opening/closing the Git / GitHub panes
- [x] create pull request actions

We came up with these during the editor tools mini summit, and i'm totally open to revisiting this list now.  

### Test plan
 - [x] unit tests for `reporterProxy`
 - [x] unit tests for all the places we are incrementing metrics
 - [x] manually testing this is hard.  We don't actually send any metrics to the back end in dev mode, so I can't look at network activity to verify. There isn't an interface exposed to look directly at what's in the `StatsStore` from the Github package, because we're calling it via a services interface.  I put in some console.log statements to verify that the `Reporter` class is being called as I expect, when I perform actions that are instrumented.  

### Future work

- instrument UI for partial staging.
- measure latency for git actions