### PR TITLE
Proxy items need to be more resilient to unexpected properties

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,6 +4,7 @@ import os from 'os';
 import temp from 'temp';
 
 import FilePatchController from './controllers/file-patch-controller';
+import RefHolder from './models/ref-holder';
 
 export const LINE_ENDING_REGEX = /\r?\n/;
 export const CO_AUTHOR_REGEX = /^co-authored-by. (.+?) <(.+?)>$/i;
@@ -409,16 +410,14 @@ export function extractCoAuthorsAndRawCommitMessage(commitMessage) {
 }
 
 export function createItem(node, componentHolder = null, uri = null, extra = {}) {
+  const holder = componentHolder || new RefHolder();
+
   const override = {
     getElement: () => node,
 
-    getRealItem: () => componentHolder.getOr(null),
+    getRealItem: () => holder.getOr(null),
 
-    getRealItemPromise: () => componentHolder.getPromise(),
-
-    destroy: () => componentHolder && componentHolder.map(component => {
-      return component.destroy && component.destroy();
-    }),
+    getRealItemPromise: () => holder.getPromise(),
 
     ...extra,
   };
@@ -434,16 +433,18 @@ export function createItem(node, componentHolder = null, uri = null, extra = {})
           return target[name];
         }
 
-        return componentHolder.get()[name];
+        return holder.map(component => component[name]).getOr(undefined);
       },
 
       set(target, name, value) {
-        componentHolder.get()[name] = value;
-        return true;
+        return holder.map(component => {
+          component[name] = value;
+          return true;
+        }).getOr(true);
       },
 
       has(target, name) {
-        return Reflect.has(componentHolder.get(), name) || Reflect.has(target, name);
+        return holder.map(component => Reflect.has(component, name)).getOr(false) || Reflect.has(target, name);
       },
     });
   } else {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -433,7 +433,9 @@ export function createItem(node, componentHolder = null, uri = null, extra = {})
           return target[name];
         }
 
-        return holder.map(component => component[name]).getOr(undefined);
+        // The {value: ...} wrapper prevents .map() from flattening a returned RefHolder.
+        // If component[name] is a RefHolder, we want to return that RefHolder as-is.
+        return holder.map(component => ({value: component[name]})).getOr({value: undefined});
       },
 
       set(target, name, value) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -435,7 +435,8 @@ export function createItem(node, componentHolder = null, uri = null, extra = {})
 
         // The {value: ...} wrapper prevents .map() from flattening a returned RefHolder.
         // If component[name] is a RefHolder, we want to return that RefHolder as-is.
-        return holder.map(component => ({value: component[name]})).getOr({value: undefined});
+        const {value} = holder.map(component => ({value: component[name]})).getOr({value: undefined});
+        return value;
       },
 
       set(target, name, value) {


### PR DESCRIPTION
One of the Atom main process tests triggered a race condition in the Proxy we construct as an "item" to pass to the Atom API in `PaneItem`. A code path that iterated over the pane items in the workspace caused underscore.js to look for the `.length` property on every item, but that caused our Proxy to throw because its component `RefHolder` was still empty.

I'm armoring the Proxy items against empty holders to prevent this and turn it into a no-op.