### PR TITLE
Snapshot fixes

### DIFF
--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -14,18 +14,6 @@ class ReporterProxy {
     this.gitHubPackageVersion = pjson.version;
 
     this.timeout = null;
-
-    // if for some reason a user disables the metrics package, we don't want to
-    // just keep accumulating events in memory until the heat death of the universe.
-    // Use a no-op class, clear all queues, move on with our lives.
-    setTimeout(FIVE_MINUTES_IN_MILLISECONDS, () => {
-      if (this.reporter === null) {
-        this.setReporter(new FakeReporter());
-        this.events = [];
-        this.timings = [];
-        this.counters = [];
-      }
-    });
   }
 
   // function that is called after the reporter is actually loaded, to

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -13,6 +13,8 @@ class ReporterProxy {
     this.counters = [];
     this.gitHubPackageVersion = pjson.version;
 
+    this.timeout = null;
+
     // if for some reason a user disables the metrics package, we don't want to
     // just keep accumulating events in memory until the heat death of the universe.
     // Use a no-op class, clear all queues, move on with our lives.
@@ -43,6 +45,54 @@ class ReporterProxy {
       this.reporter.incrementCounter(counterName);
     });
   }
+
+  incrementCounter(counterName) {
+    if (this.reporter === null) {
+      this.startTimer();
+      this.counters.push(counterName);
+      return;
+    }
+
+    this.reporter.incrementCounter(counterName);
+  }
+
+  addTiming(eventType, durationInMilliseconds, metadata = {}) {
+    if (this.reporter === null) {
+      this.startTimer();
+      this.timings.push({eventType, durationInMilliseconds, metadata});
+      return;
+    }
+
+    this.reporter.addTiming(eventType, durationInMilliseconds, metadata);
+  }
+
+  addEvent(eventType, event) {
+    if (this.reporter === null) {
+      this.startTimer();
+      this.events.push({eventType, event});
+      return;
+    }
+
+    this.reporter.addCustomEvent(eventType, event);
+  }
+
+  startTimer() {
+    if (this.timeout !== null) {
+      return;
+    }
+
+    // if for some reason a user disables the metrics package, we don't want to
+    // just keep accumulating events in memory until the heat death of the universe.
+    // Use a no-op class, clear all queues, move on with our lives.
+    this.timeout = setTimeout(FIVE_MINUTES_IN_MILLISECONDS, () => {
+      if (this.reporter === null) {
+        this.setReporter(new FakeReporter());
+        this.events = [];
+        this.timings = [];
+        this.counters = [];
+      }
+    });
+  }
 }
 
 export const reporterProxy = new ReporterProxy();
@@ -56,27 +106,15 @@ export class FakeReporter {
 }
 
 export function incrementCounter(counterName) {
-  if (reporterProxy.reporter) {
-    reporterProxy.reporter.incrementCounter(counterName);
-  } else {
-    reporterProxy.counters.push(counterName);
-  }
+  reporterProxy.incrementCounter(counterName);
 }
 
 export function addTiming(eventType, durationInMilliseconds, metadata = {}) {
   metadata.gitHubPackageVersion = reporterProxy.gitHubPackageVersion;
-  if (reporterProxy.reporter) {
-    reporterProxy.reporter.addTiming(eventType, durationInMilliseconds, metadata);
-  } else {
-    reporterProxy.timings.push({eventType, durationInMilliseconds, metadata});
-  }
+  reporterProxy.addTiming(eventType, durationInMilliseconds, metadata);
 }
 
 export function addEvent(eventType, event) {
   event.gitHubPackageVersion = reporterProxy.gitHubPackageVersion;
-  if (reporterProxy.reporter) {
-    reporterProxy.reporter.addCustomEvent(eventType, event);
-  } else {
-    reporterProxy.events.push({eventType, event});
-  }
+  reporterProxy.addEvent(eventType, event);
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "main": "./lib/index",
-  "version": "0.18.0",
+  "version": "0.18.0-0",
   "description": "GitHub integration",
   "repository": "https://github.com/atom/github",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "main": "./lib/index",
-  "version": "0.18.0-0",
+  "version": "0.18.0-1",
   "description": "GitHub integration",
   "repository": "https://github.com/atom/github",
   "license": "MIT",


### PR DESCRIPTION
Let's see how many prerelease versions I burn through getting us to snapshot properly.

- [x] Make `setTimeout` call in ReporterProxy lazier (not triggered through the statically called constructor).