### PR TITLE
Upgrade Relay

### DIFF
--- a/lib/containers/__generated__/currentPullRequestContainerQuery.graphql.js
+++ b/lib/containers/__generated__/currentPullRequestContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 40b7bc7d6c17a665a1fe95116c6f6719
+ * @relayHash 5821e0667d3f593dc75d2c4ac34985ca
  */
 
 /* eslint-disable */
@@ -27,6 +27,10 @@ export type currentPullRequestContainerQueryResponse = {|
       |}
     |}
   |}
+|};
+export type currentPullRequestContainerQuery = {|
+  variables: currentPullRequestContainerQueryVariables,
+  response: currentPullRequestContainerQueryResponse,
 |};
 */
 

--- a/lib/containers/__generated__/issueishDetailContainerQuery.graphql.js
+++ b/lib/containers/__generated__/issueishDetailContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash fd2fb50c17cd6fc965d556a7247314a9
+ * @relayHash d9bc206d6bd62b978d889af219ec648d
  */
 
 /* eslint-disable */
@@ -21,6 +21,10 @@ export type issueishDetailContainerQueryResponse = {|
   +repository: ?{|
     +$fragmentRefs: issueishDetailController_repository$ref
   |}
+|};
+export type issueishDetailContainerQuery = {|
+  variables: issueishDetailContainerQueryVariables,
+  response: issueishDetailContainerQueryResponse,
 |};
 */
 

--- a/lib/containers/__generated__/issueishSearchContainerQuery.graphql.js
+++ b/lib/containers/__generated__/issueishSearchContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 39c0b6593d96d2f8436bff9ca0d239c4
+ * @relayHash 4f7294887e96b0a41dd57f0f3164f765
  */
 
 /* eslint-disable */
@@ -21,6 +21,10 @@ export type issueishSearchContainerQueryResponse = {|
       +$fragmentRefs: issueishListController_results$ref
     |}>,
   |}
+|};
+export type issueishSearchContainerQuery = {|
+  variables: issueishSearchContainerQueryVariables,
+  response: issueishSearchContainerQueryResponse,
 |};
 */
 

--- a/lib/containers/__generated__/remoteContainerQuery.graphql.js
+++ b/lib/containers/__generated__/remoteContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 7fbd7496eff90270ea34a304108aa100
+ * @relayHash 982797d241da7600c6e95299dff83585
  */
 
 /* eslint-disable */
@@ -21,6 +21,10 @@ export type remoteContainerQueryResponse = {|
       +name: string,
     |},
   |}
+|};
+export type remoteContainerQuery = {|
+  variables: remoteContainerQueryVariables,
+  response: remoteContainerQueryResponse,
 |};
 */
 

--- a/lib/controllers/__generated__/issueTimelineControllerQuery.graphql.js
+++ b/lib/controllers/__generated__/issueTimelineControllerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 11a080534b1e9e618daa153d559f5efc
+ * @relayHash f743b45dcda2d5c1204b416ba482392d
  */
 
 /* eslint-disable */
@@ -19,6 +19,10 @@ export type issueTimelineControllerQueryResponse = {|
   +resource: ?{|
     +$fragmentRefs: issueTimelineController_issue$ref
   |}
+|};
+export type issueTimelineControllerQuery = {|
+  variables: issueTimelineControllerQueryVariables,
+  response: issueTimelineControllerQueryResponse,
 |};
 */
 
@@ -230,42 +234,56 @@ v4 = {
   "args": null,
   "storageKey": null
 },
-v5 = {
+v5 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "timelineCursor",
+    "type": "String"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "timelineCount",
+    "type": "Int"
+  }
+],
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "login",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "avatarUrl",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "number",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "user",
@@ -274,7 +292,7 @@ v10 = {
   "concreteType": "User",
   "plural": false,
   "selections": [
-    v5,
+    v6,
     v3
   ]
 };
