### PR TITLE
Undo an initial commit

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -812,6 +812,10 @@ export default class GitShellOutStrategy {
     return this.exec(['reset', `--${type}`, revision]);
   }
 
+  deleteRef(ref) {
+    return this.exec(['update-ref', '-d', ref]);
+  }
+
   /**
    * Branches
    */

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -341,7 +341,18 @@ export default class Present extends State {
         ...Keys.filePatch.eachWithOpts({staged: true}),
         Keys.headDescription,
       ],
-      () => this.git().reset('soft', 'HEAD~'),
+      async () => {
+        try {
+          await this.git().reset('soft', 'HEAD~');
+        } catch (e) {
+          if (/unknown revision/.test(e.stdErr)) {
+            // Initial commit
+            await this.git().deleteRef('HEAD');
+          } else {
+            throw e;
+          }
+        }
+      },
     );
   }
 


### PR DESCRIPTION
Calling `git reset --soft HEAD~` fails when HEAD is still the initial commit in a repository, because `HEAD~` does not exist yet. Use `git update-ref -d HEAD` to delete HEAD instead for an equivalent outcome.

Fixes #1440.