### PR TITLE
Checkout Pull Request

### DIFF
--- a/lib/containers/issueish-detail-container.js
+++ b/lib/containers/issueish-detail-container.js
@@ -21,6 +21,7 @@ export default class IssueishDetailContainer extends React.Component {
     repo: PropTypes.string.isRequired,
     issueishNumber: PropTypes.number.isRequired,
 
+    repository: PropTypes.object.isRequired,
     loginModel: GithubLoginModelPropType.isRequired,
 
     switchToIssueish: PropTypes.func.isRequired,
@@ -29,10 +30,15 @@ export default class IssueishDetailContainer extends React.Component {
 
   constructor(props) {
     super(props);
-    autobind(this, 'fetchData', 'renderWithToken', 'renderWithResult', 'handleLogin', 'handleLogout');
+    autobind(this,
+      'fetchToken', 'renderWithToken',
+      'fetchRepositoryData', 'renderWithRepositoryData',
+      'renderWithResult',
+      'handleLogin', 'handleLogout',
+    );
   }
 
-  fetchData(loginModel) {
+  fetchToken(loginModel) {
     return yubikiri({
       token: loginModel.getToken(this.props.host),
     });
@@ -40,22 +46,34 @@ export default class IssueishDetailContainer extends React.Component {
 
   render() {
     return (
-      <ObserveModel model={this.props.loginModel} fetchData={this.fetchData}>
+      <ObserveModel model={this.props.loginModel} fetchData={this.fetchToken}>
         {this.renderWithToken}
       </ObserveModel>
     );
   }
 
-  renderWithToken(data) {
-    if (!data) {
+  fetchRepositoryData(repository) {
+    return yubikiri({
+      branches: repository.getBranches(),
+      remotes: repository.getRemotes(),
+      isMerging: repository.isMerging(),
+      isRebasing: repository.isRebasing(),
+      unstagedChanges: repository.getUnstagedChanges(),
+      stagedChanges: repository.getStagedChanges(),
+      mergeConflicts: repository.getMergeConflicts(),
+    });
+  }
+
+  renderWithToken(tokenData) {
+    if (!tokenData) {
       return <LoadingView />;
     }
 
-    if (data.token === UNAUTHENTICATED) {
+    if (tokenData.token === UNAUTHENTICATED) {
       return <GithubLoginView onLogin={this.handleLogin} />;
     }
 
-    if (data.token === INSUFFICIENT) {
+    if (tokenData.token === INSUFFICIENT) {
       return (
         <GithubLoginView onLogin={this.handleLogin}>
           <p>
@@ -65,7 +83,19 @@ export default class IssueishDetailContainer extends React.Component {
       );
     }
 
-    const environment = RelayNetworkLayerManager.getEnvironmentForHost(this.props.host, data.token);
+    return (
+      <ObserveModel model={this.props.repository} fetchData={this.fetchRepositoryData}>
+        {repoData => this.renderWithRepositoryData(repoData, tokenData.token)}
+      </ObserveModel>
+    );
+  }
+
+  renderWithRepositoryData(repoData, token) {
+    if (!repoData) {
+      return <LoadingView />;
+    }
+
+    const environment = RelayNetworkLayerManager.getEnvironmentForHost(this.props.host, token);
     const query = graphql`
       query issueishDetailContainerQuery
       (
@@ -98,13 +128,13 @@ export default class IssueishDetailContainer extends React.Component {
           environment={environment}
           query={query}
           variables={variables}
-          render={this.renderWithResult}
+          render={queryResult => this.renderWithResult(queryResult, repoData)}
         />
       </RelayEnvironment>
     );
   }
 
-  renderWithResult({error, props, retry}) {
+  renderWithResult({error, props, retry}, repoData) {
     if (error) {
       return (
         <QueryErrorView
@@ -123,6 +153,7 @@ export default class IssueishDetailContainer extends React.Component {
     return (
       <IssueishDetailController
         {...props}
+        {...repoData}
         issueishNumber={this.props.issueishNumber}
         onTitleChange={this.props.onTitleChange}
         switchToIssueish={this.props.switchToIssueish}

--- a/lib/items/issueish-pane-item.js
+++ b/lib/items/issueish-pane-item.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Emitter} from 'event-kit';
 
 import {autobind} from '../helpers';
-import {GithubLoginModelPropType} from '../prop-types';
+import {GithubLoginModelPropType, WorkdirContextPoolPropType} from '../prop-types';
 import IssueishDetailContainer from '../containers/issueish-detail-container';
 
 export default class IssueishPaneItem extends Component {
@@ -13,17 +13,19 @@ export default class IssueishPaneItem extends Component {
     repo: PropTypes.string.isRequired,
     issueishNumber: PropTypes.number.isRequired,
 
+    workingDirectory: PropTypes.string.isRequired,
+    workdirContextPool: WorkdirContextPoolPropType.isRequired,
     loginModel: GithubLoginModelPropType.isRequired,
   }
 
-  static uriPattern = 'atom-github://issueish/{host}/{owner}/{repo}/{issueishNumber}'
+  static uriPattern = 'atom-github://issueish/{host}/{owner}/{repo}/{issueishNumber}?workdir={workingDirectory}'
 
-  static buildURI(host, owner, repo, number) {
+  static buildURI(host, owner, repo, number, workdir) {
     return 'atom-github://issueish/' +
       encodeURIComponent(host) + '/' +
       encodeURIComponent(owner) + '/' +
       encodeURIComponent(repo) + '/' +
-      encodeURIComponent(number);
+      encodeURIComponent(number) + '?workdir=' + encodeURIComponent(workdir);
   }
 
   constructor(props) {
@@ -43,6 +45,8 @@ export default class IssueishPaneItem extends Component {
   }
 
   render() {
+    const repository = this.props.workdirContextPool.getContext(this.props.workingDirectory).getRepository();
+
     return (
       <IssueishDetailContainer
         host={this.state.host}
@@ -50,6 +54,7 @@ export default class IssueishPaneItem extends Component {
         repo={this.state.repo}
         issueishNumber={this.state.issueishNumber}
 
+        repository={repository}
         loginModel={this.props.loginModel}
 
         onTitleChange={this.handleTitleChanged}

--- a/lib/prop-types.js
+++ b/lib/prop-types.js
@@ -10,6 +10,10 @@ export const DOMNodePropType = (props, propName, componentName) => {
   }
 };
 
+export const WorkdirContextPoolPropType = PropTypes.shape({
+  getContext: PropTypes.func.isRequired,
+});
+
 export const GithubLoginModelPropType = PropTypes.shape({
   getToken: PropTypes.func.isRequired,
   setToken: PropTypes.func.isRequired,

--- a/test/containers/issueish-detail-container.test.js
+++ b/test/containers/issueish-detail-container.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 
+import {cloneRepository, buildRepository} from '../helpers';
 import {expectRelayQuery} from '../../lib/relay-network-layer-manager';
 import {issueishDetailContainerProps} from '../fixtures/props/issueish-pane-props';
 import {createPullRequestDetailResult} from '../fixtures/factories/pull-request-result';
@@ -9,10 +10,13 @@ import {InMemoryStrategy, UNAUTHENTICATED} from '../../lib/shared/keytar-strateg
 import IssueishDetailContainer from '../../lib/containers/issueish-detail-container';
 
 describe('IssueishDetailContainer', function() {
-  let loginModel;
+  let loginModel, repository;
 
-  beforeEach(function() {
+  beforeEach(async function() {
     loginModel = new GithubLoginModel(InMemoryStrategy);
+
+    const workDir = await cloneRepository();
+    repository = await buildRepository(workDir);
   });
 
   function useResult() {
@@ -40,7 +44,7 @@ describe('IssueishDetailContainer', function() {
   }
 
   function buildApp(overrideProps = {}) {
-    return <IssueishDetailContainer {...issueishDetailContainerProps({loginModel, ...overrideProps})} />;
+    return <IssueishDetailContainer {...issueishDetailContainerProps({loginModel, repository, ...overrideProps})} />;
   }
 
   it('renders a spinner while the token is being fetched', function() {

--- a/test/fixtures/props/issueish-pane-props.js
+++ b/test/fixtures/props/issueish-pane-props.js
@@ -1,9 +1,12 @@
 import GithubLoginModel from '../../../lib/models/github-login-model';
+import WorkdirContextPool from '../../../lib/models/workdir-context-pool';
 import {InMemoryStrategy} from '../../../lib/shared/keytar-strategy';
 
 export function issueishPaneItemProps(overrides = {}) {
   return {
     loginModel: new GithubLoginModel(InMemoryStrategy),
+    workdirContextPool: new WorkdirContextPool(),
+    workingDirectory: __dirname,
     ...overrides,
   };
 }

--- a/test/items/issueish-pane-item.test.js
+++ b/test/items/issueish-pane-item.test.js
@@ -39,7 +39,7 @@ describe('IssueishPaneItem', function() {
   it('renders within the workspace center', async function() {
     const wrapper = mount(buildApp({}));
 
-    const uri = IssueishPaneItem.buildURI('one.com', 'me', 'code', 400);
+    const uri = IssueishPaneItem.buildURI('one.com', 'me', 'code', 400, __dirname);
     const item = await atomEnv.workspace.open(uri);
 
     assert.lengthOf(wrapper.update().find('IssueishPaneItem'), 1);
@@ -53,7 +53,7 @@ describe('IssueishPaneItem', function() {
 
   it('switches to a different issueish', async function() {
     const wrapper = mount(buildApp({}));
-    await atomEnv.workspace.open(IssueishPaneItem.buildURI('host.com', 'me', 'original', 1));
+    await atomEnv.workspace.open(IssueishPaneItem.buildURI('host.com', 'me', 'original', 1, __dirname));
 
     const before = wrapper.update().find('IssueishDetailContainer');
     assert.strictEqual(before.prop('host'), 'host.com');
@@ -73,7 +73,7 @@ describe('IssueishPaneItem', function() {
   it('reconstitutes its original URI', async function() {
     const wrapper = mount(buildApp({}));
 
-    const uri = IssueishPaneItem.buildURI('host.com', 'me', 'original', 1);
+    const uri = IssueishPaneItem.buildURI('host.com', 'me', 'original', 1, __dirname);
     const item = await atomEnv.workspace.open(uri);
     assert.strictEqual(item.getURI(), uri);
     assert.strictEqual(item.serialize().uri, uri);
@@ -86,7 +86,7 @@ describe('IssueishPaneItem', function() {
 
   it('broadcasts title changes', async function() {
     const wrapper = mount(buildApp({}));
-    const item = await atomEnv.workspace.open(IssueishPaneItem.buildURI('host.com', 'user', 'repo', 1));
+    const item = await atomEnv.workspace.open(IssueishPaneItem.buildURI('host.com', 'user', 'repo', 1, __dirname));
     assert.strictEqual(item.getTitle(), 'user/repo#1');
 
     const handler = sinon.stub();
@@ -102,7 +102,7 @@ describe('IssueishPaneItem', function() {
 
   it('tracks pending state termination', async function() {
     mount(buildApp({}));
-    const item = await atomEnv.workspace.open(IssueishPaneItem.buildURI('host.com', 'user', 'repo', 1));
+    const item = await atomEnv.workspace.open(IssueishPaneItem.buildURI('host.com', 'user', 'repo', 1, __dirname));
 
     const handler = sinon.stub();
     subs.add(item.onDidTerminatePendingState(handler));


### PR DESCRIPTION
Build on the foundation established in #1556 to add pull request checkout functionality to the IssueishPaneItem.

##### Screenshots

| Before | After |
| -- | -- |
| <img width="350" alt="screen shot 2018-07-05 at 9 19 13 am" src="https://user-images.githubusercontent.com/17565/42325544-89a77c86-8034-11e8-8ec8-a00fe2ef7c2d.png"> | _TBD_ |

##### Remaining Work

- [x] Associate a working directory with each IssueishPaneItem by its URI. Use a WorkdirContextPool to identify the corresponding Repository.
- [x] Observe the Repository model in the IssueishDetailContainer and extract repository data for the IssueishDetailController.
- [ ] Pass a WorkdirContextPool to each IssueishPaneItem from the RootController that creates it.
- [ ] Introduce a MaybeOperation model to capture the common pattern of an action handler that (a) may be either enabled or disabled for various reasons and (b) toggles component state to `true` while performing some asynchronous work.
- [ ] Return an indexed `RemoteSet` from `repository.getRemotes()`, like we do with the `BranchSet` returned by `getBranches()`.
  - [ ] Update other callers of `getRemotes()` to use the `RemoteSet`.
- [ ] Create a MaybeOperation for the checkout action. Populate its enablement based on the relationship of the current issueish and the state of the repository.
- [ ] Write the handler method for the checkout action.
  - [ ] "Happy path:" fetch and checkout the PR's branch to a new branch in the local repository.
  - [ ] Handle the case where the PR already corresponds to a branch in the local repository.
  - [ ] Do something for the edge cases where a PR already corresponds to _multiple_ branches in the local repository.
  - [ ] Gracefully handle the edge case where the automatically generated local branch name already exists.
- [ ] Render a button in the IssueishDetailView that triggers the checkout action. Disable it and modify its text based on the operation state.
- [ ] Track changes to the current issueish by switching the active repository.
- [ ]  🚧 _doot doot doot_ 🚧 

##### Reviews

Before we merge, I'd like:

* A ✅ review from @simurai once he's happy with the design and UX flow.
* A ✅ review from @sguthals for Q&A