### PR TITLE
Prevent race conditions in focus management code

### DIFF
--- a/lib/atom/atom-text-editor.js
+++ b/lib/atom/atom-text-editor.js
@@ -129,14 +129,14 @@ export default class AtomTextEditor extends React.PureComponent {
   }
 
   contains(element) {
-    return this.refElement.get().contains(element);
+    return this.refElement.map(e => e.contains(element)).getOr(false);
   }
 
   focus() {
-    this.refElement.get().focus();
+    this.refElement.map(e => e.focus());
   }
 
   getModel() {
-    return this.refElement.get().getModel();
+    return this.refElement.map(e => e.getModel()).getOr(null);
   }
 }

--- a/lib/controllers/commit-controller.js
+++ b/lib/controllers/commit-controller.js
@@ -1,12 +1,12 @@
 import path from 'path';
 
 import React from 'react';
-import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import {CompositeDisposable} from 'event-kit';
 import fs from 'fs-extra';
 
 import CommitView from '../views/commit-view';
+import RefHolder from '../models/ref-holder';
 import {AuthorPropType, UserStorePropType} from '../prop-types';
 import {autobind} from '../helpers';
 
@@ -44,7 +44,7 @@ export default class CommitController extends React.Component {
     autobind(this, 'commit', 'handleMessageChange', 'toggleExpandedCommitMessageEditor', 'grammarAdded');
 
     this.subscriptions = new CompositeDisposable();
-    this.refCommitView = null;
+    this.refCommitView = new RefHolder();
   }
 
   // eslint-disable-next-line camelcase
@@ -78,17 +78,13 @@ export default class CommitController extends React.Component {
     }
   }
 
