### PR TITLE
Restyle hovercards II

### DIFF
--- a/lib/containers/issueish-tooltip-container.js
+++ b/lib/containers/issueish-tooltip-container.js
@@ -32,6 +32,10 @@ class IssueishTooltip extends React.Component {
     const icon = icons[state] || '';
     return (
       <div className="github-IssueishTooltip">
+        <div className="issueish-avatar-and-title">
+          <img className="author-avatar" src={author.avatarUrl} title={author.login} />
+          <h3 className="issueish-title">{title}</h3>
+        </div>
         <div className="issueish-badge-and-link">
           <span className={cx('issueish-badge', 'badge', state.toLowerCase())}>
             <Octicon icon={icon} />
@@ -40,11 +44,6 @@ class IssueishTooltip extends React.Component {
           <span className="issueish-link">
             {repository.owner.login}/{repository.name}#{number}
           </span>
-        </div>
-        <h3 className="issueish-title">{title}</h3>
-        <div className="issueish-avatar-and-title">
-          <img className="author-avatar" src={author.avatarUrl} title={author.login} />
-          <strong>{author.login}</strong>
         </div>
       </div>
     );

--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -131,7 +131,7 @@ export default class StatusBarTileController extends React.Component {
           manager={this.props.tooltips}
           target={this.refBranchViewRoot}
           trigger="click"
-          className="github-Popover">
+          className="github-StatusBarTileController-tooltipMenu">
           <BranchMenuView
             workspace={this.props.workspace}
             notificationManager={this.props.notificationManager}

--- a/styles/issueish-tooltip.less
+++ b/styles/issueish-tooltip.less
@@ -1,19 +1,42 @@
 @import 'variables';
 
 .github-IssueishTooltip {
-  text-align: left;
-  font-size: .9em;
+  display: flex;
+  flex-direction: column;
   padding: @component-padding/2;
+  font-size: .9em;
+  text-align: left;
+
+  .issueish-avatar-and-title {
+    display: flex;
+    align-items: center;
+    margin: @component-padding/2;
+  }
+
+  .author-avatar {
+    margin-right: @component-padding;
+    width: 26px;
+    height: 26px;
+    align-self: flex-start;
+    border-radius: @component-border-radius;
+  }
+
+  .issueish-title {
+    margin: 0;
+    font-size: 1.25em;
+    font-weight: 600;
+    line-height: 1.3;
+    color: @text-color-highlight;
+    white-space: initial;
+  }
 
   .issueish-badge-and-link {
-    padding-bottom: @component-padding;
+    margin: @component-padding/2;
   }
 
   .issueish-badge {
-    align-self: flex-start;
-    flex-shrink: 0;
     margin-right: @component-padding;
-    font-weight: bold;
+    font-weight: 500;
     text-transform: capitalize;
     border-radius: @component-border-radius;
 
@@ -33,7 +56,9 @@
     }
 
     .icon:before {
-      vertical-align: text-top;
+      width: auto;
+      font-size: 14px;
+      vertical-align: -1px;
     }
   }
 
@@ -41,28 +66,4 @@
     color: @text-color-subtle;
   }
 
-  .issueish-title {
-    display: block;
-    margin: 0;
-    padding-bottom: @component-padding;
-    font-size: 1.1em;
-    font-weight: 600;
-    line-height: 1.3;
-    color: @text-color-highlight;
-    white-space: initial;
-  }
-
-  .issueish-avatar-and-title {
-    strong {
-      font-weight: normal;
-      color: @text-color-subtle;
-    }
-  }
-
-  .author-avatar {
-    margin-right: @component-padding/2;
-    width: 20px;
-    height: 20px;
-    border-radius: @component-border-radius;
-  }
 }

--- a/styles/issueish-tooltip.less
+++ b/styles/issueish-tooltip.less
@@ -15,6 +15,7 @@
 
   .author-avatar {
     margin-right: @component-padding;
+    flex: 0 0 26px; // prevent sqeezing
     width: 26px;
     height: 26px;
     align-self: flex-start;

--- a/styles/popover.less
+++ b/styles/popover.less
@@ -5,7 +5,7 @@
 
 .github-Popover {
   &.tooltip {
-    width: 400px; // Same as the github-Panel
+    max-width: 400px; // Same as the github-Panel
     padding-left: @component-padding;
     padding-right: @component-padding;
     box-sizing: border-box;

--- a/styles/status-bar-tile-controller.less
+++ b/styles/status-bar-tile-controller.less
@@ -3,6 +3,31 @@
 .github-StatusBarTileController {
   display: inline-block;
 
+  &-tooltipMenu {
+    &.tooltip {
+      width: 400px; // Same as the github-Panel
+      padding-left: @component-padding;
+      padding-right: @component-padding;
+      box-sizing: border-box;
+    }
+    .tooltip-inner.tooltip-inner {
+      padding: @component-padding / 2;
+      background-color: @tool-panel-background-color;
+      border: 1px solid @base-border-color;
+      box-shadow: 0 4px 8px hsla(0, 0, 0, .1);
+      color: @text-color;
+    }
+    &.top .tooltip-arrow.tooltip-arrow {
+      width: @component-padding;
+      height: @component-padding;
+      border-width: 0 0 1px 1px;
+      border-color: @base-border-color;
+      background-color: @tool-panel-background-color;
+      border-bottom-right-radius: 2px;
+      transform: rotate(-45deg);
+    }
+  }
+
   & > .inline-block:hover {
     text-decoration: underline;
     cursor: default;

--- a/styles/user-mention-tooltip.less
+++ b/styles/user-mention-tooltip.less
@@ -18,8 +18,7 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    margin: @component-padding/2;
-    margin-left: @component-padding;
+    margin: @component-padding/2 @component-padding;
     font-size: @font-size;
     line-height: 20px;
     text-align: left;


### PR DESCRIPTION
### Description of the Change

This changes the issueish tooltips to match the header of the detail panes. Title is at the top, badge at the bottom.

Before | After
--- | ---
![screen shot 2018-07-20 at 12 05 27 pm](https://user-images.githubusercontent.com/378023/42981063-46757e8a-8c15-11e8-81cd-2929444ed989.png) | ![screen shot 2018-07-20 at 12 04 48 pm](https://user-images.githubusercontent.com/378023/42981062-46463e68-8c15-11e8-822a-9c0e25c2195a.png)

When clicked, user sees 👇 and it should be more familiar.

![image](https://user-images.githubusercontent.com/378023/42981157-c39a4be8-8c15-11e8-9997-45c5305a8cff.png)


### Alternate Designs

Might be nice to also have the CI check in there?

### Benefits

- The tooltip and pane header are more consistent and the user doesn't have to learn a new UI pattern.
- Tooltips are flexible in width.

### Possible Drawbacks

The user name got removed.

### Applicable Issues

This is a follow-up to #1593
