### PR TITLE
Always keep hunk-view header visible

### DIFF
--- a/styles/hunk-view.less
+++ b/styles/hunk-view.less
@@ -14,6 +14,8 @@
     font-size: .9em;
     background-color: @panel-heading-background-color;
     border-bottom: 1px solid @panel-heading-border-color;
+    position: sticky;
+    top: 0;
   }
 
   &-title {


### PR DESCRIPTION
### Description of the Change

This change will ensure that the "hunk view" header is always visible by making use of the CSS property [`position: sticky`](https://developer.mozilla.org/en-US/docs/Web/CSS/position)

Currently, the header scrolls out of the viewport when the hunk is particularly long. This causes a problem when attempting to stage/unstage only certain lines - the user needs to scroll back up until the header comes into view again, being sure to look for the relevant header for this hunk.

### Alternate Designs

n/a

### Benefits

Better user experience when dealing with large hunks.

### Possible Drawbacks

Potentially confusing when two hunk headers are visible/adjacent (one from previous hunk with very few or no more of its lines showing, another from the next hunk).

### Applicable Issues

n/a