@@ -355,20 +373,7 @@ return {
                 "alias": null,
                 "name": "timeline",
                 "storageKey": null,
-                "args": [
-                  {
-                    "kind": "Variable",
-                    "name": "after",
-                    "variableName": "timelineCursor",
-                    "type": "String"
-                  },
-                  {
-                    "kind": "Variable",
-                    "name": "first",
-                    "variableName": "timelineCount",
-                    "type": "Int"
-                  }
-                ],
+                "args": v5,
                 "concreteType": "IssueTimelineConnection",
                 "plural": false,
                 "selections": [
@@ -452,8 +457,8 @@ return {
                                 "plural": false,
                                 "selections": [
                                   v2,
-                                  v5,
                                   v6,
+                                  v7,
                                   v3
                                 ]
                               },
@@ -476,7 +481,7 @@ return {
                                     "concreteType": "Repository",
                                     "plural": false,
                                     "selections": [
-                                      v7,
+                                      v8,
                                       {
                                         "kind": "LinkedField",
                                         "alias": null,
@@ -487,7 +492,7 @@ return {
                                         "plural": false,
                                         "selections": [
                                           v2,
-                                          v5,
+                                          v6,
                                           v3
                                         ]
                                       },
@@ -506,8 +511,8 @@ return {
                                     "kind": "InlineFragment",
                                     "type": "PullRequest",
                                     "selections": [
-                                      v8,
                                       v9,
+                                      v10,
                                       v4,
                                       {
                                         "kind": "ScalarField",
@@ -522,8 +527,8 @@ return {
                                     "kind": "InlineFragment",
                                     "type": "Issue",
                                     "selections": [
-                                      v8,
                                       v9,
+                                      v10,
                                       v4,
                                       {
                                         "kind": "ScalarField",
@@ -552,8 +557,8 @@ return {
                                 "plural": false,
                                 "selections": [
                                   v2,
+                                  v7,
                                   v6,
-                                  v5,
                                   v3
                                 ]
                               },
@@ -587,9 +592,9 @@ return {
                                 "concreteType": "GitActor",
                                 "plural": false,
                                 "selections": [
-                                  v7,
-                                  v10,
-                                  v6
+                                  v8,
+                                  v11,
+                                  v7
                                 ]
                               },
                               {
@@ -601,9 +606,9 @@ return {
                                 "concreteType": "GitActor",
                                 "plural": false,
                                 "selections": [
+                                  v8,
                                   v7,
-                                  v6,
-                                  v10
+                                  v11
                                 ]
                               },
                               {
@@ -653,20 +658,7 @@ return {
                 "kind": "LinkedHandle",
                 "alias": null,
                 "name": "timeline",
-                "args": [
-                  {
-                    "kind": "Variable",
-                    "name": "after",
-                    "variableName": "timelineCursor",
-                    "type": "String"
-                  },
-                  {
-                    "kind": "Variable",
-                    "name": "first",
-                    "variableName": "timelineCount",
-                    "type": "Int"
-                  }
-                ],
+                "args": v5,
                 "handle": "connection",
                 "key": "IssueTimelineController_timeline",
                 "filters": null

--- a/lib/controllers/__generated__/prTimelineControllerQuery.graphql.js
+++ b/lib/controllers/__generated__/prTimelineControllerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash af853f1ab5f7d7727fafd178050ec61a
+ * @relayHash 1a3787f5d7fae81fbb3897db8f0bae46
  */
 
 /* eslint-disable */
@@ -19,6 +19,10 @@ export type prTimelineControllerQueryResponse = {|
   +resource: ?{|
     +$fragmentRefs: prTimelineController_pullRequest$ref
   |}
+|};
+export type prTimelineControllerQuery = {|
+  variables: prTimelineControllerQueryVariables,
+  response: prTimelineControllerQueryResponse,
 |};
 */
 
@@ -344,52 +348,66 @@ v7 = {
   "plural": false,
   "selections": v6
 },
-v8 = {
+v8 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "timelineCursor",
+    "type": "String"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "timelineCount",
+    "type": "Int"
+  }
+],
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "avatarUrl",
   "args": null,
   "storageKey": null
 },
-v9 = [
+v10 = [
   v2,
   v5,
-  v8,
+  v9,
   v3
 ],
-v10 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "number",
   "args": null,
   "storageKey": null
 },
-v12 = {
+v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v13 = {
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "oid",
   "args": null,
   "storageKey": null
 },
-v14 = [
-  v13,
+v15 = [
+  v14,
   v3
 ],
-v15 = {
+v16 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "commit",
@@ -397,29 +415,29 @@ v15 = {
   "args": null,
   "concreteType": "Commit",
   "plural": false,
-  "selections": v14
+  "selections": v15
 },
-v16 = {
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "bodyHTML",
   "args": null,
   "storageKey": null
 },
-v17 = {
+v18 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "createdAt",
   "args": null,
   "storageKey": null
 },
-v18 = [
+v19 = [
   v2,
-  v8,
+  v9,
   v5,
   v3
 ],
-v19 = {
+v20 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "actor",
@@ -427,9 +445,9 @@ v19 = {
   "args": null,
   "concreteType": null,
   "plural": false,
-  "selections": v18
+  "selections": v19
 },
-v20 = {
+v21 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "user",
@@ -549,20 +567,7 @@ return {
                 "alias": null,
                 "name": "timeline",
                 "storageKey": null,
-                "args": [
-                  {
-                    "kind": "Variable",
-                    "name": "after",
-                    "variableName": "timelineCursor",
-                    "type": "String"
-                  },
-                  {
-                    "kind": "Variable",
-                    "name": "first",
-                    "variableName": "timelineCount",
-                    "type": "Int"
-                  }
-                ],
+                "args": v8,
                 "concreteType": "PullRequestTimelineConnection",
                 "plural": false,
                 "selections": [
@@ -644,7 +649,7 @@ return {
                                 "args": null,
                                 "concreteType": null,
                                 "plural": false,
-                                "selections": v9
+                                "selections": v10
                               },
                               {
                                 "kind": "LinkedField",
@@ -665,7 +670,7 @@ return {
                                     "concreteType": "Repository",
                                     "plural": false,
                                     "selections": [
-                                      v10,
+                                      v11,
                                       v7,
                                       v3,
                                       {
@@ -682,8 +687,8 @@ return {
                                     "kind": "InlineFragment",
                                     "type": "PullRequest",
                                     "selections": [
-                                      v11,
                                       v12,
+                                      v13,
                                       v4,
                                       {
                                         "kind": "ScalarField",
@@ -698,8 +703,8 @@ return {
                                     "kind": "InlineFragment",
                                     "type": "Issue",
                                     "selections": [
-                                      v11,
                                       v12,
+                                      v13,
                                       v4,
                                       {
                                         "kind": "ScalarField",
@@ -718,7 +723,7 @@ return {
                             "kind": "InlineFragment",
                             "type": "CommitCommentThread",
                             "selections": [
-                              v15,
+                              v16,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -762,11 +767,11 @@ return {
                                             "args": null,
                                             "concreteType": null,
                                             "plural": false,
-                                            "selections": v9
+                                            "selections": v10
                                           },
-                                          v15,
                                           v16,
                                           v17,
+                                          v18,
                                           {
                                             "kind": "ScalarField",
                                             "alias": null,
@@ -793,7 +798,7 @@ return {
                             "kind": "InlineFragment",
                             "type": "HeadRefForcePushedEvent",
                             "selections": [
-                              v19,
+                              v20,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -802,7 +807,7 @@ return {
                                 "args": null,
                                 "concreteType": "Commit",
                                 "plural": false,
-                                "selections": v14
+                                "selections": v15
                               },
                               {
                                 "kind": "LinkedField",
@@ -812,17 +817,17 @@ return {
                                 "args": null,
                                 "concreteType": "Commit",
                                 "plural": false,
-                                "selections": v14
+                                "selections": v15
                               },
-                              v17
+                              v18
                             ]
                           },
                           {
                             "kind": "InlineFragment",
                             "type": "MergedEvent",
                             "selections": [
-                              v19,
-                              v15,
+                              v20,
+                              v16,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -830,7 +835,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v17
+                              v18
                             ]
                           },
                           {
@@ -845,10 +850,10 @@ return {
                                 "args": null,
                                 "concreteType": null,
                                 "plural": false,
-                                "selections": v18
+                                "selections": v19
                               },
-                              v16,
                               v17,
+                              v18,
                               v4
                             ]
                           },
@@ -865,9 +870,9 @@ return {
                                 "concreteType": "GitActor",
                                 "plural": false,
                                 "selections": [
-                                  v10,
-                                  v20,
-                                  v8
+                                  v11,
+                                  v21,
+                                  v9
                                 ]
                               },
                               {
@@ -879,9 +884,9 @@ return {
                                 "concreteType": "GitActor",
                                 "plural": false,
                                 "selections": [
-                                  v10,
-                                  v8,
-                                  v20
+                                  v11,
+                                  v9,
+                                  v21
                                 ]
                               },
                               {
@@ -891,7 +896,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v13,
+                              v14,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -925,20 +930,7 @@ return {
                 "kind": "LinkedHandle",
                 "alias": null,
                 "name": "timeline",
-                "args": [
-                  {
-                    "kind": "Variable",
-                    "name": "after",
-                    "variableName": "timelineCursor",
-                    "type": "String"
-                  },
-                  {
-                    "kind": "Variable",
-                    "name": "first",
-                    "variableName": "timelineCount",
-                    "type": "Int"
-                  }
-                ],
+                "args": v8,
                 "handle": "connection",
                 "key": "prTimelineContainer_timeline",
                 "filters": null

--- a/lib/items/__generated__/issueishTooltipItemQuery.graphql.js
+++ b/lib/items/__generated__/issueishTooltipItemQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash e8e09ef59fd58c211220126ee7dcd2a5
+ * @relayHash ec7add21f4125e294e4679a0fed3dfc9
  */
 
 /* eslint-disable */
@@ -17,6 +17,10 @@ export type issueishTooltipItemQueryResponse = {|
   +resource: ?{|
     +$fragmentRefs: issueishTooltipContainer_resource$ref
   |}
+|};
+export type issueishTooltipItemQuery = {|
+  variables: issueishTooltipItemQueryVariables,
+  response: issueishTooltipItemQueryResponse,
 |};
 */
 

--- a/lib/items/__generated__/userMentionTooltipItemQuery.graphql.js
+++ b/lib/items/__generated__/userMentionTooltipItemQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 65b45175c8b30ca98da00fa016b8a0dc
+ * @relayHash 618ef28f16a644f2aa8240535a6b5ea4
  */
 
 /* eslint-disable */
@@ -17,6 +17,10 @@ export type userMentionTooltipItemQueryResponse = {|
   +repositoryOwner: ?{|
     +$fragmentRefs: userMentionTooltipContainer_repositoryOwner$ref
   |}
+|};
+export type userMentionTooltipItemQuery = {|
+  variables: userMentionTooltipItemQueryVariables,
+  response: userMentionTooltipItemQueryResponse,
 |};
 */
 

--- a/lib/views/__generated__/issueishDetailViewRefetchQuery.graphql.js
+++ b/lib/views/__generated__/issueishDetailViewRefetchQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash e59fe378fd0cacef7e695703a6cb0022
+ * @relayHash 7c0400f69539fb35f8ee2107122c5baf
  */
 
 /* eslint-disable */
@@ -24,6 +24,10 @@ export type issueishDetailViewRefetchQueryResponse = {|
   +issueish: ?{|
     +$fragmentRefs: issueishDetailView_issueish$ref
   |},
+|};
+export type issueishDetailViewRefetchQuery = {|
+  variables: issueishDetailViewRefetchQueryVariables,
+  response: issueishDetailViewRefetchQueryResponse,
 |};
 */
 

--- a/lib/views/__generated__/prStatusesViewRefetchQuery.graphql.js
+++ b/lib/views/__generated__/prStatusesViewRefetchQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 785a8d24aba2ef8a8145215f0bff78a0
+ * @relayHash 5b2061918400a59074629fc3e4800b18
  */
 
 /* eslint-disable */
@@ -17,6 +17,10 @@ export type prStatusesViewRefetchQueryResponse = {|
   +node: ?{|
     +$fragmentRefs: prStatusesView_pullRequest$ref
   |}
+|};
+export type prStatusesViewRefetchQuery = {|
+  variables: prStatusesViewRefetchQueryVariables,
+  response: prStatusesViewRefetchQueryResponse,
 |};
 */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -178,12 +178,18 @@
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-      "integrity": "sha1-UkryQNGjYFJ7cwR17PoTRKpUDd4=",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
         "call-me-maybe": "^1.0.1",
         "glob-to-regexp": "^0.3.0"
       }
+    },
+    "@nodelib/fs.stat": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz",
+      "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A==",
+      "dev": true
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
@@ -937,9 +943,9 @@
       }
     },
     "babel-plugin-relay": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-relay/-/babel-plugin-relay-1.6.0.tgz",
-      "integrity": "sha1-oiTaUkNi1pA6UkIUobhAUw/fvSg=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-relay/-/babel-plugin-relay-1.6.1.tgz",
+      "integrity": "sha512-irDphb1GIv1eV+vG1M/zP0UE7bC/s0rlKIWkf2kZtkGD6EwejEAOtFrt68b9rUm1IHATTUzGRe07t7n8A7GIrA==",
       "requires": {
         "babel-runtime": "^6.23.0",
         "babel-types": "^6.24.1"
@@ -1407,9 +1413,9 @@
       }
     },
     "babel-preset-fbjs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.1.4.tgz",
-      "integrity": "sha1-IvNY5mVAc6z2HkegUqd317zPA68=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.2.0.tgz",
+      "integrity": "sha512-jj0KFJDioYZMtPtZf77dQuU+Ad/1BtN0UnAYlHDa8J8f4tGXr3YrPoJImD5MdueaOPeN/jUdrCgu330EfXr0XQ==",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "^6.8.0",
@@ -3094,12 +3100,13 @@
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-glob": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.1.tgz",
-      "integrity": "sha512-wSyW1TBK3ia5V+te0rGPXudeMHoUQW6O5Y9oATiaGhpENmEifPDlOdhpsnlj5HoG6ttIvGiY1DdCmI9X2xGMhg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
+      "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
       "dev": true,
       "requires": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.0.1",
         "glob-parent": "^3.1.0",
         "is-glob": "^4.0.0",
         "merge2": "^1.2.1",
@@ -3514,9 +3521,9 @@
       }
     },
     "graphql-compiler": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/graphql-compiler/-/graphql-compiler-1.6.0.tgz",
-      "integrity": "sha1-JPFGzfiLgOBFMipXKhpdhLnCqdU=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/graphql-compiler/-/graphql-compiler-1.6.1.tgz",
+      "integrity": "sha512-pDZkKjNHqp63qKxrooqv312DVk/wToClXWduHis+YOl1p362keKQClfYRjaswIL+R49jPjr7cC2Y5iv6vle/sA==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.1",
@@ -4927,9 +4934,9 @@
       }
     },
     "merge2": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
-      "integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
+      "integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==",
       "dev": true
     },
     "micromatch": {
@@ -6237,14 +6244,40 @@
       }
     },
     "react-relay": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/react-relay/-/react-relay-1.6.0.tgz",
-      "integrity": "sha1-eg7KQ1yBubAdiRfUvKZQfu+83+Q=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/react-relay/-/react-relay-1.6.1.tgz",
+      "integrity": "sha512-g2P0QkJ4c+nAkxREmstFgp8vPshq8mlE3R0gFtEekWeXjCF99F6SNuPC5geSnPZzIosJXuAYOS6W1Epk6P8LPQ==",
       "requires": {
         "babel-runtime": "^6.23.0",
-        "fbjs": "^0.8.14",
+        "fbjs": "0.8.17",
         "prop-types": "^15.5.8",
-        "relay-runtime": "1.6.0"
+        "relay-runtime": "1.6.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.18",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+          "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+        }
       }
     },
     "react-select": {
@@ -6373,50 +6406,56 @@
       "dev": true
     },
     "relay-compiler": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-1.6.0.tgz",
-      "integrity": "sha1-ChvI0owc8x2JhRCKdhumwNtI1KE=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-1.6.1.tgz",
+      "integrity": "sha512-biugFmjBpiF5mvVXUIV3DzEgnuJTonZaTN8ASH6WOJSY0lyQ0eGJ2m6RFm7c9a2A/fpAQzduj1udY0bMrJJSWg==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.0.0-beta.40",
-        "@babel/types": "7.0.0-beta.40",
+        "@babel/generator": "7.0.0-beta.54",
+        "@babel/parser": "7.0.0-beta.54",
+        "@babel/types": "7.0.0-beta.54",
         "babel-polyfill": "^6.20.0",
-        "babel-preset-fbjs": "^2.1.4",
+        "babel-preset-fbjs": "2.2.0",
         "babel-runtime": "^6.23.0",
         "babel-traverse": "^6.26.0",
-        "babylon": "7.0.0-beta.40",
         "chalk": "^1.1.1",
-        "fast-glob": "^2.0.0",
+        "fast-glob": "^2.2.2",
         "fb-watchman": "^2.0.0",
-        "fbjs": "^0.8.14",
-        "graphql-compiler": "1.6.0",
+        "fbjs": "0.8.17",
+        "graphql-compiler": "1.6.1",
         "immutable": "~3.7.6",
-        "relay-runtime": "1.6.0",
+        "relay-runtime": "1.6.1",
         "signedsource": "^1.0.0",
         "yargs": "^9.0.0"
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.0.0-beta.40",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.40.tgz",
-          "integrity": "sha1-q2H5VW9PcdvRE4lJx5W7miHjAuo=",
+          "version": "7.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.54.tgz",
+          "integrity": "sha1-wEPH7r7r/X5mXZXCgaSq/IPU4ck=",
           "dev": true,
           "requires": {
-            "@babel/types": "7.0.0-beta.40",
+            "@babel/types": "7.0.0-beta.54",
             "jsesc": "^2.5.1",
-            "lodash": "^4.2.0",
+            "lodash": "^4.17.5",
             "source-map": "^0.5.0",
             "trim-right": "^1.0.1"
           }
         },
+        "@babel/parser": {
+          "version": "7.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.54.tgz",
+          "integrity": "sha1-wBqmO1fJyNzodEeWyB2d8SHyDbQ=",
+          "dev": true
+        },
         "@babel/types": {
-          "version": "7.0.0-beta.40",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.40.tgz",
-          "integrity": "sha1-JcPXquFBJqvgX8sJjGWma21rjBQ=",
+          "version": "7.0.0-beta.54",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.54.tgz",
+          "integrity": "sha1-AlrWhJL+1ULBPxTFeaRMhI5TEGM=",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
+            "lodash": "^4.17.5",
             "to-fast-properties": "^2.0.0"
           }
         },
@@ -6446,12 +6485,6 @@
                 "core-js": "^2.4.0",
                 "regenerator-runtime": "^0.11.0"
               }
-            },
-            "babylon": {
-              "version": "6.18.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-              "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-              "dev": true
             }
           }
         },
@@ -6486,10 +6519,33 @@
           }
         },
         "babylon": {
-          "version": "7.0.0-beta.40",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-          "integrity": "sha1-kfyM1W1euYso5v3kEEXylXd5lAo=",
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "dev": true,
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.7",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+              "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+              "dev": true
+            }
+          }
         },
         "jsesc": {
           "version": "2.5.1",
@@ -6502,16 +6558,48 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
+        },
+        "ua-parser-js": {
+          "version": "0.7.18",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+          "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
+          "dev": true
         }
       }
     },
     "relay-runtime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-1.6.0.tgz",
-      "integrity": "sha1-K3AFj7d6TJOhcXUs4Uf47o2KiLk=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-1.6.1.tgz",
+      "integrity": "sha512-qBN8HYEsA+zqJMvNcULNeBJukIOqcuAQ5ivN0nV4OI2SbR/hHz8vryTx02Drh85uk/bbEZe+6q2gw39hFSx3/Q==",
       "requires": {
         "babel-runtime": "^6.23.0",
-        "fbjs": "^0.8.14"
+        "fbjs": "0.8.17"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.18",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+          "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+        }
       }
     },
     "repeat-element": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "prop-types": "15.6.2",
     "react": "16.4.0",
     "react-dom": "16.4.0",
-    "react-relay": "1.6.0",
+    "react-relay": "1.6.1",
     "react-select": "1.2.1",
     "relay-runtime": "1.6.0",
     "temp": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "atom-babel6-transpiler": "1.2.0",
     "babel-generator": "6.26.1",
     "babel-plugin-chai-assert-async": "0.1.0",
-    "babel-plugin-relay": "1.6.0",
+    "babel-plugin-relay": "1.6.1",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
     "babel-plugin-transform-object-rest-spread": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-dom": "16.4.0",
     "react-relay": "1.6.1",
     "react-select": "1.2.1",
-    "relay-runtime": "1.6.0",
+    "relay-runtime": "1.6.1",
     "temp": "0.8.3",
     "tinycolor2": "1.4.1",
     "tree-kill": "1.2.0",


### PR DESCRIPTION
Subsumes #1615, #1616, and #1618. (It's easier to upgrade all of the Relay dependencies at once.)

This is currently blocked by an Enzyme bug (which looks like airbnb/enzyme#1717, although the root cause is likely different?)