### PR TITLE
Split GithubTabController into twos, nay, into threes and fours

### DIFF
--- a/keymaps/git.cson
+++ b/keymaps/git.cson
@@ -17,7 +17,7 @@
   'alt-m enter': 'github:resolve-as-current'
   'alt-m r': 'github:revert-current'
 
-'.github-Panel':
+'.github-Git':
   'cmd-enter': 'github:commit'
   'ctrl-enter': 'github:commit'
 

--- a/lib/containers/github-tab-container.js
+++ b/lib/containers/github-tab-container.js
@@ -59,7 +59,7 @@ export default class GitHubTabContainer extends React.Component {
   }
 
   renderRepositoryData(data) {
-    if (!data) {
+    if (!data || this.props.repository.isLoading()) {
       return <LoadingView />;
     }
 

--- a/lib/containers/github-tab-container.js
+++ b/lib/containers/github-tab-container.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import yubikiri from 'yubikiri';
+
+import {GithubLoginModelPropType, RefHolderPropType} from '../prop-types';
+import {autobind} from '../helpers';
+import OperationStateObserver, {PUSH, PULL, FETCH} from '../models/operation-state-observer';
+import GitHubTabController from '../controllers/github-tab-controller';
+import ObserveModel from '../views/observe-model';
+import LoadingView from '../views/loading-view';
+
+export default class GitHubTabContainer extends React.Component {
+  static propTypes = {
+    workspace: PropTypes.object.isRequired,
+    repository: PropTypes.object,
+    loginModel: GithubLoginModelPropType.isRequired,
+    rootHolder: RefHolderPropType.isRequired,
+  }
+
+  constructor(props) {
+    super(props);
+    autobind(this, 'fetchRepositoryData', 'renderRepositoryData');
+
+    this.state = {};
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    if (props.repository !== state.lastRepository) {
+      return {
+        lastRepository: props.repository,
+        remoteOperationObserver: new OperationStateObserver(props.repository, PUSH, PULL, FETCH),
+      };
+    }
+
+    return null;
+  }
+
+  fetchRepositoryData(repository) {
+    return yubikiri({
+      workingDirectory: repository.getWorkingDirectoryPath(),
+      allRemotes: repository.getRemotes(),
+      branches: repository.getBranches(),
+      selectedRemoteName: repository.getConfig('atomGithub.currentRemote'),
+      aheadCount: async query => {
+        const branches = await query.branches;
+        const currentBranch = branches.getHeadBranch();
+        return repository.getAheadCount(currentBranch.getName());
+      },
+      pushInProgress: repository.getOperationStates().isPushInProgress(),
+    });
+  }
+
+  render() {
+    return (
+      <ObserveModel model={this.props.repository} fetchData={this.fetchRepositoryData}>
+        {this.renderRepositoryData}
+      </ObserveModel>
+    );
+  }
+
+  renderRepositoryData(data) {
+    if (!data) {
+      return <LoadingView />;
+    }
+
+    if (!this.props.repository.isPresent()) {
+      // TODO include a better message here.
+      return null;
+    }
+
+    return <GitHubTabController {...data} {...this.props} />;
+  }
+}

--- a/lib/containers/github-tab-container.js
+++ b/lib/containers/github-tab-container.js
@@ -68,6 +68,12 @@ export default class GitHubTabContainer extends React.Component {
       return null;
     }
 
-    return <GitHubTabController {...data} {...this.props} />;
+    return (
+      <GitHubTabController
+        {...data}
+        {...this.props}
+        remoteOperationObserver={this.state.remoteOperationObserver}
+      />
+    );
   }
 }

--- a/lib/containers/github-tab-container.js
+++ b/lib/containers/github-tab-container.js
@@ -7,7 +7,8 @@ import {autobind} from '../helpers';
 import OperationStateObserver, {PUSH, PULL, FETCH} from '../models/operation-state-observer';
 import GitHubTabController from '../controllers/github-tab-controller';
 import ObserveModel from '../views/observe-model';
