### PR TITLE
Remove "(preview)" from GitHub tab title

### DIFF
--- a/lib/controllers/github-tab-controller.js
+++ b/lib/controllers/github-tab-controller.js
@@ -136,7 +136,7 @@ export default class GithubTabController extends React.Component {
   }
 
   getTitle() {
-    return 'GitHub (preview)';
+    return 'GitHub';
   }
 
   getIconName() {

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -363,7 +363,7 @@ export default class GithubPackage {
 
   createGithubTabControllerStub(uri) {
     return StubItem.create('github-tab-controller', {
-      title: 'GitHub (preview)',
+      title: 'GitHub',
     }, uri);
   }
 


### PR DESCRIPTION
### Description of the Change

This removes the "(preview)" in the tab title.

Before | After
--- | ---
![screen shot 2018-07-20 at 3 19 24 pm](https://user-images.githubusercontent.com/378023/42986399-59013ff6-8c30-11e8-9571-fa0ef7d9e850.png) | ![screen shot 2018-07-20 at 3 18 44 pm](https://user-images.githubusercontent.com/378023/42986398-58d51732-8c30-11e8-8f69-6b9ea2a634dd.png)


### Benefits

- With the recent changes, might be time to remove the "beta" label.
- More space for other tabs (depends a bit on the theme).
- Less cluttered UI

### Possible Drawbacks

None

### Applicable Issues

None
