### PR TITLE
Bootstrap Istanbul in-process

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -262,6 +262,10 @@ after(() => {
 
   if (global._nyc) {
     global._nyc.writeCoverageFile();
+
+    if (global._nycInProcess) {
+      global._nyc.report();
+    }
   }
 });
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -12,7 +12,55 @@ global.assert = chai.assert;
 // Give tests that rely on filesystem event delivery lots of breathing room.
 until.setDefaultTimeout(parseInt(process.env.UNTIL_TIMEOUT || '3000', 10));
 
-if (process.env.NYC_CONFIG) {
+if (process.env.ATOM_GITHUB_BABEL_ENV === 'coverage' && !process.env.NYC_CONFIG) {
+  // Set up Istanbul in this process.
+  // This mimics the argument parsing and setup performed in:
+  //   https://github.com/istanbuljs/nyc/blob/v13.0.0/bin/nyc.js
+  // And the process-under-test wrapping done by:
+  //   https://github.com/istanbuljs/nyc/blob/v13.0.0/bin/wrap.js
+
+  const configUtil = require('nyc/lib/config-util');
+
+  const yargs = configUtil.buildYargs();
+  const config = configUtil.loadConfig({}, path.join(__dirname, '..'));
+  configUtil.addCommandsAndHelp(yargs);
+  const argv = yargs.config(config).parse([]);
+
+  argv.instrumenter = require.resolve('nyc/lib/instrumenters/noop');
+  argv.reporter = 'lcovonly';
+  argv.cwd = path.join(__dirname, '..');
+  argv.tempDirectory = path.join(__dirname, '..', '.nyc_output');
+
+  global._nyc = new NYC(argv);
+
+  if (argv.clean) {
+    global._nyc.reset();
+  } else {
+    global._nyc.createTempDirectory();
+  }
+  if (argv.all) {
+    global._nyc.addAllFiles();
+  }
+
+  process.env.NYC_CONFIG = JSON.stringify(argv);
+  process.env.NYC_CWD = path.join(__dirname, '..');
+  process.env.NYC_ROOT_ID = global._nyc.rootId;
+  process.env.NYC_INSTRUMENTER = argv.instrumenter;
+  process.env.NYC_PARENT_PID = process.pid;
+
+  process.isChildProcess = true;
+  global._nyc.config._processInfo = {
+    ppid: '0',
+    root: global._nyc.rootId,
+  };
+
+  global._nyc.wrap();
+
+  global._nycInProcess = true;
+} else if (process.env.NYC_CONFIG) {
+  // Istanbul is running us from a parent process. Simulate the wrap.js call in:
+  //   https://github.com/istanbuljs/nyc/blob/v13.0.0/bin/wrap.js
+
   const parentPid = process.env.NYC_PARENT_PID || '0';
   process.env.NYC_PARENT_PID = process.pid;
 


### PR DESCRIPTION
If `ATOM_GITHUB_BABEL_ENV` is set to `coverage`, initialize Istanbul to capture coverage data in lcov format. This'll save us a bunch of trips to the command-line to run `npm run test:coverage:lcov` just to bring coverage annotations up to date. ✨ 

Also known as "abusing the crap out of Istanbul for fun and profit."