-import LoadingView from '../views/loading-view';
+import RemoteSet from '../models/remote-set';
+import BranchSet from '../models/branch-set';
 
 export default class GitHubTabContainer extends React.Component {
   static propTypes = {
@@ -60,7 +61,19 @@ export default class GitHubTabContainer extends React.Component {
 
   renderRepositoryData(data) {
     if (!data || this.props.repository.isLoading()) {
-      return <LoadingView />;
+      return (
+        <GitHubTabController
+          {...this.props}
+          remoteOperationObserver={this.state.remoteOperationObserver}
+
+          workingDirectory=""
+          allRemotes={new RemoteSet()}
+          branches={new BranchSet()}
+          aheadCount={0}
+          pushInProgress={false}
+          isLoading={true}
+        />
+      );
     }
 
     if (!this.props.repository.isPresent()) {
@@ -73,6 +86,7 @@ export default class GitHubTabContainer extends React.Component {
         {...data}
         {...this.props}
         remoteOperationObserver={this.state.remoteOperationObserver}
+        isLoading={false}
       />
     );
   }

--- a/lib/controllers/github-tab-controller.js
+++ b/lib/controllers/github-tab-controller.js
@@ -1,130 +1,64 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import yubikiri from 'yubikiri';
 
-import RemoteSelectorView from '../views/remote-selector-view';
-import RemoteContainer from '../containers/remote-container';
-import GithubLoginModel from '../models/github-login-model';
-import OperationStateObserver, {PUSH, PULL, FETCH} from '../models/operation-state-observer';
-import ObserveModel from '../views/observe-model';
+import {
+  GithubLoginModelPropType, RefHolderPropType, RemoteSetPropType, BranchSetPropType, OperationStateObserverPropType,
+} from '../prop-types';
 import {autobind} from '../helpers';
+import GitHubTabView from '../views/github-tab-view';
 
-export default class GithubTabController extends React.Component {
+export default class GitHubTabController extends React.Component {
   static propTypes = {
     workspace: PropTypes.object.isRequired,
-    repository: PropTypes.object,
-    loginModel: PropTypes.instanceOf(GithubLoginModel),
-  }
+    repository: PropTypes.object.isRequired,
+    remoteOperationObserver: OperationStateObserverPropType.isRequired,
+    loginModel: GithubLoginModelPropType.isRequired,
+    rootHolder: RefHolderPropType.isRequired,
 
-  static uriPattern = 'atom-github://dock-item/github';
-
-  static buildURI() {
-    return this.uriPattern;
+    workingDirectory: PropTypes.string.isRequired,
+    allRemotes: RemoteSetPropType.isRequired,
+    branches: BranchSetPropType.isRequired,
+    selectedRemoteName: PropTypes.string.isRequired,
+    aheadCount: PropTypes.number.isRequired,
+    pushInProgress: PropTypes.bool.isRequired,
   }
 
   constructor(props) {
     super(props);
-    autobind(this, 'handleRemoteSelect');
-
-    this.state = {};
-  }
-
-  static getDerivedStateFromProps(props, state) {
-    if (props.repository !== state.lastRepository) {
-      return {
-        lastRepository: props.repository,
-        remoteOperationObserver: new OperationStateObserver(props.repository, PUSH, PULL, FETCH),
-      };
-    }
-
-    return null;
-  }
-
-  fetchModelData(repo) {
-    return yubikiri({
-      workingDirectory: repo.getWorkingDirectoryPath(),
-      allRemotes: repo.getRemotes(),
-      branches: repo.getBranches(),
-      selectedRemoteName: repo.getConfig('atomGithub.currentRemote'),
-      selectedPrUrl: async query => {
-        const branches = await query.branches;
-        const currentBranch = branches.getHeadBranch();
-        if (!currentBranch.isPresent()) { return null; }
-        return repo.getConfig(`branch.${currentBranch.getName()}.atomPrUrl`);
-      },
-      aheadCount: async query => {
-        const branches = await query.branches;
-        const currentBranch = branches.getHeadBranch();
-        return repo.getAheadCount(currentBranch.getName());
-      },
-    });
-  }
-
-  serialize() {
-    return {
-      deserializer: 'GithubDockItem',
-      uri: this.getURI(),
-    };
+    autobind(this, 'handlePushBranch', 'handleRemoteSelect');
   }
 
   render() {
-    return (
-      <ObserveModel model={this.props.repository} fetchData={this.fetchModelData}>
-        {data => { return data ? this.renderWithData(data) : null; } }
-      </ObserveModel>
-    );
-  }
+    const gitHubRemotes = this.props.allRemotes.filter(remote => remote.isGithubRepo());
+    const currentBranch = this.props.branches.getHeadBranch();
 
-  renderWithData(data) {
-    const {
-      workingDirectory, allRemotes, branches, selectedRemoteName, aheadCount,
-    } = data;
-    if (!this.props.repository.isPresent()) {
-      return null;
-    }
-
-    const remotes = allRemotes.filter(remote => remote.isGithubRepo());
-    const currentBranch = branches.getHeadBranch();
-
-    let remote = remotes.withName(selectedRemoteName);
+    let currentRemote = gitHubRemotes.withName(this.props.selectedRemoteName);
     let manyRemotesAvailable = false;
-    if (!remote.isPresent() && remotes.size() === 1) {
-      remote = Array.from(remotes)[0];
-    } else if (!remote.isPresent() && remotes.size() > 1) {
+    if (!currentRemote.isPresent() && gitHubRemotes.size() === 1) {
+      currentRemote = Array.from(gitHubRemotes)[0];
+    } else if (!currentRemote.isPresent() && gitHubRemotes.size() > 1) {
       manyRemotesAvailable = true;
     }
 
-    const pushInProgress = this.props.repository.getOperationStates().isPushInProgress();
-
     return (
-      <div ref={c => { this.root = c; }} className="github-GithubTabController">
-        <div className="github-GithubTabController-content">
-          {/* only supporting GH.com for now, hardcoded values */}
-          {remote.isPresent() &&
-            <RemoteContainer
-              host="https://api.github.com"
-              loginModel={this.props.loginModel}
-              remoteOperationObserver={this.state.remoteOperationObserver}
-              workingDirectory={workingDirectory}
-              workspace={this.props.workspace}
-              onPushBranch={() => this.handlePushBranch(currentBranch, remote)}
-              remote={remote}
-              remotes={remotes}
-              branches={branches}
-              aheadCount={aheadCount}
-              pushInProgress={pushInProgress}
-            />
-          }
-          {!remote.isPresent() && manyRemotesAvailable &&
-            <RemoteSelectorView
-              remotes={remotes}
-              currentBranch={currentBranch}
-              selectRemote={this.handleRemoteSelect}
-            />
-          }
-          {!remote.isPresent() && !manyRemotesAvailable && this.renderNoRemotes()}
-        </div>
-      </div>
+      <GitHubTabView
+        workspace={this.props.workspace}
+        remoteOperationObserver={this.props.remoteOperationObserver}
+        loginModel={this.props.loginModel}
+        rootHolder={this.props.rootHolder}
+
+        workingDirectory={this.props.workingDirectory}
+        branches={this.props.branches}
+        currentBranch={currentBranch}
+        remotes={gitHubRemotes}
+        currentRemote={currentRemote}
+        manyRemotesAvailable={manyRemotesAvailable}
+        aheadCount={this.props.aheadCount}
+        pushInProgress={this.props.pushInProgress}
+
+        handlePushBranch={this.handlePushBranch}
+        handleRemoteSelect={this.handleRemoteSelect}
+      />
     );
   }
 
@@ -135,48 +69,8 @@ export default class GithubTabController extends React.Component {
     });
   }
 
-  getTitle() {
-    return 'GitHub (preview)';
-  }
-
-  getIconName() {
-    return 'octoface';
-  }
-
-  getDefaultLocation() {
-    return 'right';
-  }
-
-  getPreferredWidth() {
-    return 400;
-  }
-
-  getURI() {
-    return this.constructor.uriPattern;
-  }
-
-  getWorkingDirectory() {
-    return this.props.repository.getWorkingDirectoryPath();
-  }
-
-  renderNoRemotes() {
-    return (
-      <div className="github-GithubTabController-no-remotes">
-        This repository does not have any remotes hosted at GitHub.com.
-      </div>
-    );
-  }
-
   handleRemoteSelect(e, remote) {
     e.preventDefault();
     return this.props.repository.setConfig('atomGithub.currentRemote', remote.getName());
-  }
-
-  hasFocus() {
-    return this.root && this.root.contains(document.activeElement);
-  }
-
-  restoreFocus() {
-    // No-op
   }
 }

--- a/lib/controllers/github-tab-controller.js
+++ b/lib/controllers/github-tab-controller.js
@@ -21,6 +21,7 @@ export default class GitHubTabController extends React.Component {
     selectedRemoteName: PropTypes.string,
     aheadCount: PropTypes.number.isRequired,
     pushInProgress: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
   }
 
   constructor(props) {
@@ -55,6 +56,7 @@ export default class GitHubTabController extends React.Component {
         manyRemotesAvailable={manyRemotesAvailable}
         aheadCount={this.props.aheadCount}
         pushInProgress={this.props.pushInProgress}
+        isLoading={this.props.isLoading}
 
         handlePushBranch={this.handlePushBranch}
         handleRemoteSelect={this.handleRemoteSelect}

--- a/lib/controllers/github-tab-controller.js
+++ b/lib/controllers/github-tab-controller.js
@@ -18,7 +18,7 @@ export default class GitHubTabController extends React.Component {
     workingDirectory: PropTypes.string.isRequired,
     allRemotes: RemoteSetPropType.isRequired,
     branches: BranchSetPropType.isRequired,
-    selectedRemoteName: PropTypes.string.isRequired,
+    selectedRemoteName: PropTypes.string,
     aheadCount: PropTypes.number.isRequired,
     pushInProgress: PropTypes.bool.isRequired,
   }

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -265,7 +265,7 @@ export default class RootController extends React.Component {
         <PaneItem
           workspace={this.props.workspace}
           uriPattern={GitTabItem.uriPattern}
-          className="github-GitTabItem-root">
+          className="github-Git-root">
           {({itemHolder}) => (
             <GitTabItem
               ref={itemHolder.setter}

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -292,7 +292,7 @@ export default class RootController extends React.Component {
         <PaneItem
           workspace={this.props.workspace}
           uriPattern={GitHubTabItem.uriPattern}
-          className="github-GithubTabController-root">
+          className="github-GitHub-root">
           {({itemHolder}) => (
             <GitHubTabItem
               ref={itemHolder.setter}

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -14,10 +14,10 @@ import InitDialog from '../views/init-dialog';
 import CredentialDialog from '../views/credential-dialog';
 import Commands, {Command} from '../atom/commands';
 import GitTimingsView from '../views/git-timings-view';
-import GithubTabController from './github-tab-controller';
 import FilePatchController from './file-patch-controller';
 import IssueishPaneItem from '../items/issueish-pane-item';
 import GitTabItem from '../items/git-tab-item';
+import GitHubTabItem from '../items/github-tab-item';
 import StatusBarTileController from './status-bar-tile-controller';
 import RepositoryConflictController from './repository-conflict-controller';
 import GitCacheView from '../views/git-cache-view';
@@ -86,7 +86,7 @@ export default class RootController extends React.Component {
     });
 
     this.githubTabTracker = new TabTracker('github', {
-      uri: GithubTabController.buildURI(),
+      uri: GitHubTabItem.buildURI(),
       getWorkspace: () => this.props.workspace,
     });
 
@@ -291,10 +291,10 @@ export default class RootController extends React.Component {
         </PaneItem>
         <PaneItem
           workspace={this.props.workspace}
-          uriPattern={GithubTabController.uriPattern}
+          uriPattern={GitHubTabItem.uriPattern}
           className="github-GithubTabController-root">
           {({itemHolder}) => (
-            <GithubTabController
+            <GitHubTabItem
               ref={itemHolder.setter}
               repository={this.props.repository}
               loginModel={this.props.loginModel}
@@ -361,7 +361,7 @@ export default class RootController extends React.Component {
 
     if (this.props.startRevealed) {
       const docks = new Set(
-        [GitTabItem.buildURI(), GithubTabController.buildURI()]
+        [GitTabItem.buildURI(), GitHubTabItem.buildURI()]
           .map(uri => this.props.workspace.paneContainerForURI(uri))
           .filter(container => container && (typeof container.show) === 'function'),
       );

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -342,7 +342,7 @@ export default class GithubPackage {
       this.gitTabStubItem = this.gitTabStubItem || item;
       break;
     case 'atom-github://dock-item/github':
-      item = this.createGithubTabControllerStub(uri);
+      item = this.createGitHubStub(uri);
       this.githubTabStubItem = this.githubTabStubItem || item;
       break;
     default:
@@ -361,8 +361,8 @@ export default class GithubPackage {
     }, uri);
   }
 
-  createGithubTabControllerStub(uri) {
-    return StubItem.create('github-tab-controller', {
+  createGitHubStub(uri) {
+    return StubItem.create('github', {
       title: 'GitHub (preview)',
     }, uri);
   }

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -338,7 +338,7 @@ export default class GithubPackage {
     // but only set it as the active item for a tab type
     // if it doesn't already exist
     case 'atom-github://dock-item/git':
-      item = this.createGitTabControllerStub(uri);
+      item = this.createGitStub(uri);
       this.gitTabStubItem = this.gitTabStubItem || item;
       break;
     case 'atom-github://dock-item/github':
@@ -355,8 +355,8 @@ export default class GithubPackage {
     return item;
   }
 
-  createGitTabControllerStub(uri) {
-    return StubItem.create('git-tab-controller', {
+  createGitStub(uri) {
+    return StubItem.create('git', {
       title: 'Git',
     }, uri);
   }

--- a/lib/items/github-tab-item.js
+++ b/lib/items/github-tab-item.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {GithubLoginModelPropType} from '../prop-types';
+import RefHolder from '../models/ref-holder';
+import GitHubTabContainer from '../containers/github-tab-container';
+
+export default class GitHubTabItem extends React.Component {
+  static propTypes = {
+    workspace: PropTypes.object.isRequired,
+    repository: PropTypes.object,
+    loginModel: GithubLoginModelPropType.isRequired,
+  }
+
+  static uriPattern = 'atom-github://dock-item/github';
+
+  static buildURI() {
+    return this.uriPattern;
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.rootHolder = new RefHolder();
+  }
+
+  getTitle() {
+    return 'GitHub (preview)';
+  }
+
+  getIconName() {
+    return 'octoface';
+  }
+
+  getDefaultLocation() {
+    return 'right';
+  }
+
+  getPreferredWidth() {
+    return 400;
+  }
+
+  getWorkingDirectory() {
+    return this.props.repository.getWorkingDirectoryPath();
+  }
+
+  serialize() {
+    return {
+      deserializer: 'GithubDockItem',
+      uri: this.getURI(),
+    };
+  }
+
+  render() {
+    return (
+      <GitHubTabContainer {...this.props} rootHolder={this.rootHolder} />
+    );
+  }
+
+  hasFocus() {
+    return this.rootHolder.map(root => root.contains(document.activeElement), () => false);
+  }
+
+  restoreFocus() {
+    // No-op
+  }
+}

--- a/lib/items/github-tab-item.js
+++ b/lib/items/github-tab-item.js
@@ -10,6 +10,12 @@ export default class GitHubTabItem extends React.Component {
     workspace: PropTypes.object.isRequired,
     repository: PropTypes.object,
     loginModel: GithubLoginModelPropType.isRequired,
+
+    documentActiveElement: PropTypes.func,
+  }
+
+  static defaultProps = {
+    documentActiveElement: /* istanbul ignore next */ () => document.activeElement,
   }
 
   static uriPattern = 'atom-github://dock-item/github';
@@ -58,7 +64,7 @@ export default class GitHubTabItem extends React.Component {
   }
 
   hasFocus() {
-    return this.rootHolder.map(root => root.contains(document.activeElement), () => false);
+    return this.rootHolder.map(root => root.contains(this.props.documentActiveElement())).getOr(false);
   }
 
   restoreFocus() {

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -83,8 +83,8 @@ export default class GitTabView extends React.Component {
   render() {
     if (this.props.repository.isTooLarge()) {
       return (
-        <div className="github-Panel is-empty" tabIndex="-1" ref={c => { this.refRoot = c; }}>
-          <div ref="noRepoMessage" className="github-Panel no-repository">
+        <div className="github-Git is-empty" tabIndex="-1" ref={c => { this.refRoot = c; }}>
+          <div ref="noRepoMessage" className="github-Git no-repository">
             <div className="large-icon">
               <GitLogo />
             </div>
@@ -99,8 +99,8 @@ export default class GitTabView extends React.Component {
     } else if (this.props.repository.hasDirectory() &&
                !isValidWorkdir(this.props.repository.getWorkingDirectoryPath())) {
       return (
-        <div className="github-Panel is-empty" tabIndex="-1" ref={c => { this.refRoot = c; }}>
-          <div ref="noRepoMessage" className="github-Panel no-repository">
+        <div className="github-Git is-empty" tabIndex="-1" ref={c => { this.refRoot = c; }}>
+          <div ref="noRepoMessage" className="github-Git no-repository">
             <div className="large-icon">
               <GitLogo />
             </div>
@@ -122,8 +122,8 @@ export default class GitTabView extends React.Component {
         : <span>Initialize a new project directory with a Git repository</span>;
 
       return (
-        <div className="github-Panel is-empty" tabIndex="-1" ref={c => { this.refRoot = c; }}>
-          <div ref="noRepoMessage" className="github-Panel no-repository">
+        <div className="github-Git is-empty" tabIndex="-1" ref={c => { this.refRoot = c; }}>
+          <div ref="noRepoMessage" className="github-Git no-repository">
             <div className="large-icon">
               <GitLogo />
             </div>
@@ -139,7 +139,7 @@ export default class GitTabView extends React.Component {
 
       return (
         <div
-          className={cx('github-Panel', {'is-loading': isLoading})}
+          className={cx('github-Git', {'is-loading': isLoading})}
           tabIndex="-1"
           ref={c => { this.refRoot = c; }}>
           <StagingView

--- a/lib/views/github-tab-view.js
+++ b/lib/views/github-tab-view.js
@@ -5,7 +5,8 @@ import {
   GithubLoginModelPropType, RefHolderPropType, RemoteSetPropType, RemotePropType, BranchSetPropType, BranchPropType,
   OperationStateObserverPropType,
 } from '../prop-types';
-import RemoteSelectorView from '../views/remote-selector-view';
+import LoadingView from './loading-view';
+import RemoteSelectorView from './remote-selector-view';
 import RemoteContainer from '../containers/remote-container';
 
 export default class GitHubTabView extends React.Component {
@@ -23,6 +24,7 @@ export default class GitHubTabView extends React.Component {
     manyRemotesAvailable: PropTypes.bool.isRequired,
     aheadCount: PropTypes.number.isRequired,
     pushInProgress: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
 
     handlePushBranch: PropTypes.func.isRequired,
     handleRemoteSelect: PropTypes.func.isRequired,
@@ -39,6 +41,10 @@ export default class GitHubTabView extends React.Component {
   }
 
   renderRemote() {
+    if (this.props.isLoading) {
+      return <LoadingView />;
+    }
+
     if (this.props.currentRemote.isPresent()) {
       // Single, chosen or unambiguous remote
       // only supporting GH.com for now, hardcoded values

--- a/lib/views/github-tab-view.js
+++ b/lib/views/github-tab-view.js
@@ -30,8 +30,8 @@ export default class GitHubTabView extends React.Component {
 
   render() {
     return (
-      <div className="github-GithubTabController" ref={this.props.rootHolder.setter}>
-        <div className="github-GithubTabController-content">
+      <div className="github-GitHub" ref={this.props.rootHolder.setter}>
+        <div className="github-GitHub-content">
           {this.renderRemote()}
         </div>
       </div>
@@ -73,7 +73,7 @@ export default class GitHubTabView extends React.Component {
     // No remotes available
     // TODO: display a view that lets you create a repository on GitHub
     return (
-      <div className="github-GithubTabController-no-remotes">
+      <div className="github-GitHub-noRemotes">
         This repository does not have any remotes hosted at GitHub.com.
       </div>
     );

--- a/lib/views/github-tab-view.js
+++ b/lib/views/github-tab-view.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  GithubLoginModelPropType, RefHolderPropType, RemoteSetPropType, RemotePropType, BranchSetPropType, BranchPropType,
+  OperationStateObserverPropType,
+} from '../prop-types';
+import RemoteSelectorView from '../views/remote-selector-view';
+import RemoteContainer from '../containers/remote-container';
+
+export default class GitHubTabView extends React.Component {
+  static propTypes = {
+    workspace: PropTypes.object.isRequired,
+    remoteOperationObserver: OperationStateObserverPropType.isRequired,
+    loginModel: GithubLoginModelPropType.isRequired,
+    rootHolder: RefHolderPropType.isRequired,
+
+    workingDirectory: PropTypes.string.isRequired,
+    branches: BranchSetPropType.isRequired,
+    currentBranch: BranchPropType.isRequired,
+    remotes: RemoteSetPropType.isRequired,
+    currentRemote: RemotePropType.isRequired,
+    manyRemotesAvailable: PropTypes.bool.isRequired,
+    aheadCount: PropTypes.number.isRequired,
+    pushInProgress: PropTypes.bool.isRequired,
+
+    handlePushBranch: PropTypes.func.isRequired,
+    handleRemoteSelect: PropTypes.func.isRequired,
+  }
+
+  render() {
+    return (
+      <div className="github-GithubTabController" ref={this.props.rootHolder.setter}>
+        <div className="github-GithubTabController-content">
+          {this.renderRemote()}
+        </div>
+      </div>
+    );
+  }
+
+  renderRemote() {
+    if (this.props.currentRemote.isPresent()) {
+      // Single, chosen or unambiguous remote
+      // only supporting GH.com for now, hardcoded values
+      return (
+        <RemoteContainer
+          host="https://api.github.com"
+          loginModel={this.props.loginModel}
+          remoteOperationObserver={this.props.remoteOperationObserver}
+          workingDirectory={this.props.workingDirectory}
+          workspace={this.props.workspace}
+          onPushBranch={() => this.props.handlePushBranch(this.props.currentBranch, this.props.currentRemote)}
+          remote={this.props.currentRemote}
+          remotes={this.props.remotes}
+          branches={this.props.branches}
+          aheadCount={this.props.aheadCount}
+          pushInProgress={this.props.pushInProgress}
+        />
+      );
+    }
+
+    if (this.props.manyRemotesAvailable) {
+      // No chosen remote, multiple remotes hosted on GitHub instances
+      return (
+        <RemoteSelectorView
+          remotes={this.props.remotes}
+          currentBranch={this.props.currentBranch}
+          selectRemote={this.props.handleRemoteSelect}
+        />
+      );
+    }
+
+    // No remotes available
+    // TODO: display a view that lets you create a repository on GitHub
+    return (
+      <div className="github-GithubTabController-no-remotes">
+        This repository does not have any remotes hosted at GitHub.com.
+      </div>
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "atom --test test",
     "test:coverage": "nyc script/capture-env",
-    "test:coverage:lcov": "npm run test:coverage && nyc report --reporter=lcovonly",
+    "test:coverage:lcov": "nyc --reporter=lcovonly script/capture-env npm run test:coverage",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint --max-warnings 0 test lib",
     "fetch-schema": "node script/fetch-schema",

--- a/styles/git-tab.less
+++ b/styles/git-tab.less
@@ -1,12 +1,12 @@
 @import "variables";
 
-.github-StubItem-git-tab-controller,
-.github-GitTabItem-root {
+.github-StubItem-git,
+.github-Git-root {
   flex: 1;
   display: flex;
 }
 
-.github-Panel {
+.github-Git {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -47,7 +47,7 @@
 }
 
 atom-dock.bottom {
-  .github-Panel {
+  .github-Git {
     flex-direction: row;
   }
 
@@ -55,7 +55,7 @@ atom-dock.bottom {
     display: contents; // make these invisible to layout
   }
 
-  .github-Panel > div {
+  .github-Git > div {
     flex: 1;
   }
 

--- a/styles/github-tab.less
+++ b/styles/github-tab.less
@@ -4,7 +4,7 @@
   display: flex;
 }
 
-.github-Github {
+.github-GitHub {
   flex: 1;
   min-width: 0;
   display: flex;

--- a/styles/github-tab.less
+++ b/styles/github-tab.less
@@ -1,10 +1,10 @@
-.github-StubItem-github-tab-controller,
-.github-GithubTabController-root {
+.github-StubItem-github,
+.github-GitHub-root {
   flex: 1;
   display: flex;
 }
 
-.github-GithubTabController {
+.github-Github {
   flex: 1;
   min-width: 0;
   display: flex;
@@ -16,7 +16,7 @@
     flex-direction: column;
   }
 
-  &-no-remotes {
+  &-noRemotes {
     margin: 10px;
     font-size: @font-size * 1.25;
   }

--- a/styles/popover.less
+++ b/styles/popover.less
@@ -5,7 +5,7 @@
 
 .github-Popover {
   &.tooltip {
-    width: 400px; // Same as the github-Panel
+    width: 400px; // Same as the github-Git
     padding-left: @component-padding;
     padding-right: @component-padding;
     box-sizing: border-box;

--- a/test/containers/github-tab-container.test.js
+++ b/test/containers/github-tab-container.test.js
@@ -47,12 +47,12 @@ describe('GitHubTabContainer', function() {
   });
 
   describe('while loading', function() {
-    it('renders a loading spinner', async function() {
+    it('passes isLoading to its view', async function() {
       const repository = new Repository(await cloneRepository());
       assert.isTrue(repository.isLoading());
       const wrapper = mount(buildApp({repository}));
 
-      assert.isTrue(wrapper.find('LoadingView').exists());
+      assert.isTrue(wrapper.find('GitHubTabController').prop('isLoading'));
     });
   });
 
@@ -63,7 +63,7 @@ describe('GitHubTabContainer', function() {
       await repository.getLoadPromise();
       const wrapper = mount(buildApp({repository}));
 
-      await assert.async.isTrue(wrapper.update().find('GitHubTabController').exists());
+      await assert.async.isFalse(wrapper.update().find('GitHubTabController').prop('isLoading'));
       assert.strictEqual(wrapper.find('GitHubTabController').prop('workingDirectory'), workdir);
     });
   });

--- a/test/containers/github-tab-container.test.js
+++ b/test/containers/github-tab-container.test.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import {cloneRepository} from '../helpers';
+import GitHubTabContainer from '../../lib/containers/github-tab-container';
+import Repository from '../../lib/models/repository';
+import {gitHubTabContainerProps} from '../fixtures/props/github-tab-props';
+
+describe('GitHubTabContainer', function() {
+  let atomEnv;
+
+  beforeEach(function() {
+    atomEnv = global.buildAtomEnvironment();
+  });
+
+  afterEach(function() {
+    atomEnv.destroy();
+  });
+
+  function buildApp(overrideProps = {}) {
+    const repository = Repository.absent();
+    return <GitHubTabContainer {...gitHubTabContainerProps(atomEnv, repository, overrideProps)} />;
+  }
+
+  describe('operation state observer', function() {
+    it('creates an observer on the current repository', function() {
+      const repository = Repository.absent();
+      const wrapper = mount(buildApp({repository}));
+
+      const observer = wrapper.state('remoteOperationObserver');
+      assert.strictEqual(observer.repository, repository);
+
+      wrapper.setProps({});
+      assert.strictEqual(wrapper.state('remoteOperationObserver'), observer);
+    });
+
+    it('creates a new observer when the repository changes', function() {
+      const repository0 = Repository.absent();
+      const wrapper = mount(buildApp({repository: repository0}));
+
+      const observer0 = wrapper.state('remoteOperationObserver');
+
+      const repository1 = Repository.absent();
+      wrapper.setProps({repository: repository1});
+      assert.notStrictEqual(wrapper.state('remoteOperationObserver'), observer0);
+    });
+  });
+
+  describe('while loading', function() {
+    it('renders a loading spinner', async function() {
+      const repository = new Repository(await cloneRepository());
+      assert.isTrue(repository.isLoading());
+      const wrapper = mount(buildApp({repository}));
+
+      assert.isTrue(wrapper.find('LoadingView').exists());
+    });
+  });
+
+  describe('once loaded', function() {
+    it('renders the controller', async function() {
+      const workdir = await cloneRepository();
+      const repository = new Repository(workdir);
+      await repository.getLoadPromise();
+      const wrapper = mount(buildApp({repository}));
+
+      await assert.async.isTrue(wrapper.update().find('GitHubTabController').exists());
+      assert.strictEqual(wrapper.find('GitHubTabController').prop('workingDirectory'), workdir);
+    });
+  });
+});

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -61,14 +61,14 @@ describe('GitTabController', function() {
 
     const wrapper = mount(await buildApp(repository));
 
-    assert.isTrue(wrapper.find('.github-Panel').hasClass('is-loading'));
+    assert.isTrue(wrapper.find('.github-Git').hasClass('is-loading'));
     assert.lengthOf(wrapper.find('StagingView'), 1);
     assert.lengthOf(wrapper.find('CommitController'), 1);
 
     await repository.getLoadPromise();
     await updateWrapper(repository, wrapper);
 
-    await assert.async.isFalse(wrapper.update().find('.github-Panel').hasClass('is-loading'));
+    await assert.async.isFalse(wrapper.update().find('.github-Git').hasClass('is-loading'));
     assert.lengthOf(wrapper.find('StagingView'), 1);
     assert.lengthOf(wrapper.find('CommitController'), 1);
   });
@@ -292,7 +292,7 @@ describe('GitTabController', function() {
       it('blurs on tool-panel:unfocus', function() {
         sinon.spy(workspace.getActivePane(), 'activate');
 
-        commandRegistry.dispatch(wrapper.find('.github-Panel').getDOMNode(), 'tool-panel:unfocus');
+        commandRegistry.dispatch(wrapper.find('.github-Git').getDOMNode(), 'tool-panel:unfocus');
 
         assert.isTrue(workspace.getActivePane().activate.called);
       });

--- a/test/controllers/github-tab-controller.test.js
+++ b/test/controllers/github-tab-controller.test.js
@@ -1,18 +1,19 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {shallow} from 'enzyme';
 
-import {cloneRepository, initRepository, buildRepository} from '../helpers';
+import {gitHubTabControllerProps} from '../fixtures/props/github-tab-props';
 import GithubTabController from '../../lib/controllers/github-tab-controller';
 import Repository from '../../lib/models/repository';
-import GithubLoginModel from '../../lib/models/github-login-model';
-import {InMemoryStrategy} from '../../lib/shared/keytar-strategy';
+import BranchSet from '../../lib/models/branch-set';
+import Branch, {nullBranch} from '../../lib/models/branch';
+import RemoteSet from '../../lib/models/remote-set';
+import Remote from '../../lib/models/remote';
 
 describe('GithubTabController', function() {
-  let atomEnv, loginModel;
+  let atomEnv;
 
   beforeEach(function() {
     atomEnv = global.buildAtomEnvironment();
-    loginModel = new GithubLoginModel(InMemoryStrategy);
   });
 
   afterEach(function() {
@@ -20,80 +21,84 @@ describe('GithubTabController', function() {
   });
 
   function buildApp(overrideProps = {}) {
-    return (
-      <GithubTabController
-        repository={Repository.absent()}
-        workspace={atomEnv.workspace}
-        loginModel={loginModel}
-        {...overrideProps}
-      />
-    );
+    const props = {
+      repository: Repository.absent(),
+      ...overrideProps,
+    };
+
+    return <GithubTabController {...gitHubTabControllerProps(atomEnv, props.repository, props)} />;
   }
 
-  it('renders nothing when the repository is absent', async function() {
-    const wrapper = mount(buildApp({repository: Repository.absent()}));
-    await assert.async.lengthOf(wrapper.update().find('ObserveModel').children(), 0);
+  describe('derived view props', function() {
+    const dotcom0 = new Remote('yes0', 'git@github.com:aaa/bbb.git');
+    const dotcom1 = new Remote('yes1', 'https://github.com/ccc/ddd.git');
+    const nonDotcom = new Remote('no0', 'git@sourceforge.net:eee/fff.git');
+
+    it('passes the current branch', function() {
+      const currentBranch = new Branch('aaa', nullBranch, nullBranch, true);
+      const otherBranch = new Branch('bbb');
+      const branches = new BranchSet([currentBranch, otherBranch]);
+      const wrapper = shallow(buildApp({branches}));
+
+      assert.strictEqual(wrapper.find('GitHubTabView').prop('currentBranch'), currentBranch);
+    });
+
+    it('passes remotes hosted on GitHub', function() {
+      const allRemotes = new RemoteSet([dotcom0, dotcom1, nonDotcom]);
+      const wrapper = shallow(buildApp({allRemotes}));
+
+      const passed = wrapper.find('GitHubTabView').prop('remotes');
+      assert.isTrue(passed.withName('yes0').isPresent());
+      assert.isTrue(passed.withName('yes1').isPresent());
+      assert.isFalse(passed.withName('no0').isPresent());
+    });
+
+    it('detects an explicitly specified current remote', function() {
+      const allRemotes = new RemoteSet([dotcom0, dotcom1, nonDotcom]);
+      const wrapper = shallow(buildApp({allRemotes, selectedRemoteName: 'yes1'}));
+      assert.strictEqual(wrapper.find('GitHubTabView').prop('currentRemote'), dotcom1);
+      assert.isFalse(wrapper.find('GitHubTabView').prop('manyRemotesAvailable'));
+    });
+
+    it('uses a single GitHub-hosted remote', function() {
+      const allRemotes = new RemoteSet([dotcom0, nonDotcom]);
+      const wrapper = shallow(buildApp({allRemotes}));
+      assert.strictEqual(wrapper.find('GitHubTabView').prop('currentRemote'), dotcom0);
+      assert.isFalse(wrapper.find('GitHubTabView').prop('manyRemotesAvailable'));
+    });
+
+    it('indicates when multiple remotes are available', function() {
+      const allRemotes = new RemoteSet([dotcom0, dotcom1]);
+      const wrapper = shallow(buildApp({allRemotes}));
+      assert.isFalse(wrapper.find('GitHubTabView').prop('currentRemote').isPresent());
+      assert.isTrue(wrapper.find('GitHubTabView').prop('manyRemotesAvailable'));
+    });
   });
 
-  it('renders a RemoteContainer when only a single dotcom Remote is present', async function() {
-    const repository = await buildRepository(await cloneRepository());
-    await repository.addRemote('single', 'git@github.com:owner/name.git');
-    await repository.addRemote('nondotcom', 'git@sourceforge.net:owner/name.git');
+  describe('actions', function() {
+    it('pushes a branch', async function() {
+      const repository = Repository.absent();
+      sinon.stub(repository, 'push').resolves(true);
+      const wrapper = shallow(buildApp({repository}));
 
-    const wrapper = mount(buildApp({repository}));
-    await assert.async.isTrue(wrapper.update().find('RemoteContainer').exists());
+      const branch = new Branch('abc');
+      const remote = new Remote('def', 'git@github.com:def/ghi.git');
+      assert.isTrue(await wrapper.find('GitHubTabView').prop('handlePushBranch')(branch, remote));
 
-    const container = wrapper.find('RemoteContainer');
-    assert.strictEqual(container.prop('loginModel'), loginModel);
-    assert.strictEqual(container.prop('workspace'), atomEnv.workspace);
-    assert.strictEqual(container.prop('workingDirectory'), repository.getWorkingDirectoryPath());
-    assert.strictEqual(container.prop('remote').getName(), 'single');
+      assert.isTrue(repository.push.calledWith('abc', {remote, setUpstream: true}));
+    });
 
-    sinon.stub(repository, 'push').resolves();
-    await container.prop('onPushBranch')();
+    it('chooses a remote', async function() {
+      const repository = Repository.absent();
+      sinon.stub(repository, 'setConfig').resolves(true);
+      const wrapper = shallow(buildApp({repository}));
 
-    assert.isTrue(repository.push.calledWith('master', {remote: container.prop('remote'), setUpstream: true}));
-  });
+      const remote = new Remote('aaa', 'git@github.com:aaa/aaa.git');
+      const event = {preventDefault: sinon.spy()};
+      assert.isTrue(await wrapper.find('GitHubTabView').prop('handleRemoteSelect')(event, remote));
 
-  it('renders a RemoteSelectorView when multiple Remotes are present', async function() {
-    const repository = await buildRepository(await cloneRepository());
-    await repository.addRemote('one', 'git@github.com:owner/name.git');
-    await repository.addRemote('nondotcom', 'git@sourceforge.net:owner/name.git');
-    await repository.addRemote('two', 'git@github.com:owner/name.git');
-    const chosen = await repository.addRemote('three', 'git@github.com:owner/name.git');
-
-    const wrapper = mount(buildApp({repository}));
-    await assert.async.isTrue(wrapper.update().find('RemoteSelectorView').exists());
-
-    const view = wrapper.find('RemoteSelectorView');
-    assert.strictEqual(view.prop('remotes').size(), 3);
-
-    const e = {preventDefault: sinon.spy()};
-    await view.prop('selectRemote')(e, chosen);
-
-    assert.isTrue(e.preventDefault.called);
-    assert.strictEqual(await repository.getConfig('atomGithub.currentRemote'), 'three');
-  });
-
-  it('renders a RemoteContainer when multiple Remotes are present, but one has been selected', async function() {
-    const repository = await buildRepository(await cloneRepository());
-    await repository.addRemote('one', 'git@github.com:owner/name.git');
-    await repository.addRemote('two', 'git@github.com:owner/name.git');
-    await repository.addRemote('nondotcom', 'git@sourceforge.net:owner/name.git');
-    await repository.addRemote('three', 'git@github.com:owner/name.git');
-    await repository.setConfig('atomGithub.currentRemote', 'two');
-
-    const wrapper = mount(buildApp({repository}));
-    await assert.async.isTrue(wrapper.update().find('RemoteContainer').exists());
-    const container = wrapper.find('RemoteContainer');
-    assert.strictEqual(container.prop('remote').getName(), 'two');
-  });
-
-  it('renders a static message when no dotcom remotes are present', async function() {
-    const repository = await buildRepository(await initRepository());
-    await repository.addRemote('nondotcom', 'git@sourceforge.net:owner/name.git');
-
-    const wrapper = mount(buildApp({repository}));
-    await assert.async.isTrue(wrapper.update().find('.github-GithubTabController-no-remotes').exists());
+      assert.isTrue(event.preventDefault.called);
+      assert.isTrue(repository.setConfig.calledWith('atomGithub.currentRemote', 'aaa'));
+    });
   });
 });

--- a/test/controllers/github-tab-controller.test.js
+++ b/test/controllers/github-tab-controller.test.js
@@ -2,14 +2,14 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import {gitHubTabControllerProps} from '../fixtures/props/github-tab-props';
-import GithubTabController from '../../lib/controllers/github-tab-controller';
+import GitHubTabController from '../../lib/controllers/github-tab-controller';
 import Repository from '../../lib/models/repository';
 import BranchSet from '../../lib/models/branch-set';
 import Branch, {nullBranch} from '../../lib/models/branch';
 import RemoteSet from '../../lib/models/remote-set';
 import Remote from '../../lib/models/remote';
 
-describe('GithubTabController', function() {
+describe('GitHubTabController', function() {
   let atomEnv;
 
   beforeEach(function() {
@@ -26,7 +26,7 @@ describe('GithubTabController', function() {
       ...overrideProps,
     };
 
-    return <GithubTabController {...gitHubTabControllerProps(atomEnv, props.repository, props)} />;
+    return <GitHubTabController {...gitHubTabControllerProps(atomEnv, props.repository, props)} />;
   }
 
   describe('derived view props', function() {

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -12,7 +12,7 @@ import WorkdirContextPool from '../../lib/models/workdir-context-pool';
 import GithubLoginModel from '../../lib/models/github-login-model';
 import {InMemoryStrategy} from '../../lib/shared/keytar-strategy';
 import GitTabItem from '../../lib/items/git-tab-item';
-import GithubTabController from '../../lib/controllers/github-tab-controller';
+import GitHubTabItem from '../../lib/items/github-tab-item';
 import ResolutionProgress from '../../lib/models/conflicts/resolution-progress';
 import IssueishPaneItem from '../../lib/items/issueish-pane-item';
 import * as reporterProxy from '../../lib/reporter-proxy';
@@ -79,8 +79,8 @@ describe('RootController', function() {
 
       assert.isFalse(wrapper.update().find('GitTabItem').exists());
       assert.isUndefined(workspace.paneForURI(GitTabItem.buildURI()));
-      assert.isFalse(wrapper.update().find('GithubTabController').exists());
-      assert.isUndefined(workspace.paneForURI(GithubTabController.buildURI()));
+      assert.isFalse(wrapper.update().find('GitHubTabItem').exists());
+      assert.isUndefined(workspace.paneForURI(GitHubTabItem.buildURI()));
 
       assert.isUndefined(workspace.getActivePaneItem());
       assert.isFalse(workspace.getRightDock().isVisible());
@@ -95,7 +95,7 @@ describe('RootController', function() {
 
       await assert.async.isTrue(workspace.getRightDock().isVisible());
       assert.isTrue(wrapper.find('GitTabItem').exists());
-      assert.isTrue(wrapper.find('GithubTabController').exists());
+      assert.isTrue(wrapper.find('GitHubTabItem').exists());
       assert.isUndefined(workspace.getActivePaneItem());
     });
   });

--- a/test/fixtures/props/github-tab-props.js
+++ b/test/fixtures/props/github-tab-props.js
@@ -1,0 +1,11 @@
+import {InMemoryStrategy} from '../../../lib/shared/keytar-strategy';
+import GithubLoginModel from '../../../lib/models/github-login-model';
+
+export function gitHubTabItemProps(atomEnv, repository, overrides = {}) {
+  return {
+    workspace: atomEnv.workspace,
+    repository,
+    loginModel: new GithubLoginModel(InMemoryStrategy),
+    ...overrides,
+  };
+}

--- a/test/fixtures/props/github-tab-props.js
+++ b/test/fixtures/props/github-tab-props.js
@@ -36,3 +36,26 @@ export function gitHubTabControllerProps(atomEnv, repository, overrides = {}) {
     ...overrides,
   };
 }
+
+export function gitHubTabViewProps(atomEnv, repository, overrides = {}) {
+  return {
+    workspace: atomEnv.workspace,
+    remoteOperationObserver: new OperationStateObserver(repository, PUSH, PULL, FETCH),
+    loginModel: new GithubLoginModel(InMemoryStrategy),
+    rootHolder: new RefHolder(),
+
+    workingDirectory: repository.getWorkingDirectoryPath(),
+    branches: new BranchSet(),
+    currentBranch: nullBranch,
+    remotes: new RemoteSet(),
+    currentRemote: nullRemote,
+    manyRemotesAvailable: false,
+    aheadCount: 0,
+    pushInProgress: false,
+
+    handlePushBranch: () => {},
+    handleRemoteSelect: () => {},
+
+    ...overrides,
+  };
+}

--- a/test/fixtures/props/github-tab-props.js
+++ b/test/fixtures/props/github-tab-props.js
@@ -1,11 +1,20 @@
 import {InMemoryStrategy} from '../../../lib/shared/keytar-strategy';
 import GithubLoginModel from '../../../lib/models/github-login-model';
+import RefHolder from '../../../lib/models/ref-holder';
 
 export function gitHubTabItemProps(atomEnv, repository, overrides = {}) {
   return {
     workspace: atomEnv.workspace,
     repository,
     loginModel: new GithubLoginModel(InMemoryStrategy),
+    ...overrides,
+  };
+}
+
+export function gitHubTabContainerProps(atomEnv, repository, overrides = {}) {
+  return {
+    ...gitHubTabItemProps(atomEnv, repository),
+    rootHolder: new RefHolder(),
     ...overrides,
   };
 }

--- a/test/fixtures/props/github-tab-props.js
+++ b/test/fixtures/props/github-tab-props.js
@@ -1,6 +1,11 @@
 import {InMemoryStrategy} from '../../../lib/shared/keytar-strategy';
 import GithubLoginModel from '../../../lib/models/github-login-model';
 import RefHolder from '../../../lib/models/ref-holder';
+import OperationStateObserver, {PUSH, PULL, FETCH} from '../../../lib/models/operation-state-observer';
+import RemoteSet from '../../../lib/models/remote-set';
+import {nullRemote} from '../../../lib/models/remote';
+import BranchSet from '../../../lib/models/branch-set';
+import {nullBranch} from '../../../lib/models/branch';
 
 export function gitHubTabItemProps(atomEnv, repository, overrides = {}) {
   return {
@@ -15,6 +20,19 @@ export function gitHubTabContainerProps(atomEnv, repository, overrides = {}) {
   return {
     ...gitHubTabItemProps(atomEnv, repository),
     rootHolder: new RefHolder(),
+    ...overrides,
+  };
+}
+
+export function gitHubTabControllerProps(atomEnv, repository, overrides = {}) {
+  return {
+    ...gitHubTabContainerProps(atomEnv, repository),
+    remoteOperationObserver: new OperationStateObserver(repository, PUSH, PULL, FETCH),
+    workingDirectory: repository.getWorkingDirectoryPath(),
+    allRemotes: new RemoteSet(),
+    branches: new BranchSet(),
+    aheadCount: 0,
+    pushInProgress: false,
     ...overrides,
   };
 }

--- a/test/integration/launch.test.js
+++ b/test/integration/launch.test.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 import {setup, teardown} from './helpers';
 import GitTabItem from '../../lib/items/git-tab-item';
-import GithubTabController from '../../lib/controllers/github-tab-controller';
+import GitHubTabItem from '../../lib/items/github-tab-item';
 
 describe('Package initialization', function() {
   let context;
@@ -23,7 +23,7 @@ describe('Package initialization', function() {
       return rightDock.getPaneItems().map(i => i.getURI());
     };
 
-    await assert.async.includeMembers(getPaneItemURIs(), [GitTabItem.buildURI(), GithubTabController.buildURI()]);
+    await assert.async.includeMembers(getPaneItemURIs(), [GitTabItem.buildURI(), GitHubTabItem.buildURI()]);
     assert.isTrue(rightDock.isVisible());
   });
 
@@ -38,7 +38,7 @@ describe('Package initialization', function() {
       return rightDock.getPaneItems().map(i => i.getURI());
     };
 
-    await assert.async.includeMembers(getPaneItemURIs(), [GitTabItem.buildURI(), GithubTabController.buildURI()]);
+    await assert.async.includeMembers(getPaneItemURIs(), [GitTabItem.buildURI(), GitHubTabItem.buildURI()]);
     assert.isFalse(rightDock.isVisible());
   });
 
@@ -53,7 +53,7 @@ describe('Package initialization', function() {
       return rightDock.getPaneItems().map(i => i.getURI());
     };
 
-    await assert.async.includeMembers(getPaneItemURIs(), [GitTabItem.buildURI(), GithubTabController.buildURI()]);
+    await assert.async.includeMembers(getPaneItemURIs(), [GitTabItem.buildURI(), GitHubTabItem.buildURI()]);
     assert.isFalse(rightDock.isVisible());
   });
 
@@ -66,7 +66,7 @@ describe('Package initialization', function() {
     const prevContext = await setup(this.currentTest, nonFirstRun);
 
     const prevWorkspace = prevContext.atomEnv.workspace;
-    await prevWorkspace.open(GithubTabController.buildURI(), {searchAllPanes: true});
+    await prevWorkspace.open(GitHubTabItem.buildURI(), {searchAllPanes: true});
     prevWorkspace.hide(GitTabItem.buildURI());
 
     const prevState = prevContext.atomEnv.serialize();
@@ -77,7 +77,7 @@ describe('Package initialization', function() {
     await context.atomEnv.deserialize(prevState);
 
     const paneItemURIs = context.atomEnv.workspace.getPaneItems().map(i => i.getURI());
-    assert.include(paneItemURIs, GithubTabController.buildURI());
+    assert.include(paneItemURIs, GitHubTabItem.buildURI());
     assert.notInclude(paneItemURIs, GitTabItem.buildURI());
   });
 
@@ -95,7 +95,7 @@ describe('Package initialization', function() {
 
     await assert.async.includeMembers(
       getPaneItemURIs(prevContext),
-      [GitTabItem.buildURI(), GithubTabController.buildURI()],
+      [GitTabItem.buildURI(), GitHubTabItem.buildURI()],
     );
 
     const prevWorkspace = prevContext.atomEnv.workspace;
@@ -112,7 +112,7 @@ describe('Package initialization', function() {
     });
     await context.atomEnv.deserialize(prevState);
 
-    await assert.async.include(getPaneItemURIs(context), GithubTabController.buildURI());
+    await assert.async.include(getPaneItemURIs(context), GitHubTabItem.buildURI());
     assert.notInclude(getPaneItemURIs(context), GitTabItem.buildURI());
   });
 });

--- a/test/integration/open.test.js
+++ b/test/integration/open.test.js
@@ -26,12 +26,12 @@ describe('opening and closing tabs', function() {
 
   it('opens but does not focus the git tab on github:toggle-git-tab', async function() {
     const editor = await atomEnv.workspace.open(__filename);
-    assert.isFalse(wrapper.find('.github-Panel').exists());
+    assert.isFalse(wrapper.find('.github-Git').exists());
 
     await commands.dispatch(workspaceElement, 'github:toggle-git-tab');
 
     wrapper.update();
-    assert.isTrue(wrapper.find('.github-Panel').exists());
+    assert.isTrue(wrapper.find('.github-Git').exists());
 
     assert.isTrue(atomEnv.workspace.getRightDock().isVisible());
     await assert.async.strictEqual(atomEnv.workspace.getActivePaneItem(), editor);
@@ -41,12 +41,12 @@ describe('opening and closing tabs', function() {
     await commands.dispatch(workspaceElement, 'github:toggle-git-tab');
     atomEnv.workspace.getRightDock().hide();
     wrapper.update();
-    assert.isTrue(wrapper.find('.github-Panel').exists());
+    assert.isTrue(wrapper.find('.github-Git').exists());
 
     await commands.dispatch(workspaceElement, 'github:toggle-git-tab');
     wrapper.update();
 
-    assert.isTrue(wrapper.find('.github-Panel').exists());
+    assert.isTrue(wrapper.find('.github-Git').exists());
     assert.isTrue(atomEnv.workspace.getRightDock().isVisible());
   });
 
@@ -54,13 +54,13 @@ describe('opening and closing tabs', function() {
     await commands.dispatch(workspaceElement, 'github:toggle-git-tab');
     wrapper.update();
 
-    assert.isTrue(wrapper.find('.github-Panel').exists());
+    assert.isTrue(wrapper.find('.github-Git').exists());
     assert.isTrue(atomEnv.workspace.getRightDock().isVisible());
 
     await commands.dispatch(workspaceElement, 'github:toggle-git-tab');
     wrapper.update();
 
-    assert.isTrue(wrapper.find('.github-Panel').exists());
+    assert.isTrue(wrapper.find('.github-Git').exists());
     assert.isFalse(atomEnv.workspace.getRightDock().isVisible());
   });
 
@@ -70,18 +70,18 @@ describe('opening and closing tabs', function() {
     await commands.dispatch(workspaceElement, 'github:toggle-git-tab-focus');
     wrapper.update();
 
-    assert.isTrue(wrapper.find('.github-Panel').exists());
+    assert.isTrue(wrapper.find('.github-Git').exists());
     assert.isTrue(atomEnv.workspace.getRightDock().isVisible());
-    assert.isTrue(wrapper.find('.github-Panel[tabIndex]').getDOMNode().contains(document.activeElement));
+    assert.isTrue(wrapper.find('.github-Git[tabIndex]').getDOMNode().contains(document.activeElement));
   });
 
   it('focuses a blurred git tab on github:toggle-git-tab-focus', async function() {
     await commands.dispatch(workspaceElement, 'github:toggle-git-tab');
     wrapper.update();
 
-    assert.isTrue(wrapper.find('.github-Panel').exists());
+    assert.isTrue(wrapper.find('.github-Git').exists());
     assert.isTrue(atomEnv.workspace.getRightDock().isVisible());
-    assert.isFalse(wrapper.find('.github-Panel[tabIndex]').getDOMNode().contains(document.activeElement));
+    assert.isFalse(wrapper.find('.github-Git[tabIndex]').getDOMNode().contains(document.activeElement));
 
     await commands.dispatch(workspaceElement, 'github:toggle-git-tab-focus');
     wrapper.update();

--- a/test/items/github-tab-item.test.js
+++ b/test/items/github-tab-item.test.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import PaneItem from '../../lib/atom/pane-item';
+import GitHubTabItem from '../../lib/items/github-tab-item';
+import {cloneRepository, buildRepository} from '../helpers';
+import {gitHubTabItemProps} from '../fixtures/props/github-tab-props';
+
+describe('GitHubTabItem', function() {
+  let atomEnv, repository;
+
+  beforeEach(async function() {
+    atomEnv = global.buildAtomEnvironment();
+
+    const workdirPath = await cloneRepository();
+    repository = await buildRepository(workdirPath);
+  });
+
+  afterEach(function() {
+    atomEnv.destroy();
+  });
+
+  function buildApp(overrideProps = {}) {
+    const props = gitHubTabItemProps(atomEnv, repository, overrideProps);
+
+    return (
+      <PaneItem workspace={props.workspace} uriPattern={GitHubTabItem.uriPattern}>
+        {({itemHolder}) => (
+          <GitHubTabItem
+            ref={itemHolder.setter}
+            {...props}
+          />
+        )}
+      </PaneItem>
+    );
+  }
+
+  it('renders within the dock with the component as its owner', async function() {
+    mount(buildApp());
+
+    await atomEnv.workspace.open(GitHubTabItem.buildURI());
+
+    const paneItem = atomEnv.workspace.getRightDock().getPaneItems()
+      .find(item => item.getURI() === 'atom-github://dock-item/github');
+    assert.strictEqual(paneItem.getTitle(), 'GitHub (preview)');
+    assert.strictEqual(paneItem.getIconName(), 'octoface');
+  });
+
+  it('access the working directory path', async function() {
+    mount(buildApp());
+    const item = await atomEnv.workspace.open(GitHubTabItem.buildURI());
+
+    assert.strictEqual(item.getWorkingDirectory(), repository.getWorkingDirectoryPath());
+  });
+
+  it('serializes itself', async function() {
+    mount(buildApp());
+    const item = await atomEnv.workspace.open(GitHubTabItem.buildURI());
+
+    assert.deepEqual(item.serialize(), {
+      deserializer: 'GithubDockItem',
+      uri: 'atom-github://dock-item/github',
+    });
+  });
+
+  it('detects when it has focus', async function() {
+    let activeElement = document.body;
+    const wrapper = mount(buildApp({
+      documentActiveElement: () => activeElement,
+    }));
+    const item = await atomEnv.workspace.open(GitHubTabItem.buildURI());
+    await assert.async.isTrue(wrapper.update().find('.github-GithubTabController').exists());
+
+    assert.isFalse(item.hasFocus());
+
+    activeElement = wrapper.find('.github-GithubTabController').getDOMNode();
+    assert.isTrue(item.hasFocus());
+  });
+});

--- a/test/items/github-tab-item.test.js
+++ b/test/items/github-tab-item.test.js
@@ -69,11 +69,11 @@ describe('GitHubTabItem', function() {
       documentActiveElement: () => activeElement,
     }));
     const item = await atomEnv.workspace.open(GitHubTabItem.buildURI());
-    await assert.async.isTrue(wrapper.update().find('.github-GithubTabController').exists());
+    await assert.async.isTrue(wrapper.update().find('.github-GitHub').exists());
 
     assert.isFalse(item.hasFocus());
 
-    activeElement = wrapper.find('.github-GithubTabController').getDOMNode();
+    activeElement = wrapper.find('.github-GitHub').getDOMNode();
     assert.isTrue(item.hasFocus());
   });
 });

--- a/test/views/github-tab-view.test.js
+++ b/test/views/github-tab-view.test.js
@@ -56,6 +56,6 @@ describe('GitHubTabView', function() {
 
   it('renders a static message when no remotes are available', function() {
     const wrapper = shallow(buildApp({currentRemote: nullRemote, manyRemotesAvailable: false}));
-    assert.isTrue(wrapper.find('.github-GithubTabController-no-remotes').exists());
+    assert.isTrue(wrapper.find('.github-GitHub-noRemotes').exists());
   });
 });

--- a/test/views/github-tab-view.test.js
+++ b/test/views/github-tab-view.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {gitHubTabViewProps} from '../fixtures/props/github-tab-props';
+import Repository from '../../lib/models/repository';
+import Remote, {nullRemote} from '../../lib/models/remote';
+import RemoteSet from '../../lib/models/remote-set';
+import Branch from '../../lib/models/branch';
+import GitHubTabView from '../../lib/views/github-tab-view';
+
+describe('GitHubTabView', function() {
+  let atomEnv;
+
+  beforeEach(function() {
+    atomEnv = global.buildAtomEnvironment();
+  });
+
+  afterEach(function() {
+    atomEnv.destroy();
+  });
+
+  function buildApp(overrideProps = {}) {
+    const props = gitHubTabViewProps(atomEnv, overrideProps.repository || Repository.absent(), overrideProps);
+    return <GitHubTabView {...props} />;
+  }
+
+  it('renders a RemoteContainer if a remote has been chosen', function() {
+    const currentRemote = new Remote('aaa', 'git@github.com:aaa/bbb.git');
+    const currentBranch = new Branch('bbb');
+    const handlePushBranch = sinon.spy();
+    const wrapper = shallow(buildApp({currentRemote, currentBranch, handlePushBranch}));
+
+    const container = wrapper.find('RemoteContainer');
+    assert.isTrue(container.exists());
+    assert.strictEqual(container.prop('remote'), currentRemote);
+    container.prop('onPushBranch')();
+    assert.isTrue(handlePushBranch.calledWith(currentBranch, currentRemote));
+  });
+
+  it('renders a RemoteSelectorView when many remote choices are available', function() {
+    const remotes = new RemoteSet();
+    const handleRemoteSelect = sinon.spy();
+    const wrapper = shallow(buildApp({
+      remotes,
+      currentRemote: nullRemote,
+      manyRemotesAvailable: true,
+      handleRemoteSelect,
+    }));
+
+    const selector = wrapper.find('RemoteSelectorView');
+    assert.isTrue(selector.exists());
+    assert.strictEqual(selector.prop('remotes'), remotes);
+    selector.prop('selectRemote')();
+    assert.isTrue(handleRemoteSelect.called);
+  });
+
+  it('renders a static message when no remotes are available', function() {
+    const wrapper = shallow(buildApp({currentRemote: nullRemote, manyRemotesAvailable: false}));
+    assert.isTrue(wrapper.find('.github-GithubTabController-no-remotes').exists());
+  });
+});

--- a/test/views/github-tab-view.test.js
+++ b/test/views/github-tab-view.test.js
@@ -24,6 +24,11 @@ describe('GitHubTabView', function() {
     return <GitHubTabView {...props} />;
   }
 
+  it('renders a LoadingView if data is still loading', function() {
+    const wrapper = shallow(buildApp({isLoading: true}));
+    assert.isTrue(wrapper.find('LoadingView').exists());
+  });
+
   it('renders a RemoteContainer if a remote has been chosen', function() {
     const currentRemote = new Remote('aaa', 'git@github.com:aaa/bbb.git');
     const currentBranch = new Branch('bbb');

--- a/test/views/remote-selector-view.test.js
+++ b/test/views/remote-selector-view.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import Remote from '../../lib/models/remote';
+import RemoteSet from '../../lib/models/remote-set';
+import Branch, {nullBranch} from '../../lib/models/branch';
+import RemoteSelectorView from '../../lib/views/remote-selector-view';
+
+describe('RemoteSelectorView', function() {
+  function buildApp(overrideProps = {}) {
+    const props = {
+      remotes: new RemoteSet(),
+      currentBranch: nullBranch,
+      selectRemote: () => {},
+      ...overrideProps,
+    };
+
+    return <RemoteSelectorView {...props} />;
+  }
+
+  it('shows the current branch name', function() {
+    const currentBranch = new Branch('aaa');
+    const wrapper = shallow(buildApp({currentBranch}));
+    assert.strictEqual(wrapper.find('strong').text(), 'aaa');
+  });
+
+  it('renders each remote', function() {
+    const remote0 = new Remote('zero', 'git@github.com:aaa/bbb.git');
+    const remote1 = new Remote('one', 'git@github.com:ccc/ddd.git');
+    const remotes = new RemoteSet([remote0, remote1]);
+    const selectRemote = sinon.spy();
+
+    const wrapper = shallow(buildApp({remotes, selectRemote}));
+
+    const zero = wrapper.find('li').filterWhere(w => w.key() === 'zero').find('a');
+    assert.strictEqual(zero.text(), 'zero (aaa/bbb)');
+    zero.simulate('click', 'event0');
+    assert.isTrue(selectRemote.calledWith('event0', remote0));
+
+    const one = wrapper.find('li').filterWhere(w => w.key() === 'one').find('a');
+    assert.strictEqual(one.text(), 'one (ccc/ddd)');
+    one.simulate('click', 'event1');
+    assert.isTrue(selectRemote.calledWith('event1', remote1));
+  });
+});


### PR DESCRIPTION
Split the GithubTabController out into an Item, a Container, a Controller, and a View. Backfill our test coverage to match.

The next bit of incremental progress toward #1436. Fixes #1594.