### PR TITLE
Restyle hovercards

### DIFF
--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -131,7 +131,7 @@ export default class StatusBarTileController extends React.Component {
           manager={this.props.tooltips}
           target={this.refBranchViewRoot}
           trigger="click"
-          className="github-StatusBarTileController-tooltipMenu">
+          className="github-Popover">
           <BranchMenuView
             workspace={this.props.workspace}
             notificationManager={this.props.notificationManager}

--- a/lib/views/github-dotcom-markdown.js
+++ b/lib/views/github-dotcom-markdown.js
@@ -63,6 +63,7 @@ export class BareGithubDotcomMarkdown extends React.Component {
       this.tooltipSubscriptions.add(atom.tooltips.add(node, {
         trigger: 'hover',
         delay: 0,
+        class: 'github-Popover',
         item,
       }));
       this.tooltipSubscriptions.add(new Disposable(() => item.destroy()));

--- a/lib/views/github-dotcom-markdown.js
+++ b/lib/views/github-dotcom-markdown.js
@@ -73,6 +73,7 @@ export class BareGithubDotcomMarkdown extends React.Component {
       this.tooltipSubscriptions.add(atom.tooltips.add(node, {
         trigger: 'hover',
         delay: 0,
+        class: 'github-Popover',
         item,
       }));
       this.tooltipSubscriptions.add(new Disposable(() => item.destroy()));

--- a/styles/issueish-tooltip.less
+++ b/styles/issueish-tooltip.less
@@ -1,8 +1,9 @@
 @import 'variables';
 
 .github-IssueishTooltip {
-  max-width: 500px;
   text-align: left;
+  font-size: .9em;
+  padding: @component-padding/2;
 
   .issueish-badge-and-link {
     padding-bottom: @component-padding;
@@ -36,19 +37,32 @@
     }
   }
 
+  .issueish-link {
+    color: @text-color-subtle;
+  }
+
   .issueish-title {
+    display: block;
     margin: 0;
     padding-bottom: @component-padding;
-    line-height: 1.2;
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    font-size: 1.1em;
+    font-weight: 600;
+    line-height: 1.3;
+    color: @text-color-highlight;
+    white-space: initial;
+  }
+
+  .issueish-avatar-and-title {
+    strong {
+      font-weight: normal;
+      color: @text-color-subtle;
+    }
   }
 
   .author-avatar {
-    margin-right: 10px;
+    margin-right: @component-padding/2;
     width: 20px;
     height: 20px;
+    border-radius: @component-border-radius;
   }
 }

--- a/styles/popover.less
+++ b/styles/popover.less
@@ -1,0 +1,29 @@
+@import "variables";
+
+// Popover: Custom tooltip
+// Used for branch switcher and hovercards
+
+.github-Popover {
+  &.tooltip {
+    width: 400px; // Same as the github-Panel
+    padding-left: @component-padding;
+    padding-right: @component-padding;
+    box-sizing: border-box;
+  }
+  .tooltip-inner.tooltip-inner {
+    padding: @component-padding / 2;
+    background-color: @tool-panel-background-color;
+    border: 1px solid @base-border-color;
+    box-shadow: 0 4px 8px hsla(0, 0, 0, .1);
+    color: @text-color;
+  }
+  &.top .tooltip-arrow.tooltip-arrow {
+    width: @component-padding;
+    height: @component-padding;
+    border-width: 0 0 1px 1px;
+    border-color: @base-border-color;
+    background-color: @tool-panel-background-color;
+    border-bottom-right-radius: 2px;
+    transform: rotate(-45deg);
+  }
+}

--- a/styles/status-bar-tile-controller.less
+++ b/styles/status-bar-tile-controller.less
@@ -3,31 +3,6 @@
 .github-StatusBarTileController {
   display: inline-block;
 
-  &-tooltipMenu {
-    &.tooltip {
-      width: 400px; // Same as the github-Panel
-      padding-left: @component-padding;
-      padding-right: @component-padding;
-      box-sizing: border-box;
-    }
-    .tooltip-inner.tooltip-inner {
-      padding: @component-padding / 2;
-      background-color: @tool-panel-background-color;
-      border: 1px solid @base-border-color;
-      box-shadow: 0 4px 8px hsla(0, 0, 0, .1);
-      color: @text-color;
-    }
-    &.top .tooltip-arrow.tooltip-arrow {
-      width: @component-padding;
-      height: @component-padding;
-      border-width: 0 0 1px 1px;
-      border-color: @base-border-color;
-      background-color: @tool-panel-background-color;
-      border-bottom-right-radius: 2px;
-      transform: rotate(-45deg);
-    }
-  }
-
   & > .inline-block:hover {
     text-decoration: underline;
     cursor: default;

--- a/styles/user-mention-tooltip.less
+++ b/styles/user-mention-tooltip.less
@@ -4,26 +4,39 @@
   display: flex;
 
   &-avatar {
-    flex-basis: 50px;
-    padding-right: @component-padding;
+    margin: @component-padding/2;
 
     > img {
-      width: 90px;
-      height: 90px;
-      border-radius: @component-border-radius / 2;
+      width: 60px;
+      height: 60px;
+      border-radius: @component-border-radius;
     }
   }
 
   &-info {
     flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin: @component-padding/2;
+    margin-left: @component-padding;
+    font-size: @font-size;
+    line-height: 20px;
     text-align: left;
-    line-height: 1.6;
 
     > div {
       white-space: nowrap;
     }
     .icon {
+      color: @text-color-subtle;
       vertical-align: middle;
+    }
+
+    &-username {
+      font-size: 1.2em;
+      strong {
+        font-weight: 600;
+      }
     }
   }
 }


### PR DESCRIPTION
### Description of the Change

This restyles the "hovercards".

Before | After
--- | ---
![screen shot 2018-07-19 at 10 01 56 pm](https://user-images.githubusercontent.com/378023/42944216-0863392c-8ba0-11e8-8801-ed0473bdafac.png) | ![screen shot 2018-07-19 at 10 02 41 pm](https://user-images.githubusercontent.com/378023/42944217-08900f2e-8ba0-11e8-904d-2957875ce780.png)
![screen shot 2018-07-19 at 10 02 57 pm](https://user-images.githubusercontent.com/378023/42944242-17e0bca8-8ba0-11e8-87a6-095a8cf7ba27.png) | ![screen shot 2018-07-19 at 10 03 23 pm](https://user-images.githubusercontent.com/378023/42944243-18211852-8ba0-11e8-992e-8610bad514e8.png)


### Alternate Designs

We could go closer to .com.

### Benefits

- Easier to read
- Long PR titles don't get cut off

Also, there is now a `github-Popover` class that can be re-used for other tooltips.

### Possible Drawbacks

Might not work with all themes the same.

### Applicable Issues

None, this is a direct order from @donokuda 
