### PR TITLE
Activate the git tab on item activation

### DIFF
--- a/lib/atom/pane-item.js
+++ b/lib/atom/pane-item.js
@@ -170,6 +170,8 @@ class OpenItem {
     this.constructor.nextID++;
 
     this.domNode = element || document.createElement('div');
+    this.domNode.tabIndex = '-1';
+    this.domNode.onfocus = this.onFocus.bind(this);
     this.stubItem = stub;
     this.match = match;
     this.itemHolder = new RefHolder();
@@ -209,6 +211,10 @@ class OpenItem {
     } else {
       return {};
     }
+  }
+
+  onFocus() {
+    return this.itemHolder.map(item => item.focus && item.focus());
   }
 
   renderPortal(renderProp) {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -771,9 +771,10 @@ class TabTracker {
   }
 
   async toggleFocus() {
+    const hadFocus = this.hasFocus();
     await this.ensureVisible();
 
-    if (this.hasFocus()) {
+    if (hadFocus) {
       let workspace = this.getWorkspace();
       if (workspace.getCenter) {
         workspace = workspace.getCenter();

--- a/lib/items/git-tab-item.js
+++ b/lib/items/git-tab-item.js
@@ -75,6 +75,10 @@ export default class GitTabItem extends React.Component {
     return this.refController.map(c => c.hasFocus(...args));
   }
 
+  focus() {
+    return this.refController.map(c => c.restoreFocus());
+  }
+
   focusAndSelectStagingItem(...args) {
     return this.refController.map(c => c.focusAndSelectStagingItem(...args));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3682,12 +3682,13 @@
       "dev": true
     },
     "hock": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/hock/-/hock-1.3.2.tgz",
-      "integrity": "sha1-btPovkK0ZnmBGNEhUKqA6NbvIhk=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/hock/-/hock-1.3.3.tgz",
+      "integrity": "sha512-bEX7KH/KSv2Q5zA+o1EdyeH52+gD2cfpYyAsHMEwjb9txXWttityKVf7cG0y3UVA4D8bxKDzH8LVXCQIr9rClg==",
       "dev": true,
       "requires": {
-        "deep-equal": "0.2.1"
+        "deep-equal": "0.2.1",
+        "url-equal": "0.1.2-1"
       }
     },
     "hoek": {
@@ -7844,6 +7845,23 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-equal": {
+      "version": "0.1.2-1",
+      "resolved": "https://registry.npmjs.org/url-equal/-/url-equal-0.1.2-1.tgz",
+      "integrity": "sha1-IjeVIL/gfSa1kIAEkIruEuhNBf8=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "~1.0.1"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+          "dev": true
+        }
+      }
     },
     "use": {
       "version": "3.1.0",

--- a/test/atom/pane-item.test.js
+++ b/test/atom/pane-item.test.js
@@ -8,6 +8,11 @@ import StubItem from '../../lib/items/stub-item';
 class Component extends React.Component {
   static propTypes = {
     text: PropTypes.string.isRequired,
+    didFocus: PropTypes.func,
+  }
+
+  static defaultProps = {
+    didFocus: () => {},
   }
 
   render() {
@@ -22,6 +27,10 @@ class Component extends React.Component {
 
   getText() {
     return this.props.text;
+  }
+
+  focus() {
+    return this.props.didFocus();
   }
 }
 
@@ -190,6 +199,19 @@ describe('PaneItem', function() {
       calledWith = null;
       await workspace.open('atom-github://pattern/456');
       assert.strictEqual(calledWith, 'atom-github://pattern/456');
+    });
+
+    it('calls focus() on the child item when focus() is called', async function() {
+      const didFocus = sinon.spy();
+      mount(
+        <PaneItem workspace={workspace} uriPattern="atom-github://pattern">
+          {({itemHolder}) => <Component ref={itemHolder.setter} text="a prop" didFocus={didFocus} />}
+        </PaneItem>,
+      );
+      const item = await workspace.open('atom-github://pattern');
+      item.getElement().dispatchEvent(new FocusEvent('focus'));
+
+      assert.isTrue(didFocus.called);
     });
 
     it('removes a child when its pane is destroyed', async function() {

--- a/test/integration/open.test.js
+++ b/test/integration/open.test.js
@@ -81,7 +81,7 @@ describe('opening and closing tabs', function() {
 
     assert.isTrue(wrapper.find('.github-Git').exists());
     assert.isTrue(atomEnv.workspace.getRightDock().isVisible());
-    assert.isFalse(wrapper.find('.github-Git[tabIndex]').getDOMNode().contains(document.activeElement));
+    await assert.async.isFalse(wrapper.find('.github-Git[tabIndex]').getDOMNode().contains(document.activeElement));
 
     await commands.dispatch(workspaceElement, 'github:toggle-git-tab-focus');
     wrapper.update();


### PR DESCRIPTION
Atom calls a `.focus()` method on the root DOM element of a pane item's view when it's activated by a mechanism other than a mouse click on a contained element. Register `onfocus` handlers on our root DOM nodes and propagate these to our components appropriately.

Fixes #1614.