### PR TITLE
Support arbitrary channel names when launching Atom Helper

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -31,7 +31,7 @@ export function getPackageRoot() {
 }
 
 function getAtomAppName() {
-  const match = atom.getVersion().match(/-([a-z]+)(\d+|-)/);
+  const match = atom.getVersion().match(/-([A-Za-z]+)(\d+|-)/);
   if (match) {
     const channel = match[1];
     return `Atom ${channel.charAt(0).toUpperCase() + channel.slice(1)} Helper`;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -31,9 +31,10 @@ export function getPackageRoot() {
 }
 
 function getAtomAppName() {
-  const match = atom.getVersion().match(/beta|nightly/);
+  const match = atom.getVersion().match(/-([a-z]+)(\d+|-)/);
   if (match) {
-    return `Atom ${match[0].charAt(0).toUpperCase() + match[0].slice(1)} Helper`;
+    const channel = match[1];
+    return `Atom ${channel.charAt(0).toUpperCase() + channel.slice(1)} Helper`;
   }
 
   return 'Atom Helper';


### PR DESCRIPTION
### Description of the Change

This change modifies the `getAtomAppName` function to use a looser regex for identifying the channel name of the current Atom version.  This is necessary on macOS because we will now be calling the helper app `Atom Dev Helper.app` during CI builds against Atom master.

### Alternate Designs

Could have added `dev` to the existing channel name regex, but this seemed more future-proof.  Happy to go back to the old approach, though.

### Benefits

Less code changes to this function in the future?

### Possible Drawbacks

What happens if a weird Atom build with a different version format comes along?

### Applicable Issues

https://github.com/atom/atom/pull/17680
