### PR TITLE
🐛 Fix default dir for git repo init

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -410,6 +410,10 @@ export default class RootController extends React.Component {
       return null;
     }
 
+    if (!initDialogPath) {
+      initDialogPath = this.props.repository.getWorkingDirectoryPath();
+    }
+
     return new Promise(resolve => {
       this.setState({initDialogActive: true, initDialogPath, initDialogResolve: resolve});
     });


### PR DESCRIPTION
### Description of the Change
The linked issue details the unexpected default directory when using the atom sidebar to initialize a git repository. This PR ensures that the default directory is the working directory, as would be expected.

Before this change, the conditional on line 35 of [init-dialog.js](https://github.com/atom/github/blob/master/lib/views/init-dialog.js) would always set the default directory to the home directory.
### Alternate Designs
An in-depth look at why initDialogPath is null here could possibly provide a more elegant solution; however, this is concise enough to fix the issue without needing consideration for negative fallouts.

### Benefits
Users initializing a git repository with the sidebar will now have the default directory begin being set to the current working directory. This is what most users would expect, rather than it defaulting to the home directory.

### Possible Drawbacks
None

### Applicable Issues
https://github.com/atom/github/issues/1237