-  componentDidMount() {
-    this.domNode = ReactDom.findDOMNode(this);
-  }
-
   render() {
     const message = this.getCommitMessage();
     const operationStates = this.props.repository.getOperationStates();
 
     return (
       <CommitView
-        ref={c => { this.refCommitView = c; }}
+        ref={this.refCommitView.setter}
         tooltips={this.props.tooltips}
         config={this.props.config}
         stagedChangesExist={this.props.stagedChangesExist}
@@ -241,19 +237,19 @@ export default class CommitController extends React.Component {
   }
 
   rememberFocus(event) {
-    return this.refCommitView.rememberFocus(event);
+    return this.refCommitView.map(view => view.rememberFocus(event)).getOr(null);
   }
 
   setFocus(focus) {
-    return this.refCommitView.setFocus(focus);
+    return this.refCommitView.map(view => view.setFocus(focus)).getOr(false);
   }
 
   hasFocus() {
-    return this.domNode && this.domNode.contains(document.activeElement);
+    return this.refCommitView.map(view => view.hasFocus()).getOr(false);
   }
 
   hasFocusEditor() {
-    return this.refCommitView.hasFocusEditor();
+    return this.refCommitView.map(view => view.hasFocusEditor()).getOr(false);
   }
 }
 

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import Author from '../models/author';
 import GitTabView from '../views/git-tab-view';
 import UserStore from '../models/user-store';
+import RefHolder from '../models/ref-holder';
 import {
   CommitPropType, BranchPropType, FilePatchItemPropType, MergeConflictItemPropType, RefHolderPropType,
 } from '../prop-types';
@@ -64,7 +65,9 @@ export default class GitTabController extends React.Component {
     this.stagingOperationInProgress = false;
     this.lastFocus = GitTabView.focus.STAGING;
 
-    this.refView = null;
+    this.refView = new RefHolder();
+    this.refRoot = new RefHolder();
+    this.refStagingView = new RefHolder();
 
     this.state = {
       selectedCoAuthors: [],
@@ -80,7 +83,9 @@ export default class GitTabController extends React.Component {
   render() {
     return (
       <GitTabView
-        ref={c => { this.refView = c; }}
+        ref={this.refView.setter}
+        refRoot={this.refRoot}
+        refStagingView={this.refStagingView}
 
         isLoading={this.props.fetchInProgress}
         repository={this.props.repository}
@@ -135,7 +140,7 @@ export default class GitTabController extends React.Component {
 
   componentDidMount() {
     this.refreshResolutionProgress(false, false);
-    this.refView.refRoot.addEventListener('focusin', this.rememberLastFocus);
+    this.refRoot.map(root => root.addEventListener('focusin', this.rememberLastFocus));
 
     if (this.props.controllerRef) {
       this.props.controllerRef.setter(this);
@@ -149,7 +154,7 @@ export default class GitTabController extends React.Component {
   }
 
   componentWillUnmount() {
-    this.refView.refRoot.removeEventListener('focusin', this.rememberLastFocus);
+    this.refRoot.map(root => root.removeEventListener('focusin', this.rememberLastFocus));
   }
 
   /*
@@ -204,7 +209,9 @@ export default class GitTabController extends React.Component {
 
     this.stagingOperationInProgress = true;
 
-    const fileListUpdatePromise = this.refView.refStagingView.getNextListUpdatePromise();
+    const fileListUpdatePromise = this.refStagingView.map(view => {
+      return view.getNextListUpdatePromise();
+    }).getOr(Promise.resolve());
     let stageOperationPromise;
     if (stageStatus === 'staged') {
       stageOperationPromise = this.unstageFiles(filePaths);
@@ -324,19 +331,15 @@ export default class GitTabController extends React.Component {
   }
 
   rememberLastFocus(event) {
-    if (!this.refView) {
-      return;
-    }
-
-    this.lastFocus = this.refView.rememberFocus(event) || GitTabView.focus.STAGING;
+    this.lastFocus = this.refView.map(view => view.rememberFocus(event)).getOr(false) || GitTabView.focus.STAGING;
   }
 
   restoreFocus() {
-    this.refView.setFocus(this.lastFocus);
+    this.refView.map(view => view.setFocus(this.lastFocus));
   }
 
   hasFocus() {
-    return this.refView.refRoot.contains(document.activeElement);
+    return this.refRoot.map(root => root.contains(document.activeElement)).getOr(false);
   }
 
   wasActivated(isStillActive) {
@@ -346,10 +349,10 @@ export default class GitTabController extends React.Component {
   }
 
   focusAndSelectStagingItem(filePath, stagingStatus) {
-    return this.refView.focusAndSelectStagingItem(filePath, stagingStatus);
+    return this.refView.map(view => view.focusAndSelectStagingItem(filePath, stagingStatus)).getOr(null);
   }
 
   quietlySelectItem(filePath, stagingStatus) {
-    return this.refView.quietlySelectItem(filePath, stagingStatus);
+    return this.refView.map(view => view.quietlySelectItem(filePath, stagingStatus)).getOr(null);
   }
 }

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -331,7 +331,7 @@ export default class GitTabController extends React.Component {
   }
 
   rememberLastFocus(event) {
-    this.lastFocus = this.refView.map(view => view.rememberFocus(event)).getOr(false) || GitTabView.focus.STAGING;
+    this.lastFocus = this.refView.map(view => view.rememberFocus(event)).getOr(null) || GitTabView.focus.STAGING;
   }
 
   restoreFocus() {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -416,6 +416,10 @@ export function createItem(node, componentHolder = null, uri = null, extra = {})
 
     getRealItemPromise: () => componentHolder.getPromise(),
 
+    destroy: () => componentHolder.map(component => {
+      return component.destroy && component.destroy();
+    }),
+
     ...extra,
   };
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -416,7 +416,7 @@ export function createItem(node, componentHolder = null, uri = null, extra = {})
 
     getRealItemPromise: () => componentHolder.getPromise(),
 
-    destroy: () => componentHolder.map(component => {
+    destroy: () => componentHolder && componentHolder.map(component => {
       return component.destroy && component.destroy();
     }),
 

--- a/lib/models/ref-holder.js
+++ b/lib/models/ref-holder.js
@@ -48,7 +48,7 @@ export default class RefHolder {
   }
 
   isEmpty() {
-    return this.value === undefined;
+    return this.value === undefined || this.value === null;
   }
 
   get() {
@@ -83,10 +83,9 @@ export default class RefHolder {
   }
 
   setter = value => {
-    if (value === null || value === undefined) { return; }
     const oldValue = this.value;
     this.value = value;
-    if (value !== oldValue) {
+    if (value !== oldValue && value !== null && value !== undefined) {
       this.emitter.emit('did-update', value);
     }
   }

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -133,6 +133,7 @@ export default class CommitView extends React.Component {
 
     const showAbortMergeButton = this.props.isMerging || null;
 
+    /* istanbul ignore next */
     const modKey = process.platform === 'darwin' ? 'Cmd' : 'Ctrl';
 
     return (
@@ -550,11 +551,11 @@ export default class CommitView extends React.Component {
   }
 
   hasFocusEditor() {
-    return this.refEditor.get().contains(document.activeElement);
+    return this.refEditor.map(editor => editor.contains(document.activeElement)).getOr(false);
   }
 
   rememberFocus(event) {
-    if (this.refEditor.get().contains(event.target)) {
+    if (this.refEditor.map(editor => editor.contains(event.target)).getOr(false)) {
       return CommitView.focus.EDITOR;
     }
 
@@ -575,41 +576,39 @@ export default class CommitView extends React.Component {
 
   setFocus(focus) {
     let fallback = false;
+    const focusElement = element => {
+      element.focus();
+      return true;
+    };
 
     if (focus === CommitView.focus.EDITOR) {
-      this.refEditor.get().focus();
-      return true;
+      if (this.refEditor.map(focusElement).getOr(false)) {
+        return true;
+      }
     }
 
     if (focus === CommitView.focus.ABORT_MERGE_BUTTON) {
-      if (!this.refAbortMergeButton.isEmpty()) {
-        this.refAbortMergeButton.get().focus();
+      if (this.refAbortMergeButton.map(focusElement).getOr(false)) {
         return true;
-      } else {
-        fallback = true;
       }
+      fallback = true;
     }
 
     if (focus === CommitView.focus.COMMIT_BUTTON) {
-      if (!this.refCommitButton.isEmpty()) {
-        this.refCommitButton.get().focus();
+      if (this.refCommitButton.map(focusElement).getOr(false)) {
         return true;
-      } else {
-        fallback = true;
       }
+      fallback = true;
     }
 
     if (focus === CommitView.focus.COAUTHOR_INPUT) {
-      if (!this.refCoAuthorSelect.isEmpty()) {
-        this.refCoAuthorSelect.get().focus();
+      if (this.refCoAuthorSelect.map(focusElement).getOr(false)) {
         return true;
-      } else {
-        fallback = true;
       }
+      fallback = true;
     }
 
-    if (fallback) {
-      this.refEditor.get().focus();
+    if (fallback && this.refEditor.map(focusElement).getOr(false)) {
       return true;
     }
 

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -12,7 +12,7 @@ import RefHolder from '../models/ref-holder';
 import Author from '../models/author';
 import ObserveModel from './observe-model';
 import {LINE_ENDING_REGEX, autobind} from '../helpers';
-import {AuthorPropType, UserStorePropType, RefHolderPropType} from '../prop-types';
+import {AuthorPropType, UserStorePropType} from '../prop-types';
 import {incrementCounter} from '../reporter-proxy';
 
 const TOOLTIP_DELAY = 200;
@@ -30,8 +30,6 @@ export default class CommitView extends React.Component {
   };
 
   static propTypes = {
-    refRoot: RefHolderPropType,
-
     config: PropTypes.object.isRequired,
     tooltips: PropTypes.object.isRequired,
     commandRegistry: PropTypes.object.isRequired,
@@ -55,10 +53,6 @@ export default class CommitView extends React.Component {
     toggleExpandedCommitMessageEditor: PropTypes.func.isRequired,
   };
 
-  static defaultProps = {
-    refRoot: new RefHolder(),
-  }
-
   constructor(props, context) {
     super(props, context);
     autobind(
@@ -78,6 +72,7 @@ export default class CommitView extends React.Component {
     this.timeoutHandle = null;
     this.subscriptions = new CompositeDisposable();
 
+    this.refRoot = new RefHolder();
     this.refExpandButton = new RefHolder();
     this.refCommitButton = new RefHolder();
     this.refHardWrapButton = new RefHolder();
@@ -143,7 +138,7 @@ export default class CommitView extends React.Component {
     const modKey = process.platform === 'darwin' ? 'Cmd' : 'Ctrl';
 
     return (
-      <div className="github-CommitView" ref={this.props.refRoot.setter}>
+      <div className="github-CommitView" ref={this.refRoot.setter}>
         <Commands registry={this.props.commandRegistry} target="atom-workspace">
           <Command command="github:commit" callback={this.commit} />
           <Command command="github:amend-last-commit" callback={this.amendLastCommit} />
@@ -557,7 +552,7 @@ export default class CommitView extends React.Component {
   }
 
   hasFocus() {
-    return this.props.refRoot.map(element => element.contains(document.activeElement)).getOr(false);
+    return this.refRoot.map(element => element.contains(document.activeElement)).getOr(false);
   }
 
   hasFocusEditor() {

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -12,7 +12,7 @@ import RefHolder from '../models/ref-holder';
 import Author from '../models/author';
 import ObserveModel from './observe-model';
 import {LINE_ENDING_REGEX, autobind} from '../helpers';
-import {AuthorPropType, UserStorePropType} from '../prop-types';
+import {AuthorPropType, UserStorePropType, RefHolderPropType} from '../prop-types';
 import {incrementCounter} from '../reporter-proxy';
 
 const TOOLTIP_DELAY = 200;
@@ -30,6 +30,8 @@ export default class CommitView extends React.Component {
   };
 
   static propTypes = {
+    refRoot: RefHolderPropType,
+
     config: PropTypes.object.isRequired,
     tooltips: PropTypes.object.isRequired,
     commandRegistry: PropTypes.object.isRequired,
@@ -52,6 +54,10 @@ export default class CommitView extends React.Component {
     prepareToCommit: PropTypes.func.isRequired,
     toggleExpandedCommitMessageEditor: PropTypes.func.isRequired,
   };
+
+  static defaultProps = {
+    refRoot: new RefHolder(),
+  }
 
   constructor(props, context) {
     super(props, context);
@@ -137,7 +143,7 @@ export default class CommitView extends React.Component {
     const modKey = process.platform === 'darwin' ? 'Cmd' : 'Ctrl';
 
     return (
-      <div className="github-CommitView">
+      <div className="github-CommitView" ref={this.props.refRoot.setter}>
         <Commands registry={this.props.commandRegistry} target="atom-workspace">
           <Command command="github:commit" callback={this.commit} />
           <Command command="github:amend-last-commit" callback={this.amendLastCommit} />
@@ -548,6 +554,10 @@ export default class CommitView extends React.Component {
     } else {
       this.props.updateSelectedCoAuthors(selectedCoAuthors);
     }
+  }
+
+  hasFocus() {
+    return this.props.refRoot.map(element => element.contains(document.activeElement)).getOr(false);
   }
 
   hasFocusEditor() {

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -7,8 +7,9 @@ import StagingView from './staging-view';
 import GitLogo from './git-logo';
 import CommitController from '../controllers/commit-controller';
 import RecentCommitsController from '../controllers/recent-commits-controller';
+import RefHolder from '../models/ref-holder';
 import {isValidWorkdir, autobind} from '../helpers';
-import {AuthorPropType, UserStorePropType} from '../prop-types';
+import {AuthorPropType, UserStorePropType, RefHolderPropType} from '../prop-types';
 
 export default class GitTabView extends React.Component {
   static focus = {
@@ -18,6 +19,9 @@ export default class GitTabView extends React.Component {
   };
 
   static propTypes = {
+    refRoot: RefHolderPropType,
+    refStagingView: RefHolderPropType,
+
     repository: PropTypes.object.isRequired,
     isLoading: PropTypes.bool.isRequired,
 
@@ -65,25 +69,25 @@ export default class GitTabView extends React.Component {
 
     this.subscriptions = new CompositeDisposable();
 
-    this.refRoot = null;
-    this.refStagingView = null;
-    this.refCommitViewComponent = null;
+    this.refCommitController = new RefHolder();
   }
 
   componentDidMount() {
-    this.subscriptions.add(
-      this.props.commandRegistry.add(this.refRoot, {
-        'tool-panel:unfocus': this.blur,
-        'core:focus-next': this.advanceFocus,
-        'core:focus-previous': this.retreatFocus,
-      }),
-    );
+    this.props.refRoot.map(root => {
+      return this.subscriptions.add(
+        this.props.commandRegistry.add(root, {
+          'tool-panel:unfocus': this.blur,
+          'core:focus-next': this.advanceFocus,
+          'core:focus-previous': this.retreatFocus,
+        }),
+      );
+    });
   }
 
   render() {
     if (this.props.repository.isTooLarge()) {
       return (
-        <div className="github-Git is-empty" tabIndex="-1" ref={c => { this.refRoot = c; }}>
+        <div className="github-Git is-empty" tabIndex="-1" ref={this.props.refRoot.setter}>
           <div ref="noRepoMessage" className="github-Git no-repository">
             <div className="large-icon">
               <GitLogo />
@@ -99,7 +103,7 @@ export default class GitTabView extends React.Component {
     } else if (this.props.repository.hasDirectory() &&
                !isValidWorkdir(this.props.repository.getWorkingDirectoryPath())) {
       return (
-        <div className="github-Git is-empty" tabIndex="-1" ref={c => { this.refRoot = c; }}>
+        <div className="github-Git is-empty" tabIndex="-1" ref={this.props.refRoot.setter}>
           <div ref="noRepoMessage" className="github-Git no-repository">
             <div className="large-icon">
               <GitLogo />
@@ -122,7 +126,7 @@ export default class GitTabView extends React.Component {
         : <span>Initialize a new project directory with a Git repository</span>;
 
       return (
-        <div className="github-Git is-empty" tabIndex="-1" ref={c => { this.refRoot = c; }}>
+        <div className="github-Git is-empty" tabIndex="-1" ref={this.props.refRoot.setter}>
           <div ref="noRepoMessage" className="github-Git no-repository">
             <div className="large-icon">
               <GitLogo />
@@ -141,9 +145,9 @@ export default class GitTabView extends React.Component {
         <div
           className={cx('github-Git', {'is-loading': isLoading})}
           tabIndex="-1"
-          ref={c => { this.refRoot = c; }}>
+          ref={this.props.refRoot.setter}>
           <StagingView
-            ref={c => { this.refStagingView = c; }}
+            ref={this.props.refStagingView.setter}
             commandRegistry={this.props.commandRegistry}
             notificationManager={this.props.notificationManager}
             workspace={this.props.workspace}
@@ -166,7 +170,7 @@ export default class GitTabView extends React.Component {
             isMerging={this.props.isMerging}
           />
           <CommitController
-            ref={c => { this.refCommitController = c; }}
+            ref={this.refCommitController.setter}
             tooltips={this.props.tooltips}
             config={this.props.config}
             stagedChangesExist={this.props.stagedChanges.length > 0}
@@ -189,7 +193,6 @@ export default class GitTabView extends React.Component {
             updateSelectedCoAuthors={this.props.updateSelectedCoAuthors}
           />
           <RecentCommitsController
-            ref={c => { this.refRecentCommitController = c; }}
             commits={this.props.recentCommits}
             isLoading={this.props.isLoading}
             undoLastCommit={this.props.undoLastCommit}
@@ -219,75 +222,70 @@ export default class GitTabView extends React.Component {
   rememberFocus(event) {
     let currentFocus = null;
 
-    if (this.refStagingView) {
-      currentFocus = this.refStagingView.rememberFocus(event);
-    }
+    currentFocus = this.props.refStagingView.map(view => view.rememberFocus(event)).getOr(null);
 
-    if (!currentFocus && this.refCommitController) {
-      currentFocus = this.refCommitController.rememberFocus(event);
+    if (!currentFocus) {
+      currentFocus = this.refCommitController.map(controller => controller.rememberFocus(event)).getOr(null);
     }
 
     return currentFocus;
   }
 
   setFocus(focus) {
-    if (this.refStagingView) {
-      if (this.refStagingView.setFocus(focus)) {
-        return true;
-      }
+    if (this.props.refStagingView.map(view => view.setFocus(focus)).getOr(false)) {
+      return true;
     }
 
-    if (this.refCommitController) {
-      if (this.refCommitController.setFocus(focus)) {
-        return true;
-      }
+    if (this.refCommitController.map(controller => controller.setFocus(focus)).getOr(false)) {
+      return true;
     }
 
     return false;
   }
 
   blur() {
-    this.props.workspace.getActivePane().activate();
+    this.props.workspace.getCenter().activate();
   }
 
   async advanceFocus(evt) {
     // The commit controller manages its own focus
-    if (this.refCommitController.hasFocus()) { return; }
-    if (await this.refStagingView.activateNextList()) {
+    if (this.refCommitController.map(c => c.hasFocus()).getOr(false)) {
+      return;
+    }
+
+    if (await this.props.refStagingView.map(view => view.activateNextList()).getOr(false)) {
       evt.stopPropagation();
     } else {
-      if (this.refCommitController.setFocus(GitTabView.focus.EDITOR)) {
+      if (this.refCommitController.map(c => c.setFocus(GitTabView.focus.EDITOR)).getOr(false)) {
         evt.stopPropagation();
       }
     }
   }
 
   async retreatFocus(evt) {
-    const stagingView = this.refStagingView;
-    const commitController = this.refCommitController;
-
-    if (commitController.hasFocus()) {
+    if (this.refCommitController.map(c => c.hasFocus()).getOr(false)) {
       // if the commit editor is focused, focus the last staging view list
-      if (commitController.hasFocusEditor() && await stagingView.activateLastList()) {
+      if (this.refCommitController.map(c => c.hasFocusEditor()).getOr(false) &&
+          await this.props.refStagingView.map(view => view.activateLastList()).getOr(null)
+      ) {
         this.setFocus(GitTabView.focus.STAGING);
         evt.stopPropagation();
       }
-    } else {
-      await stagingView.activatePreviousList();
+    } else if (await this.props.refStagingView.map(c => c.activatePreviousList()).getOr(null)) {
       evt.stopPropagation();
     }
   }
 
   async focusAndSelectStagingItem(filePath, stagingStatus) {
-    await this.refStagingView.quietlySelectItem(filePath, stagingStatus);
+    await this.quietlySelectItem(filePath, stagingStatus);
     this.setFocus(GitTabView.focus.STAGING);
   }
 
-  hasFocus() {
-    return this.refRoot.contains(document.activeElement);
+  quietlySelectItem(filePath, stagingStatus) {
+    return this.props.refStagingView.map(view => view.quietlySelectItem(filePath, stagingStatus)).getOr(false);
   }
 
-  quietlySelectItem(filePath, stagingStatus) {
-    return this.refStagingView.quietlySelectItem(filePath, stagingStatus);
+  hasFocus() {
+    return this.props.refRoot.map(root => root.contains(document.activeElement)).getOr(false);
   }
 }

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -12,6 +12,7 @@ import ObserveModel from './observe-model';
 import MergeConflictListItemView from './merge-conflict-list-item-view';
 import CompositeListSelection from '../models/composite-list-selection';
 import ResolutionProgress from '../models/conflicts/resolution-progress';
+import RefHolder from '../models/ref-holder';
 import FilePatchController from '../controllers/file-patch-controller';
 import Commands, {Command} from '../atom/commands';
 import {autobind} from '../helpers';
@@ -114,7 +115,7 @@ export default class StagingView extends React.Component {
 
     this.mouseSelectionInProgress = false;
     this.listElementsByItem = new WeakMap();
-    this.refRoot = null;
+    this.refRoot = new RefHolder();
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -185,7 +186,7 @@ export default class StagingView extends React.Component {
 
     return (
       <div
-        ref={c => { this.refRoot = c; }}
+        ref={this.refRoot.setter}
         className={`github-StagingView ${this.state.selection.getActiveListKey()}-changes-focused`}
         tabIndex="-1">
         {this.renderCommands()}
@@ -805,12 +806,12 @@ export default class StagingView extends React.Component {
   }
 
   rememberFocus(event) {
-    return this.refRoot.contains(event.target) ? StagingView.focus.STAGING : null;
+    return this.refRoot.map(root => root.contains(event.target)).getOr(false) ? StagingView.focus.STAGING : null;
   }
 
   setFocus(focus) {
     if (focus === StagingView.focus.STAGING) {
-      this.refRoot.focus();
+      this.refRoot.map(root => root.focus());
       return true;
     }
 
@@ -818,6 +819,6 @@ export default class StagingView extends React.Component {
   }
 
   hasFocus() {
-    return this.refRoot.contains(document.activeElement);
+    return this.refRoot.map(root => root.contains(document.activeElement)).getOr(false);
   }
 }

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -196,11 +196,19 @@ describe('GitTabController', function() {
 
     sinon.spy(stagingView, 'setFocus');
 
+    await controller.quietlySelectItem('unstaged-3.txt', 'unstaged');
+
+    const selections0 = Array.from(stagingView.state.selection.getSelectedItems());
+    assert.lengthOf(selections0, 1);
+    assert.equal(selections0[0].filePath, 'unstaged-3.txt');
+
+    assert.isFalse(stagingView.setFocus.called);
+
     await controller.focusAndSelectStagingItem('unstaged-2.txt', 'unstaged');
 
-    const selections = Array.from(stagingView.state.selection.getSelectedItems());
-    assert.lengthOf(selections, 1);
-    assert.equal(selections[0].filePath, 'unstaged-2.txt');
+    const selections1 = Array.from(stagingView.state.selection.getSelectedItems());
+    assert.lengthOf(selections1, 1);
+    assert.equal(selections1[0].filePath, 'unstaged-2.txt');
 
     assert.equal(stagingView.setFocus.callCount, 1);
   });
@@ -236,6 +244,23 @@ describe('GitTabController', function() {
       view.setFocus.resetHistory();
       wrapper.instance().restoreFocus();
       assert.isFalse(view.setFocus.called);
+    });
+
+    it('detects focus', async function() {
+      const repository = await buildRepository(await cloneRepository());
+      const wrapper = mount(await buildApp(repository));
+      const rootElement = wrapper.instance().refRoot.get();
+      sinon.stub(rootElement, 'contains');
+
+      rootElement.contains.returns(true);
+      assert.isTrue(wrapper.instance().hasFocus());
+
+      rootElement.contains.returns(false);
+      assert.isFalse(wrapper.instance().hasFocus());
+
+      rootElement.contains.returns(true);
+      wrapper.instance().refRoot.setter(null);
+      assert.isFalse(wrapper.instance().hasFocus());
     });
 
     it('does nothing on an absent repository', async function() {

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -192,8 +192,7 @@ describe('GitTabController', function() {
     await assert.async.lengthOf(wrapper.update().find('GitTabView').prop('unstagedChanges'), 3);
 
     const controller = wrapper.instance();
-    const gitTab = controller.refView;
-    const stagingView = gitTab.refStagingView;
+    const stagingView = controller.refStagingView.get();
 
     sinon.spy(stagingView, 'setFocus');
 
@@ -222,14 +221,15 @@ describe('GitTabController', function() {
   });
 
   describe('keyboard navigation commands', function() {
-    let wrapper, gitTab, stagingView, commitView, commitController, focusElement;
+    let wrapper, rootElement, gitTab, stagingView, commitView, commitController, focusElement;
     const focuses = GitTabController.focus;
 
     const extractReferences = () => {
-      gitTab = wrapper.instance().refView;
-      stagingView = gitTab.refStagingView;
-      commitController = gitTab.refCommitController;
-      commitView = commitController.refCommitView;
+      rootElement = wrapper.instance().refRoot.get();
+      gitTab = wrapper.instance().refView.get();
+      stagingView = wrapper.instance().refStagingView.get();
+      commitController = gitTab.refCommitController.get();
+      commitView = commitController.refCommitView.get();
       focusElement = stagingView.element;
 
       const commitViewElements = [];
@@ -242,7 +242,7 @@ describe('GitTabController', function() {
           focusElement = element;
         });
       };
-      stubFocus(stagingView.refRoot);
+      stubFocus(stagingView.refRoot.get());
       for (const e of commitViewElements) {
         stubFocus(e);
       }
@@ -300,18 +300,18 @@ describe('GitTabController', function() {
       it('advances focus through StagingView groups and CommitView, but does not cycle', async function() {
         assertSelected(['unstaged-1.txt']);
 
-        commandRegistry.dispatch(gitTab.refRoot, 'core:focus-next');
+        commandRegistry.dispatch(rootElement, 'core:focus-next');
         assertSelected(['conflict-1.txt']);
 
-        commandRegistry.dispatch(gitTab.refRoot, 'core:focus-next');
+        commandRegistry.dispatch(rootElement, 'core:focus-next');
         assertSelected(['staged-1.txt']);
 
-        commandRegistry.dispatch(gitTab.refRoot, 'core:focus-next');
+        commandRegistry.dispatch(rootElement, 'core:focus-next');
         assertSelected(['staged-1.txt']);
         await assert.async.strictEqual(focusElement, wrapper.find('atom-text-editor').getDOMNode());
 
         // This should be a no-op. (Actually, it'll insert a tab in the CommitView editor.)
-        commandRegistry.dispatch(gitTab.refRoot, 'core:focus-next');
+        commandRegistry.dispatch(rootElement, 'core:focus-next');
         assertSelected(['staged-1.txt']);
         assert.strictEqual(focusElement, wrapper.find('atom-text-editor').getDOMNode());
       });
@@ -320,18 +320,18 @@ describe('GitTabController', function() {
         gitTab.setFocus(focuses.EDITOR);
         sinon.stub(commitView, 'hasFocusEditor').returns(true);
 
-        commandRegistry.dispatch(gitTab.refRoot, 'core:focus-previous');
-        await assert.async.strictEqual(focusElement, stagingView.refRoot);
+        commandRegistry.dispatch(rootElement, 'core:focus-previous');
+        await assert.async.strictEqual(focusElement, stagingView.refRoot.get());
         assertSelected(['staged-1.txt']);
 
-        commandRegistry.dispatch(gitTab.refRoot, 'core:focus-previous');
+        commandRegistry.dispatch(rootElement, 'core:focus-previous');
         await assertAsyncSelected(['conflict-1.txt']);
 
-        commandRegistry.dispatch(gitTab.refRoot, 'core:focus-previous');
+        commandRegistry.dispatch(rootElement, 'core:focus-previous');
         await assertAsyncSelected(['unstaged-1.txt']);
 
         // This should be a no-op.
-        commandRegistry.dispatch(gitTab.refRoot, 'core:focus-previous');
+        commandRegistry.dispatch(rootElement, 'core:focus-previous');
         await assertAsyncSelected(['unstaged-1.txt']);
       });
     });
@@ -391,8 +391,7 @@ describe('GitTabController', function() {
 
       await assert.async.lengthOf(wrapper.update().find('GitTabView').prop('unstagedChanges'), 2);
 
-      const gitTab = wrapper.instance().refView;
-      const stagingView = gitTab.refStagingView;
+      const stagingView = wrapper.instance().refStagingView.get();
       const commitView = wrapper.find('CommitView');
 
       assert.lengthOf(stagingView.props.unstagedChanges, 2);
@@ -433,7 +432,7 @@ describe('GitTabController', function() {
       const wrapper = mount(await buildApp(repository, props));
 
       assert.lengthOf(wrapper.find('GitTabView').prop('mergeConflicts'), 5);
-      const stagingView = wrapper.instance().refView.refStagingView;
+      const stagingView = wrapper.instance().refStagingView.get();
 
       assert.equal(stagingView.props.mergeConflicts.length, 5);
       assert.equal(stagingView.props.stagedChanges.length, 0);
@@ -482,7 +481,7 @@ describe('GitTabController', function() {
 
       const wrapper = mount(await buildApp(repository));
 
-      const stagingView = wrapper.instance().refView.refStagingView;
+      const stagingView = wrapper.instance().refStagingView.get();
       assert.lengthOf(stagingView.props.unstagedChanges, 2);
 
       // ensure staging the same file twice does not cause issues
@@ -509,7 +508,7 @@ describe('GitTabController', function() {
 
       const wrapper = mount(await buildApp(repository));
 
-      const stagingView = wrapper.instance().refView.refStagingView;
+      const stagingView = wrapper.instance().refStagingView.get();
       assert.include(stagingView.props.unstagedChanges.map(c => c.filePath), 'new-file.txt');
 
       const [addedFilePatch] = stagingView.props.unstagedChanges;

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -206,6 +206,38 @@ describe('GitTabController', function() {
   });
 
   describe('focus management', function() {
+    it('remembers the last focus reported by the view', async function() {
+      const repository = await buildRepository(await cloneRepository());
+      const wrapper = mount(await buildApp(repository));
+      const view = wrapper.instance().refView.get();
+      const editorElement = wrapper.find('atom-text-editor').getDOMNode();
+      const commitElement = wrapper.find('.github-CommitView-commit').getDOMNode();
+
+      wrapper.instance().rememberLastFocus({target: editorElement});
+
+      sinon.spy(view, 'setFocus');
+      wrapper.instance().restoreFocus();
+      assert.isTrue(view.setFocus.calledWith(GitTabController.focus.EDITOR));
+
+      wrapper.instance().rememberLastFocus({target: commitElement});
+
+      view.setFocus.resetHistory();
+      wrapper.instance().restoreFocus();
+      assert.isTrue(view.setFocus.calledWith(GitTabController.focus.COMMIT_BUTTON));
+
+      wrapper.instance().rememberLastFocus({target: document.body});
+
+      view.setFocus.resetHistory();
+      wrapper.instance().restoreFocus();
+      assert.isTrue(view.setFocus.calledWith(GitTabController.focus.STAGING));
+
+      wrapper.instance().refView.setter(null);
+
+      view.setFocus.resetHistory();
+      wrapper.instance().restoreFocus();
+      assert.isFalse(view.setFocus.called);
+    });
+
     it('does nothing on an absent repository', async function() {
       const repository = Repository.absent();
 

--- a/test/models/ref-holder.test.js
+++ b/test/models/ref-holder.test.js
@@ -97,6 +97,25 @@ describe('RefHolder', function() {
     assert.isTrue(callback.calledWith(12));
   });
 
+  it('does not notify subscribers when it becomes empty', function() {
+    const h = new RefHolder();
+    h.setter(12);
+    assert.isFalse(h.isEmpty());
+
+    const callback = sinon.spy();
+    sub = h.observe(callback);
+
+    callback.resetHistory();
+    h.setter(null);
+    assert.isTrue(h.isEmpty());
+    assert.isFalse(callback.called);
+
+    callback.resetHistory();
+    h.setter(undefined);
+    assert.isTrue(h.isEmpty());
+    assert.isFalse(callback.called);
+  });
+
   it('resolves a promise when it becomes available', async function() {
     const thing = Symbol('Thing');
     const h = new RefHolder();

--- a/test/models/ref-holder.test.js
+++ b/test/models/ref-holder.test.js
@@ -71,6 +71,21 @@ describe('RefHolder', function() {
     });
   });
 
+  describe('getOr', function() {
+    it("returns the RefHolder's value if it is non-empty", function() {
+      const h = new RefHolder();
+      h.setter(1234);
+
+      assert.strictEqual(h.getOr(5678), 1234);
+    });
+
+    it('returns its argument if the RefHolder is empty', function() {
+      const h = new RefHolder();
+
+      assert.strictEqual(h.getOr(5678), 5678);
+    });
+  });
+
   it('notifies subscribers when it becomes available', function() {
     const h = new RefHolder();
     const callback = sinon.spy();
@@ -95,6 +110,18 @@ describe('RefHolder', function() {
     const callback = sinon.spy();
     sub = h.observe(callback);
     assert.isTrue(callback.calledWith(12));
+  });
+
+  it('does not notify subscribers when it is assigned the same value', function() {
+    const h = new RefHolder();
+    h.setter(12);
+
+    const callback = sinon.spy();
+    sub = h.observe(callback);
+
+    callback.resetHistory();
+    h.setter(12);
+    assert.isFalse(callback.called);
   });
 
   it('does not notify subscribers when it becomes empty', function() {

--- a/test/views/commit-view.test.js
+++ b/test/views/commit-view.test.js
@@ -321,6 +321,21 @@ describe('CommitView', function() {
     assert.isTrue(abortMerge.calledOnce);
   });
 
+  it('detects when the component has focus', function() {
+    const wrapper = mount(app);
+    const rootElement = wrapper.find('.github-CommitView').getDOMNode();
+
+    sinon.stub(rootElement, 'contains').returns(true);
+    assert.isTrue(wrapper.instance().hasFocus());
+
+    rootElement.contains.returns(false);
+    assert.isFalse(wrapper.instance().hasFocus());
+
+    rootElement.contains.returns(true);
+    wrapper.prop('refRoot').setter(null);
+    assert.isFalse(wrapper.instance().hasFocus());
+  });
+
   it('detects when the editor has focus', function() {
     const wrapper = mount(app);
 

--- a/test/views/commit-view.test.js
+++ b/test/views/commit-view.test.js
@@ -332,7 +332,7 @@ describe('CommitView', function() {
     assert.isFalse(wrapper.instance().hasFocus());
 
     rootElement.contains.returns(true);
-    wrapper.prop('refRoot').setter(null);
+    wrapper.instance().refRoot.setter(null);
     assert.isFalse(wrapper.instance().hasFocus());
   });
 

--- a/test/views/git-tab-view.test.js
+++ b/test/views/git-tab-view.test.js
@@ -1,0 +1,226 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+
+import {cloneRepository, buildRepository} from '../helpers';
+import GitTabView from '../../lib/views/git-tab-view';
+import {gitTabViewProps} from '../fixtures/props/git-tab-props';
+
+describe('GitTabView', function() {
+  let atomEnv, repository;
+
+  beforeEach(async function() {
+    atomEnv = global.buildAtomEnvironment();
+    repository = await buildRepository(await cloneRepository());
+  });
+
+  afterEach(function() {
+    atomEnv.destroy();
+  });
+
+  async function buildApp(overrides = {}) {
+    return <GitTabView {...await gitTabViewProps(atomEnv, repository, overrides)} />;
+  }
+
+  it('remembers the current focus', async function() {
+    const wrapper = mount(await buildApp());
+
+    assert.strictEqual(
+      wrapper.instance().rememberFocus({target: wrapper.find('div.github-StagingView').getDOMNode()}),
+      GitTabView.focus.STAGING,
+    );
+
+    assert.strictEqual(
+      wrapper.instance().rememberFocus({target: wrapper.find('atom-text-editor').getDOMNode()}),
+      GitTabView.focus.EDITOR,
+    );
+
+    assert.isNull(wrapper.instance().rememberFocus({target: document.body}));
+  });
+
+  it('sets a new focus', async function() {
+    const wrapper = mount(await buildApp());
+    const stagingElement = wrapper.find('div.github-StagingView').getDOMNode();
+    const editorElement = wrapper.find('atom-text-editor').getDOMNode();
+
+    sinon.spy(stagingElement, 'focus');
+    assert.isTrue(wrapper.instance().setFocus(GitTabView.focus.STAGING));
+    assert.isTrue(stagingElement.focus.called);
+
+    sinon.spy(editorElement, 'focus');
+    assert.isTrue(wrapper.instance().setFocus(GitTabView.focus.EDITOR));
+    assert.isTrue(editorElement.focus.called);
+
+    assert.isFalse(wrapper.instance().setFocus(Symbol('nah')));
+  });
+
+  it('blurs by focusing the workspace center', async function() {
+    const editor = await atomEnv.workspace.open(__filename);
+    atomEnv.workspace.getLeftDock().activate();
+    assert.notStrictEqual(atomEnv.workspace.getActivePaneItem(), editor);
+
+    const wrapper = shallow(await buildApp());
+    wrapper.instance().blur();
+
+    assert.strictEqual(atomEnv.workspace.getActivePaneItem(), editor);
+  });
+
+  it('no-ops focus management methods when refs are unavailable', async function() {
+    const wrapper = shallow(await buildApp());
+    assert.isNull(wrapper.instance().rememberFocus({}));
+    assert.isFalse(wrapper.instance().setFocus(GitTabView.focus.EDITOR));
+  });
+
+  describe('advanceFocus', function() {
+    let wrapper, event, commitController, stagingView;
+
+    beforeEach(async function() {
+      wrapper = mount(await buildApp());
+
+      commitController = wrapper.instance().refCommitController.get();
+      stagingView = wrapper.prop('refStagingView').get();
+
+      event = {stopPropagation: sinon.spy()};
+    });
+
+    it('does nothing if the commit controller has focus', async function() {
+      sinon.stub(commitController, 'hasFocus').returns(true);
+      sinon.spy(stagingView, 'activateNextList');
+
+      await wrapper.instance().advanceFocus(event);
+
+      assert.isFalse(event.stopPropagation.called);
+      assert.isFalse(stagingView.activateNextList.called);
+    });
+
+    it('activates the next staging view list and stops', async function() {
+      sinon.stub(stagingView, 'activateNextList').resolves(true);
+      sinon.spy(commitController, 'setFocus');
+
+      await wrapper.instance().advanceFocus(event);
+
+      assert.isTrue(stagingView.activateNextList.called);
+      assert.isTrue(event.stopPropagation.called);
+      assert.isFalse(commitController.setFocus.called);
+    });
+
+    it('moves focus to the commit message editor from the end of the staging view', async function() {
+      sinon.stub(stagingView, 'activateNextList').resolves(false);
+      sinon.stub(commitController, 'setFocus').returns(true);
+
+      await wrapper.instance().advanceFocus(event);
+
+      assert.isTrue(commitController.setFocus.calledWith(GitTabView.focus.EDITOR));
+      assert.isTrue(event.stopPropagation.called);
+    });
+
+    it('does nothing if refs are unavailable', async function() {
+      wrapper.instance().refCommitController.setter(null);
+
+      await wrapper.instance().advanceFocus(event);
+
+      assert.isFalse(event.stopPropagation.called);
+    });
+  });
+
+  describe('retreatFocus', function() {
+    let wrapper, event, commitController, stagingView;
+
+    beforeEach(async function() {
+      wrapper = mount(await buildApp());
+
+      commitController = wrapper.instance().refCommitController.get();
+      stagingView = wrapper.prop('refStagingView').get();
+
+      event = {stopPropagation: sinon.spy()};
+    });
+
+    it('focuses the last staging list if the commit editor has focus', async function() {
+      sinon.stub(commitController, 'hasFocus').returns(true);
+      sinon.stub(commitController, 'hasFocusEditor').returns(true);
+      sinon.stub(stagingView, 'activateLastList').resolves(true);
+
+      await wrapper.instance().retreatFocus(event);
+
+      assert.isTrue(stagingView.activateLastList.called);
+      assert.isTrue(event.stopPropagation.called);
+    });
+
+    it('does nothing if the commit controller has focus but not in its editor', async function() {
+      sinon.stub(commitController, 'hasFocus').returns(true);
+      sinon.stub(commitController, 'hasFocusEditor').returns(false);
+      sinon.spy(stagingView, 'activateLastList');
+      sinon.spy(stagingView, 'activatePreviousList');
+
+      await wrapper.instance().retreatFocus(event);
+
+      assert.isFalse(stagingView.activateLastList.called);
+      assert.isFalse(stagingView.activatePreviousList.called);
+      assert.isFalse(event.stopPropagation.called);
+    });
+
+    it('activates the previous staging list and stops', async function() {
+      sinon.stub(commitController, 'hasFocus').returns(false);
+      sinon.stub(stagingView, 'activatePreviousList').resolves(true);
+
+      await wrapper.instance().retreatFocus(event);
+
+      assert.isTrue(stagingView.activatePreviousList.called);
+      assert.isTrue(event.stopPropagation.called);
+    });
+
+    it('does nothing if refs are unavailable', async function() {
+      wrapper.instance().refCommitController.setter(null);
+      wrapper.prop('refStagingView').setter(null);
+
+      await wrapper.instance().retreatFocus(event);
+
+      assert.isFalse(event.stopPropagation.called);
+    });
+  });
+
+  it('selects a staging item', async function() {
+    const wrapper = mount(await buildApp({
+      unstagedChanges: [{filePath: 'aaa.txt', status: 'modified'}],
+    }));
+
+    const stagingView = wrapper.prop('refStagingView').get();
+    sinon.spy(stagingView, 'quietlySelectItem');
+    sinon.spy(stagingView, 'setFocus');
+
+    await wrapper.instance().quietlySelectItem('aaa.txt', 'unstaged');
+
+    assert.isTrue(stagingView.quietlySelectItem.calledWith('aaa.txt', 'unstaged'));
+    assert.isFalse(stagingView.setFocus.calledWith(GitTabView.focus.STAGING));
+  });
+
+  it('selects a staging item and focuses itself', async function() {
+    const wrapper = mount(await buildApp({
+      unstagedChanges: [{filePath: 'aaa.txt', status: 'modified'}],
+    }));
+
+    const stagingView = wrapper.prop('refStagingView').get();
+    sinon.spy(stagingView, 'quietlySelectItem');
+    sinon.spy(stagingView, 'setFocus');
+
+    await wrapper.instance().focusAndSelectStagingItem('aaa.txt', 'unstaged');
+
+    assert.isTrue(stagingView.quietlySelectItem.calledWith('aaa.txt', 'unstaged'));
+    assert.isTrue(stagingView.setFocus.calledWith(GitTabView.focus.STAGING));
+  });
+
+  it('detects when it has focus', async function() {
+    const wrapper = mount(await buildApp());
+    const rootElement = wrapper.prop('refRoot').get();
+    sinon.stub(rootElement, 'contains');
+
+    rootElement.contains.returns(true);
+    assert.isTrue(wrapper.instance().hasFocus());
+
+    rootElement.contains.returns(false);
+    assert.isFalse(wrapper.instance().hasFocus());
+
+    rootElement.contains.returns(true);
+    wrapper.prop('refRoot').setter(null);
+    assert.isFalse(wrapper.instance().hasFocus());
+  });
+});

--- a/test/views/staging-view.test.js
+++ b/test/views/staging-view.test.js
@@ -740,4 +740,49 @@ describe('StagingView', function() {
       });
     });
   }
+
+  it('remembers the current focus', function() {
+    const wrapper = mount(app);
+    const rootElement = wrapper.find('.github-StagingView').getDOMNode();
+
+    assert.strictEqual(wrapper.instance().rememberFocus({target: rootElement}), StagingView.focus.STAGING);
+    assert.isNull(wrapper.instance().rememberFocus({target: document.body}));
+
+    wrapper.instance().refRoot.setter(null);
+    assert.isNull(wrapper.instance().rememberFocus({target: rootElement}));
+  });
+
+  it('sets a new focus', function() {
+    const wrapper = mount(app);
+    const rootElement = wrapper.find('.github-StagingView').getDOMNode();
+
+    sinon.stub(rootElement, 'focus');
+
+    assert.isFalse(wrapper.instance().setFocus(Symbol('nope')));
+    assert.isFalse(rootElement.focus.called);
+
+    assert.isTrue(wrapper.instance().setFocus(StagingView.focus.STAGING));
+    assert.isTrue(rootElement.focus.called);
+
+    wrapper.instance().refRoot.setter(null);
+    rootElement.focus.resetHistory();
+    assert.isTrue(wrapper.instance().setFocus(StagingView.focus.STAGING));
+    assert.isFalse(rootElement.focus.called);
+  });
+
+  it('detects when the component does have focus', function() {
+    const wrapper = mount(app);
+    const rootElement = wrapper.find('.github-StagingView').getDOMNode();
+    sinon.stub(rootElement, 'contains');
+
+    rootElement.contains.returns(true);
+    assert.isTrue(wrapper.instance().hasFocus());
+
+    rootElement.contains.returns(false);
+    assert.isFalse(wrapper.instance().hasFocus());
+
+    rootElement.contains.returns(true);
+    wrapper.instance().refRoot.setter(null);
+    assert.isFalse(wrapper.instance().hasFocus());
+  });
 });


### PR DESCRIPTION
The root cause of #1490 and other related uncaught TypeError bugs is a set of somewhat rare race conditions triggered by focus management methods (`rememberLastFocus`, `setFocus`, `hasFocus`, ...) being triggered on our React components while refs are unavailable. We had a certain amount of null-armor in there already, but we missed a few subtle code paths.

I'm resolving this by consistently using RefHolders to store refs in the GitTabItem component tree. RefHolders force us to always explicitly handle the case when a ref is unavailable.

Note that there's still the risk of a focus event being ignored because of this. I thought about catching focus calls and playing them back later when refs do become available but I feel like that would cause a bunch of weird cases where we yank focus in undesirably because it's already moved elsewhere. The risk there is that you might have to click twice sometimes, I suppose?

I'm also very carefully _not_ taking this opportunity to tackle reworking focus management holistically in a fancier, more React-friendly declarative style. Now is the time for band-aids!