### PR TITLE
Backports 0.19.0 > 0.18-releases

### DIFF
--- a/lib/atom/atom-text-editor.js
+++ b/lib/atom/atom-text-editor.js
@@ -129,14 +129,14 @@ export default class AtomTextEditor extends React.PureComponent {
   }
 
   contains(element) {
-    return this.refElement.get().contains(element);
+    return this.refElement.map(e => e.contains(element)).getOr(false);
   }
 
   focus() {
-    this.refElement.get().focus();
+    this.refElement.map(e => e.focus());
   }
 
   getModel() {
-    return this.refElement.get().getModel();
+    return this.refElement.map(e => e.getModel()).getOr(null);
   }
 }

--- a/lib/atom/pane-item.js
+++ b/lib/atom/pane-item.js
@@ -170,6 +170,8 @@ class OpenItem {
     this.constructor.nextID++;
 
     this.domNode = element || document.createElement('div');
+    this.domNode.tabIndex = '-1';
+    this.domNode.onfocus = this.onFocus.bind(this);
     this.stubItem = stub;
     this.match = match;
     this.itemHolder = new RefHolder();
@@ -209,6 +211,10 @@ class OpenItem {
     } else {
       return {};
     }
+  }
+
+  onFocus() {
+    return this.itemHolder.map(item => item.focus && item.focus());
   }
 
   renderPortal(renderProp) {

--- a/lib/controllers/commit-controller.js
+++ b/lib/controllers/commit-controller.js
@@ -1,12 +1,12 @@
 import path from 'path';
 
 import React from 'react';
-import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import {CompositeDisposable} from 'event-kit';
 import fs from 'fs-extra';
 
 import CommitView from '../views/commit-view';
+import RefHolder from '../models/ref-holder';
 import {AuthorPropType, UserStorePropType} from '../prop-types';
 import {autobind} from '../helpers';
 
@@ -44,7 +44,7 @@ export default class CommitController extends React.Component {
     autobind(this, 'commit', 'handleMessageChange', 'toggleExpandedCommitMessageEditor', 'grammarAdded');
 
     this.subscriptions = new CompositeDisposable();
-    this.refCommitView = null;
+    this.refCommitView = new RefHolder();
   }
 
   // eslint-disable-next-line camelcase
@@ -78,17 +78,13 @@ export default class CommitController extends React.Component {
     }
   }
 
-  componentDidMount() {
-    this.domNode = ReactDom.findDOMNode(this);
-  }
-
   render() {
     const message = this.getCommitMessage();
     const operationStates = this.props.repository.getOperationStates();
 
     return (
       <CommitView
-        ref={c => { this.refCommitView = c; }}
+        ref={this.refCommitView.setter}
         tooltips={this.props.tooltips}
         config={this.props.config}
         stagedChangesExist={this.props.stagedChangesExist}
@@ -241,19 +237,19 @@ export default class CommitController extends React.Component {
   }
 
   rememberFocus(event) {
-    return this.refCommitView.rememberFocus(event);
+    return this.refCommitView.map(view => view.rememberFocus(event)).getOr(null);
   }
 
   setFocus(focus) {
-    return this.refCommitView.setFocus(focus);
+    return this.refCommitView.map(view => view.setFocus(focus)).getOr(false);
   }
 
   hasFocus() {
-    return this.domNode && this.domNode.contains(document.activeElement);
+    return this.refCommitView.map(view => view.hasFocus()).getOr(false);
   }
 
   hasFocusEditor() {
-    return this.refCommitView.hasFocusEditor();
+    return this.refCommitView.map(view => view.hasFocusEditor()).getOr(false);
   }
 }
 

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import Author from '../models/author';
 import GitTabView from '../views/git-tab-view';
 import UserStore from '../models/user-store';
+import RefHolder from '../models/ref-holder';
 import {
   CommitPropType, BranchPropType, FilePatchItemPropType, MergeConflictItemPropType, RefHolderPropType,
 } from '../prop-types';
@@ -64,7 +65,9 @@ export default class GitTabController extends React.Component {
     this.stagingOperationInProgress = false;
     this.lastFocus = GitTabView.focus.STAGING;
 
-    this.refView = null;
+    this.refView = new RefHolder();
+    this.refRoot = new RefHolder();
+    this.refStagingView = new RefHolder();
 
     this.state = {
       selectedCoAuthors: [],
@@ -80,7 +83,9 @@ export default class GitTabController extends React.Component {
   render() {
     return (
       <GitTabView
-        ref={c => { this.refView = c; }}
+        ref={this.refView.setter}
+        refRoot={this.refRoot}
+        refStagingView={this.refStagingView}
 
         isLoading={this.props.fetchInProgress}
         repository={this.props.repository}
@@ -135,7 +140,7 @@ export default class GitTabController extends React.Component {
 
   componentDidMount() {
     this.refreshResolutionProgress(false, false);
-    this.refView.refRoot.addEventListener('focusin', this.rememberLastFocus);
+    this.refRoot.map(root => root.addEventListener('focusin', this.rememberLastFocus));
 
     if (this.props.controllerRef) {
       this.props.controllerRef.setter(this);
@@ -149,7 +154,7 @@ export default class GitTabController extends React.Component {
   }
 
   componentWillUnmount() {
-    this.refView.refRoot.removeEventListener('focusin', this.rememberLastFocus);
+    this.refRoot.map(root => root.removeEventListener('focusin', this.rememberLastFocus));
   }
 
   /*
@@ -204,7 +209,9 @@ export default class GitTabController extends React.Component {
 
     this.stagingOperationInProgress = true;
 
-    const fileListUpdatePromise = this.refView.refStagingView.getNextListUpdatePromise();
+    const fileListUpdatePromise = this.refStagingView.map(view => {
+      return view.getNextListUpdatePromise();
+    }).getOr(Promise.resolve());
     let stageOperationPromise;
     if (stageStatus === 'staged') {
       stageOperationPromise = this.unstageFiles(filePaths);
@@ -324,19 +331,15 @@ export default class GitTabController extends React.Component {
   }
 
   rememberLastFocus(event) {
-    if (!this.refView) {
-      return;
-    }
-
-    this.lastFocus = this.refView.rememberFocus(event) || GitTabView.focus.STAGING;
+    this.lastFocus = this.refView.map(view => view.rememberFocus(event)).getOr(null) || GitTabView.focus.STAGING;
   }
 
   restoreFocus() {
-    this.refView.setFocus(this.lastFocus);
+    this.refView.map(view => view.setFocus(this.lastFocus));
   }
 
   hasFocus() {
-    return this.refView.refRoot.contains(document.activeElement);
+    return this.refRoot.map(root => root.contains(document.activeElement)).getOr(false);
   }
 
   wasActivated(isStillActive) {
@@ -346,10 +349,10 @@ export default class GitTabController extends React.Component {
   }
 
   focusAndSelectStagingItem(filePath, stagingStatus) {
-    return this.refView.focusAndSelectStagingItem(filePath, stagingStatus);
+    return this.refView.map(view => view.focusAndSelectStagingItem(filePath, stagingStatus)).getOr(null);
   }
 
   quietlySelectItem(filePath, stagingStatus) {
-    return this.refView.quietlySelectItem(filePath, stagingStatus);
+    return this.refView.map(view => view.quietlySelectItem(filePath, stagingStatus)).getOr(null);
   }
 }

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -771,9 +771,10 @@ class TabTracker {
   }
 
   async toggleFocus() {
+    const hadFocus = this.hasFocus();
     await this.ensureVisible();
 
-    if (this.hasFocus()) {
+    if (hadFocus) {
       let workspace = this.getWorkspace();
       if (workspace.getCenter) {
         workspace = workspace.getCenter();

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -410,6 +410,10 @@ export default class RootController extends React.Component {
       return null;
     }
 
+    if (!initDialogPath) {
+      initDialogPath = this.props.repository.getWorkingDirectoryPath();
+    }
+
     return new Promise(resolve => {
       this.setState({initDialogActive: true, initDialogPath, initDialogResolve: resolve});
     });

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -812,6 +812,10 @@ export default class GitShellOutStrategy {
     return this.exec(['reset', `--${type}`, revision]);
   }
 
+  deleteRef(ref) {
+    return this.exec(['update-ref', '-d', ref]);
+  }
+
   /**
    * Branches
    */

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,6 +4,7 @@ import os from 'os';
 import temp from 'temp';
 
 import FilePatchController from './controllers/file-patch-controller';
+import RefHolder from './models/ref-holder';
 
 export const LINE_ENDING_REGEX = /\r?\n/;
 export const CO_AUTHOR_REGEX = /^co-authored-by. (.+?) <(.+?)>$/i;
@@ -409,16 +410,14 @@ export function extractCoAuthorsAndRawCommitMessage(commitMessage) {
 }
 
 export function createItem(node, componentHolder = null, uri = null, extra = {}) {
+  const holder = componentHolder || new RefHolder();
+
   const override = {
     getElement: () => node,
 
-    getRealItem: () => componentHolder.getOr(null),
+    getRealItem: () => holder.getOr(null),
 
-    getRealItemPromise: () => componentHolder.getPromise(),
-
-    destroy: () => componentHolder && componentHolder.map(component => {
-      return component.destroy && component.destroy();
-    }),
+    getRealItemPromise: () => holder.getPromise(),
 
     ...extra,
   };
@@ -434,16 +433,21 @@ export function createItem(node, componentHolder = null, uri = null, extra = {})
           return target[name];
         }
 
-        return componentHolder.get()[name];
+        // The {value: ...} wrapper prevents .map() from flattening a returned RefHolder.
+        // If component[name] is a RefHolder, we want to return that RefHolder as-is.
+        const {value} = holder.map(component => ({value: component[name]})).getOr({value: undefined});
+        return value;
       },
 
       set(target, name, value) {
-        componentHolder.get()[name] = value;
-        return true;
+        return holder.map(component => {
+          component[name] = value;
+          return true;
+        }).getOr(true);
       },
 
       has(target, name) {
-        return Reflect.has(componentHolder.get(), name) || Reflect.has(target, name);
+        return holder.map(component => Reflect.has(component, name)).getOr(false) || Reflect.has(target, name);
       },
     });
   } else {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -416,6 +416,10 @@ export function createItem(node, componentHolder = null, uri = null, extra = {})
 
     getRealItemPromise: () => componentHolder.getPromise(),
 
+    destroy: () => componentHolder && componentHolder.map(component => {
+      return component.destroy && component.destroy();
+    }),
+
     ...extra,
   };
 

--- a/lib/items/git-tab-item.js
+++ b/lib/items/git-tab-item.js
@@ -75,6 +75,10 @@ export default class GitTabItem extends React.Component {
     return this.refController.map(c => c.hasFocus(...args));
   }
 
+  focus() {
+    return this.refController.map(c => c.restoreFocus());
+  }
+
   focusAndSelectStagingItem(...args) {
     return this.refController.map(c => c.focusAndSelectStagingItem(...args));
   }

--- a/lib/models/file-patch.js
+++ b/lib/models/file-patch.js
@@ -131,6 +131,12 @@ export default class FilePatch {
   didChangeExecutableMode() {
     const oldMode = this.getOldMode();
     const newMode = this.getNewMode();
+
+    if (!oldMode || !newMode) {
+      // Addition or deletion
+      return false;
+    }
+
     return oldMode === '100755' && newMode !== '100755' ||
       oldMode !== '100755' && newMode === '100755';
   }

--- a/lib/models/ref-holder.js
+++ b/lib/models/ref-holder.js
@@ -48,7 +48,7 @@ export default class RefHolder {
   }
 
   isEmpty() {
-    return this.value === undefined;
+    return this.value === undefined || this.value === null;
   }
 
   get() {
@@ -83,10 +83,9 @@ export default class RefHolder {
   }
 
   setter = value => {
-    if (value === null || value === undefined) { return; }
     const oldValue = this.value;
     this.value = value;
-    if (value !== oldValue) {
+    if (value !== oldValue && value !== null && value !== undefined) {
       this.emitter.emit('did-update', value);
     }
   }

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -341,7 +341,18 @@ export default class Present extends State {
         ...Keys.filePatch.eachWithOpts({staged: true}),
         Keys.headDescription,
       ],
-      () => this.git().reset('soft', 'HEAD~'),
+      async () => {
+        try {
+          await this.git().reset('soft', 'HEAD~');
+        } catch (e) {
+          if (/unknown revision/.test(e.stdErr)) {
+            // Initial commit
+            await this.git().deleteRef('HEAD');
+          } else {
+            throw e;
+          }
+        }
+      },
     );
   }
 

--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -72,6 +72,7 @@ export default class CommitView extends React.Component {
     this.timeoutHandle = null;
     this.subscriptions = new CompositeDisposable();
 
+    this.refRoot = new RefHolder();
     this.refExpandButton = new RefHolder();
     this.refCommitButton = new RefHolder();
     this.refHardWrapButton = new RefHolder();
@@ -133,10 +134,11 @@ export default class CommitView extends React.Component {
 
     const showAbortMergeButton = this.props.isMerging || null;
 
+    /* istanbul ignore next */
     const modKey = process.platform === 'darwin' ? 'Cmd' : 'Ctrl';
 
     return (
-      <div className="github-CommitView">
+      <div className="github-CommitView" ref={this.refRoot.setter}>
         <Commands registry={this.props.commandRegistry} target="atom-workspace">
           <Command command="github:commit" callback={this.commit} />
           <Command command="github:amend-last-commit" callback={this.amendLastCommit} />
@@ -549,12 +551,16 @@ export default class CommitView extends React.Component {
     }
   }
 
+  hasFocus() {
+    return this.refRoot.map(element => element.contains(document.activeElement)).getOr(false);
+  }
+
   hasFocusEditor() {
-    return this.refEditor.get().contains(document.activeElement);
+    return this.refEditor.map(editor => editor.contains(document.activeElement)).getOr(false);
   }
 
   rememberFocus(event) {
-    if (this.refEditor.get().contains(event.target)) {
+    if (this.refEditor.map(editor => editor.contains(event.target)).getOr(false)) {
       return CommitView.focus.EDITOR;
     }
 
@@ -575,41 +581,39 @@ export default class CommitView extends React.Component {
 
   setFocus(focus) {
     let fallback = false;
+    const focusElement = element => {
+      element.focus();
+      return true;
+    };
 
     if (focus === CommitView.focus.EDITOR) {
-      this.refEditor.get().focus();
-      return true;
+      if (this.refEditor.map(focusElement).getOr(false)) {
+        return true;
+      }
     }
 
     if (focus === CommitView.focus.ABORT_MERGE_BUTTON) {
-      if (!this.refAbortMergeButton.isEmpty()) {
-        this.refAbortMergeButton.get().focus();
+      if (this.refAbortMergeButton.map(focusElement).getOr(false)) {
         return true;
-      } else {
-        fallback = true;
       }
+      fallback = true;
     }
 
     if (focus === CommitView.focus.COMMIT_BUTTON) {
-      if (!this.refCommitButton.isEmpty()) {
-        this.refCommitButton.get().focus();
+      if (this.refCommitButton.map(focusElement).getOr(false)) {
         return true;
-      } else {
-        fallback = true;
       }
+      fallback = true;
     }
 
     if (focus === CommitView.focus.COAUTHOR_INPUT) {
-      if (!this.refCoAuthorSelect.isEmpty()) {
-        this.refCoAuthorSelect.get().focus();
+      if (this.refCoAuthorSelect.map(focusElement).getOr(false)) {
         return true;
-      } else {
-        fallback = true;
       }
+      fallback = true;
     }
 
-    if (fallback) {
-      this.refEditor.get().focus();
+    if (fallback && this.refEditor.map(focusElement).getOr(false)) {
       return true;
     }
 

--- a/lib/views/file-patch-view.js
+++ b/lib/views/file-patch-view.js
@@ -668,7 +668,12 @@ export default class FilePatchView extends React.Component {
   }
 
   didConfirm() {
-    return this.didClickStageButtonForHunk([...this.state.selection.getSelectedHunks()][0]);
+    const hunk = [...this.state.selection.getSelectedHunks()][0];
+    if (!hunk) {
+      return;
+    }
+
+    this.didClickStageButtonForHunk(hunk);
   }
 
   didMoveRight() {

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -7,8 +7,9 @@ import StagingView from './staging-view';
 import GitLogo from './git-logo';
 import CommitController from '../controllers/commit-controller';
 import RecentCommitsController from '../controllers/recent-commits-controller';
+import RefHolder from '../models/ref-holder';
 import {isValidWorkdir, autobind} from '../helpers';
-import {AuthorPropType, UserStorePropType} from '../prop-types';
+import {AuthorPropType, UserStorePropType, RefHolderPropType} from '../prop-types';
 
 export default class GitTabView extends React.Component {
   static focus = {
@@ -18,6 +19,9 @@ export default class GitTabView extends React.Component {
   };
 
   static propTypes = {
+    refRoot: RefHolderPropType,
+    refStagingView: RefHolderPropType,
+
     repository: PropTypes.object.isRequired,
     isLoading: PropTypes.bool.isRequired,
 
@@ -65,25 +69,25 @@ export default class GitTabView extends React.Component {
 
     this.subscriptions = new CompositeDisposable();
 
-    this.refRoot = null;
-    this.refStagingView = null;
-    this.refCommitViewComponent = null;
+    this.refCommitController = new RefHolder();
   }
 
   componentDidMount() {
-    this.subscriptions.add(
-      this.props.commandRegistry.add(this.refRoot, {
-        'tool-panel:unfocus': this.blur,
-        'core:focus-next': this.advanceFocus,
-        'core:focus-previous': this.retreatFocus,
-      }),
-    );
+    this.props.refRoot.map(root => {
+      return this.subscriptions.add(
+        this.props.commandRegistry.add(root, {
+          'tool-panel:unfocus': this.blur,
+          'core:focus-next': this.advanceFocus,
+          'core:focus-previous': this.retreatFocus,
+        }),
+      );
+    });
   }
 
   render() {
     if (this.props.repository.isTooLarge()) {
       return (
-        <div className="github-Panel is-empty" tabIndex="-1" ref={c => { this.refRoot = c; }}>
+        <div className="github-Panel is-empty" tabIndex="-1" ref={this.props.refRoot.setter}>
           <div ref="noRepoMessage" className="github-Panel no-repository">
             <div className="large-icon">
               <GitLogo />
@@ -99,7 +103,7 @@ export default class GitTabView extends React.Component {
     } else if (this.props.repository.hasDirectory() &&
                !isValidWorkdir(this.props.repository.getWorkingDirectoryPath())) {
       return (
-        <div className="github-Panel is-empty" tabIndex="-1" ref={c => { this.refRoot = c; }}>
+        <div className="github-Panel is-empty" tabIndex="-1" ref={this.props.refRoot.setter}>
           <div ref="noRepoMessage" className="github-Panel no-repository">
             <div className="large-icon">
               <GitLogo />
@@ -122,7 +126,7 @@ export default class GitTabView extends React.Component {
         : <span>Initialize a new project directory with a Git repository</span>;
 
       return (
-        <div className="github-Panel is-empty" tabIndex="-1" ref={c => { this.refRoot = c; }}>
+        <div className="github-Panel is-empty" tabIndex="-1" ref={this.props.refRoot.setter}>
           <div ref="noRepoMessage" className="github-Panel no-repository">
             <div className="large-icon">
               <GitLogo />
@@ -141,9 +145,9 @@ export default class GitTabView extends React.Component {
         <div
           className={cx('github-Panel', {'is-loading': isLoading})}
           tabIndex="-1"
-          ref={c => { this.refRoot = c; }}>
+          ref={this.props.refRoot.setter}>
           <StagingView
-            ref={c => { this.refStagingView = c; }}
+            ref={this.props.refStagingView.setter}
             commandRegistry={this.props.commandRegistry}
             notificationManager={this.props.notificationManager}
             workspace={this.props.workspace}
@@ -166,7 +170,7 @@ export default class GitTabView extends React.Component {
             isMerging={this.props.isMerging}
           />
           <CommitController
-            ref={c => { this.refCommitController = c; }}
+            ref={this.refCommitController.setter}
             tooltips={this.props.tooltips}
             config={this.props.config}
             stagedChangesExist={this.props.stagedChanges.length > 0}
@@ -189,7 +193,6 @@ export default class GitTabView extends React.Component {
             updateSelectedCoAuthors={this.props.updateSelectedCoAuthors}
           />
           <RecentCommitsController
-            ref={c => { this.refRecentCommitController = c; }}
             commits={this.props.recentCommits}
             isLoading={this.props.isLoading}
             undoLastCommit={this.props.undoLastCommit}
@@ -219,75 +222,70 @@ export default class GitTabView extends React.Component {
   rememberFocus(event) {
     let currentFocus = null;
 
-    if (this.refStagingView) {
-      currentFocus = this.refStagingView.rememberFocus(event);
-    }
+    currentFocus = this.props.refStagingView.map(view => view.rememberFocus(event)).getOr(null);
 
-    if (!currentFocus && this.refCommitController) {
-      currentFocus = this.refCommitController.rememberFocus(event);
+    if (!currentFocus) {
+      currentFocus = this.refCommitController.map(controller => controller.rememberFocus(event)).getOr(null);
     }
 
     return currentFocus;
   }
 
   setFocus(focus) {
-    if (this.refStagingView) {
-      if (this.refStagingView.setFocus(focus)) {
-        return true;
-      }
+    if (this.props.refStagingView.map(view => view.setFocus(focus)).getOr(false)) {
+      return true;
     }
 
-    if (this.refCommitController) {
-      if (this.refCommitController.setFocus(focus)) {
-        return true;
-      }
+    if (this.refCommitController.map(controller => controller.setFocus(focus)).getOr(false)) {
+      return true;
     }
 
     return false;
   }
 
   blur() {
-    this.props.workspace.getActivePane().activate();
+    this.props.workspace.getCenter().activate();
   }
 
   async advanceFocus(evt) {
     // The commit controller manages its own focus
-    if (this.refCommitController.hasFocus()) { return; }
-    if (await this.refStagingView.activateNextList()) {
+    if (this.refCommitController.map(c => c.hasFocus()).getOr(false)) {
+      return;
+    }
+
+    if (await this.props.refStagingView.map(view => view.activateNextList()).getOr(false)) {
       evt.stopPropagation();
     } else {
-      if (this.refCommitController.setFocus(GitTabView.focus.EDITOR)) {
+      if (this.refCommitController.map(c => c.setFocus(GitTabView.focus.EDITOR)).getOr(false)) {
         evt.stopPropagation();
       }
     }
   }
 
   async retreatFocus(evt) {
-    const stagingView = this.refStagingView;
-    const commitController = this.refCommitController;
-
-    if (commitController.hasFocus()) {
+    if (this.refCommitController.map(c => c.hasFocus()).getOr(false)) {
       // if the commit editor is focused, focus the last staging view list
-      if (commitController.hasFocusEditor() && await stagingView.activateLastList()) {
+      if (this.refCommitController.map(c => c.hasFocusEditor()).getOr(false) &&
+          await this.props.refStagingView.map(view => view.activateLastList()).getOr(null)
+      ) {
         this.setFocus(GitTabView.focus.STAGING);
         evt.stopPropagation();
       }
-    } else {
-      await stagingView.activatePreviousList();
+    } else if (await this.props.refStagingView.map(c => c.activatePreviousList()).getOr(null)) {
       evt.stopPropagation();
     }
   }
 
   async focusAndSelectStagingItem(filePath, stagingStatus) {
-    await this.refStagingView.quietlySelectItem(filePath, stagingStatus);
+    await this.quietlySelectItem(filePath, stagingStatus);
     this.setFocus(GitTabView.focus.STAGING);
   }
 
-  hasFocus() {
-    return this.refRoot.contains(document.activeElement);
+  quietlySelectItem(filePath, stagingStatus) {
+    return this.props.refStagingView.map(view => view.quietlySelectItem(filePath, stagingStatus)).getOr(false);
   }
 
-  quietlySelectItem(filePath, stagingStatus) {
-    return this.refStagingView.quietlySelectItem(filePath, stagingStatus);
+  hasFocus() {
+    return this.props.refRoot.map(root => root.contains(document.activeElement)).getOr(false);
   }
 }

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -739,6 +739,9 @@ export default class StagingView extends React.Component {
 
       const newEvent = new MouseEvent(event.type, event);
       requestAnimationFrame(() => {
+        if (!event.target.parentNode) {
+          return;
+        }
         event.target.parentNode.dispatchEvent(newEvent);
       });
     }

--- a/lib/views/staging-view.js
+++ b/lib/views/staging-view.js
@@ -12,6 +12,7 @@ import ObserveModel from './observe-model';
 import MergeConflictListItemView from './merge-conflict-list-item-view';
 import CompositeListSelection from '../models/composite-list-selection';
 import ResolutionProgress from '../models/conflicts/resolution-progress';
+import RefHolder from '../models/ref-holder';
 import FilePatchController from '../controllers/file-patch-controller';
 import Commands, {Command} from '../atom/commands';
 import {autobind} from '../helpers';
@@ -114,7 +115,7 @@ export default class StagingView extends React.Component {
 
     this.mouseSelectionInProgress = false;
     this.listElementsByItem = new WeakMap();
-    this.refRoot = null;
+    this.refRoot = new RefHolder();
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -185,7 +186,7 @@ export default class StagingView extends React.Component {
 
     return (
       <div
-        ref={c => { this.refRoot = c; }}
+        ref={this.refRoot.setter}
         className={`github-StagingView ${this.state.selection.getActiveListKey()}-changes-focused`}
         tabIndex="-1">
         {this.renderCommands()}
@@ -805,12 +806,12 @@ export default class StagingView extends React.Component {
   }
 
   rememberFocus(event) {
-    return this.refRoot.contains(event.target) ? StagingView.focus.STAGING : null;
+    return this.refRoot.map(root => root.contains(event.target)).getOr(false) ? StagingView.focus.STAGING : null;
   }
 
   setFocus(focus) {
     if (focus === StagingView.focus.STAGING) {
-      this.refRoot.focus();
+      this.refRoot.map(root => root.focus());
       return true;
     }
 
@@ -818,6 +819,6 @@ export default class StagingView extends React.Component {
   }
 
   hasFocus() {
-    return this.refRoot.contains(document.activeElement);
+    return this.refRoot.map(root => root.contains(document.activeElement)).getOr(false);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -194,6 +194,100 @@
         "samsam": "1.3.0"
       }
     },
+    "@smashwilson/atom-mocha-test-runner": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@smashwilson/atom-mocha-test-runner/-/atom-mocha-test-runner-1.2.1.tgz",
+      "integrity": "sha512-6t223PNmz1jYbyYcIeFB3s+wDY+hYNV+UFBDV2LokWBHqJ4VQwMYJCCXTFx+zHod3b5H4talxx4U908gotamJw==",
+      "dev": true,
+      "requires": {
+        "etch": "^0.8.0",
+        "grim": "^2.0.1",
+        "less": "^3.7.1",
+        "mocha": "^5.2.0",
+        "tmp": "0.0.31"
+      },
+      "dependencies": {
+        "browser-stdout": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+          "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "growl": {
+          "version": "1.10.5",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+          "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+          "dev": true
+        },
+        "less": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/less/-/less-3.8.1.tgz",
+          "integrity": "sha512-8HFGuWmL3FhQR0aH89escFNBQH/nEiYPP2ltDFdQw2chE28Yx2E3lhAIq9Y2saYwLSwa699s4dBVEfCY8Drf7Q==",
+          "dev": true,
+          "requires": {
+            "clone": "^2.1.2",
+            "errno": "^0.1.1",
+            "graceful-fs": "^4.1.2",
+            "image-size": "~0.5.0",
+            "mime": "^1.4.1",
+            "mkdirp": "^0.5.0",
+            "promise": "^7.1.1",
+            "request": "^2.83.0",
+            "source-map": "~0.6.0"
+          }
+        },
+        "mocha": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+          "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+          "dev": true,
+          "requires": {
+            "browser-stdout": "1.3.1",
+            "commander": "2.15.1",
+            "debug": "3.1.0",
+            "diff": "3.5.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "growl": "1.10.5",
+            "he": "1.1.1",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "supports-color": "5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "@smashwilson/enzyme-adapter-react-16": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smashwilson/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.2.tgz",
@@ -443,55 +537,6 @@
       "integrity": "sha1-OcgHq8H9WqZDqvCut8DqE3j+Y1Y=",
       "requires": {
         "babel-core": "6.x"
-      }
-    },
-    "atom-mocha-test-runner": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/atom-mocha-test-runner/-/atom-mocha-test-runner-1.2.0.tgz",
-      "integrity": "sha1-qPZQm40pqAn8tv9H8FiEthLNxqk=",
-      "dev": true,
-      "requires": {
-        "etch": "^0.8.0",
-        "grim": "^2.0.1",
-        "less": "^2.7.1",
-        "mocha": "^3.0.0",
-        "tmp": "0.0.31"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
       }
     },
     "aws-sign2": {
@@ -1675,12 +1720,6 @@
       "integrity": "sha1-ewl1dPjj6tYG+0Zk5krf3aKYGpM=",
       "dev": true
     },
-    "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-      "dev": true
-    },
     "bser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
@@ -1942,6 +1981,12 @@
         }
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1987,15 +2032,6 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "~1.0.0"
-      }
-    },
-    "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": ">= 1.0.0"
       }
     },
     "commondir": {
@@ -3408,12 +3444,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
     "graphql": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
@@ -4303,16 +4333,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -4323,12 +4343,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
     },
     "json5": {
       "version": "0.5.1",
@@ -4342,13 +4356,6 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true,
-      "optional": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -4408,233 +4415,6 @@
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
     },
-    "less": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/less/-/less-2.7.3.tgz",
-      "integrity": "sha1-zBJg9RyQCp7A2R+2mYE54CUHtjs=",
-      "dev": true,
-      "requires": {
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "mime": "^1.2.11",
-        "mkdirp": "^0.5.0",
-        "promise": "^7.1.1",
-        "request": "2.81.0",
-        "source-map": "^0.5.3"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
-          }
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true,
-          "optional": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "combined-stream": {
-          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha512-JgSRe4l4UzPwpJuxfcPWEK1SCrL4dxNjp1uqrQLMop3QZUVo+hDU8w9BJKA4JPbulTWI+UzrI2UA3tK12yQ6bg==",
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          },
-          "dependencies": {
-            "combined-stream": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "delayed-stream": "~1.0.0"
-              }
-            }
-          }
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true,
-          "optional": true
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
-          },
-          "dependencies": {
-            "combined-stream": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "delayed-stream": "~1.0.0"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.3.4",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-              "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "punycode": "^1.4.1"
-              }
-            }
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "tough-cookie": {
-          "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha512-42UXjmzk88F7URyg9wDV/dlQ7hXtl/SDV6xIMVdDq82cnDGQDyg8mI8xGBPOwpEfbhvrja6cJ8H1wr0xxykBKA==",
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        }
-      }
-    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -4672,51 +4452,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha1-maktZcAnLevoyWtgV7yPv6O+1RE="
     },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "^3.0.0",
-        "lodash._basecreate": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0"
-      }
-    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -4729,34 +4464,11 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -5009,31 +4721,6 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
-      }
-    },
-    "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
-      "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "diff": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "growl": "1.9.2",
-        "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
-        "mkdirp": "0.5.1"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.18.0",
+  "version": "0.18.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -26,9 +26,18 @@
       "dev": true,
       "requires": {
         "@babel/types": "7.0.0-beta.49",
+        "jsesc": "^2.5.1",
         "lodash": "^4.17.5",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        }
       }
     },
     "@babel/helper-function-name": {
@@ -66,8 +75,40 @@
       "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
       "dev": true,
       "requires": {
+        "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@babel/parser": {
@@ -100,8 +141,27 @@
         "@babel/helper-split-export-declaration": "7.0.0-beta.49",
         "@babel/parser": "7.0.0-beta.49",
         "@babel/types": "7.0.0-beta.49",
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
         "invariant": "^2.2.0",
         "lodash": "^4.17.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        }
       }
     },
     "@babel/types": {
@@ -118,7 +178,7 @@
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-      "integrity": "sha1-UkryQNGjYFJ7cwR17PoTRKpUDd4=",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
         "call-me-maybe": "^1.0.1",
@@ -197,6 +257,26 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
       "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
       "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -1543,6 +1623,14 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.x.x"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -1697,6 +1785,15 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
     },
     "chai": {
       "version": "4.1.2",
@@ -1996,6 +2093,24 @@
       "resolved": "https://registry.npmjs.org/cross-unzip/-/cross-unzip-0.0.2.tgz",
       "integrity": "sha1-UYO8R6CVWb78+YzEZXlkmZNZNy8=",
       "dev": true
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.x.x"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.x.x"
+          }
+        }
+      }
     },
     "css-select": {
       "version": "1.2.0",
@@ -2304,6 +2419,14 @@
         "cross-unzip": "0.0.2",
         "rimraf": "^2.5.2",
         "semver": "^5.3.0"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -3040,7 +3163,36 @@
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
+        "cross-spawn": "^4",
         "signal-exit": "^3.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
       }
     },
     "forever-agent": {
@@ -3303,10 +3455,27 @@
       "dev": true,
       "requires": {
         "async": "^1.4.0",
+        "optimist": "^0.6.1",
         "source-map": "^0.4.4",
         "uglify-js": "^2.6"
       },
       "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
+        },
         "source-map": {
           "version": "0.4.4",
           "resolved": false,
@@ -3397,6 +3566,17 @@
         }
       }
     },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
+      }
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -3411,6 +3591,11 @@
       "requires": {
         "deep-equal": "0.2.1"
       }
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -3454,8 +3639,7 @@
     "iconv-lite": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
-      "dev": true
+      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
     },
     "ignore": {
       "version": "3.3.10",
@@ -3885,7 +4069,19 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
+        "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "isstream": {
@@ -3982,7 +4178,19 @@
       "dev": true,
       "requires": {
         "istanbul-lib-coverage": "^2.0.0",
-        "make-dir": "^1.3.0"
+        "make-dir": "^1.3.0",
+        "supports-color": "^5.4.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "istanbul-lib-source-maps": {
@@ -3991,12 +4199,22 @@
       "integrity": "sha512-jenUeC0gMSSMGkvqD9xuNfs3nD7XWeXLhqaIkqHsNZ3DJBWPdlKEydE7Ya5aTgdWjrEQhrCYTv+J606cGC2vuQ==",
       "dev": true,
       "requires": {
+        "debug": "^3.1.0",
         "istanbul-lib-coverage": "^2.0.0",
         "make-dir": "^1.3.0",
         "rimraf": "^2.6.2",
         "source-map": "^0.6.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": false,
@@ -4170,6 +4388,11 @@
       "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
       "dev": true
     },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -4231,6 +4454,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -4555,6 +4779,11 @@
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
       "integrity": "sha1-5AqMTR8UtTaqA+QqU3x6268MIL4=",
       "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -5236,7 +5465,7 @@
         },
         "lru-cache": {
           "version": "4.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "requires": {
             "pseudomap": "^1.0.2",
@@ -5913,9 +6142,9 @@
       }
     },
     "react": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
-      "integrity": "sha1-3lG6V2S1280fkHkDe4Yr0muC/jI=",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.0.tgz",
+      "integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
@@ -5924,9 +6153,9 @@
       }
     },
     "react-dom": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
-      "integrity": "sha1-f4sCI7Ol++IFEWxW3rhd4yaF2tY=",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.0.tgz",
+      "integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
@@ -6263,8 +6492,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
@@ -6322,7 +6550,55 @@
       "integrity": "sha512-5TVnMD3LaeK0GRCyFlsNgJf5Fjg8J8j7VEfsoJESSWZlWRgPIf7IojsBLbTHcg2798JrrRkJ6L3k1+wj4sglgw==",
       "dev": true,
       "requires": {
-        "depd": "1.1.2"
+        "depd": "1.1.2",
+        "request": "2.83.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.35.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.19",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+          "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.35.0"
+          }
+        },
+        "request": {
+          "version": "2.83.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        }
       }
     },
     "require-directory": {
@@ -6374,6 +6650,14 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "requires": {
+        "align-text": "^0.1.1"
+      }
     },
     "rimraf": {
       "version": "2.6.2",
@@ -6675,6 +6959,14 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.x.x"
       }
     },
     "source-map": {
@@ -7325,6 +7617,32 @@
         "yargs": "~3.10.0"
       },
       "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true,
+          "optional": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          }
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        },
         "yargs": {
           "version": "3.10.0",
           "resolved": false,
@@ -7332,6 +7650,8 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
             "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@smashwilson/enzyme-adapter-react-16": "1.0.2",
-    "atom-mocha-test-runner": "1.2.0",
+    "@smashwilson/atom-mocha-test-runner": "1.2.1",
     "babel-plugin-istanbul": "4.1.6",
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",

--- a/test/atom/pane-item.test.js
+++ b/test/atom/pane-item.test.js
@@ -8,6 +8,11 @@ import StubItem from '../../lib/items/stub-item';
 class Component extends React.Component {
   static propTypes = {
     text: PropTypes.string.isRequired,
+    didFocus: PropTypes.func,
+  }
+
+  static defaultProps = {
+    didFocus: () => {},
   }
 
   render() {
@@ -22,6 +27,10 @@ class Component extends React.Component {
 
   getText() {
     return this.props.text;
+  }
+
+  focus() {
+    return this.props.didFocus();
   }
 }
 
@@ -190,6 +199,19 @@ describe('PaneItem', function() {
       calledWith = null;
       await workspace.open('atom-github://pattern/456');
       assert.strictEqual(calledWith, 'atom-github://pattern/456');
+    });
+
+    it('calls focus() on the child item when focus() is called', async function() {
+      const didFocus = sinon.spy();
+      mount(
+        <PaneItem workspace={workspace} uriPattern="atom-github://pattern">
+          {({itemHolder}) => <Component ref={itemHolder.setter} text="a prop" didFocus={didFocus} />}
+        </PaneItem>,
+      );
+      const item = await workspace.open('atom-github://pattern');
+      item.getElement().dispatchEvent(new FocusEvent('focus'));
+
+      assert.isTrue(didFocus.called);
     });
 
     it('removes a child when its pane is destroyed', async function() {

--- a/test/integration/open.test.js
+++ b/test/integration/open.test.js
@@ -81,7 +81,7 @@ describe('opening and closing tabs', function() {
 
     assert.isTrue(wrapper.find('.github-Panel').exists());
     assert.isTrue(atomEnv.workspace.getRightDock().isVisible());
-    assert.isFalse(wrapper.find('.github-Panel[tabIndex]').getDOMNode().contains(document.activeElement));
+    await assert.async.isFalse(wrapper.find('.github-Panel[tabIndex]').getDOMNode().contains(document.activeElement));
 
     await commands.dispatch(workspaceElement, 'github:toggle-git-tab-focus');
     wrapper.update();

--- a/test/models/file-patch.test.js
+++ b/test/models/file-patch.test.js
@@ -17,6 +17,38 @@ function createFilePatch(oldFilePath, newFilePath, status, hunks) {
 }
 
 describe('FilePatch', function() {
+  it('detects executable mode changes', function() {
+    const of0 = new FilePatch.File({path: 'a.txt', mode: '100644'});
+    const nf0 = new FilePatch.File({path: 'a.txt', mode: '100755'});
+    const p0 = new FilePatch.Patch({status: 'modified', hunks: []});
+    const fp0 = new FilePatch(of0, nf0, p0);
+    assert.isTrue(fp0.didChangeExecutableMode());
+
+    const of1 = new FilePatch.File({path: 'a.txt', mode: '100755'});
+    const nf1 = new FilePatch.File({path: 'a.txt', mode: '100644'});
+    const p1 = new FilePatch.Patch({status: 'modified', hunks: []});
+    const fp1 = new FilePatch(of1, nf1, p1);
+    assert.isTrue(fp1.didChangeExecutableMode());
+
+    const of2 = new FilePatch.File({path: 'a.txt', mode: '100755'});
+    const nf2 = new FilePatch.File({path: 'a.txt', mode: '100755'});
+    const p2 = new FilePatch.Patch({status: 'modified', hunks: []});
+    const fp2 = new FilePatch(of2, nf2, p2);
+    assert.isFalse(fp2.didChangeExecutableMode());
+
+    const of3 = FilePatch.File.empty();
+    const nf3 = new FilePatch.File({path: 'a.txt', mode: '100755'});
+    const p3 = new FilePatch.Patch({status: 'modified', hunks: []});
+    const fp3 = new FilePatch(of3, nf3, p3);
+    assert.isFalse(fp3.didChangeExecutableMode());
+
+    const of4 = FilePatch.File.empty();
+    const nf4 = new FilePatch.File({path: 'a.txt', mode: '100755'});
+    const p4 = new FilePatch.Patch({status: 'modified', hunks: []});
+    const fp4 = new FilePatch(of4, nf4, p4);
+    assert.isFalse(fp4.didChangeExecutableMode());
+  });
+
   describe('getStagePatchForLines()', function() {
     it('returns a new FilePatch that applies only the specified lines', function() {
       const filePatch = createFilePatch('a.txt', 'a.txt', 'modified', [

--- a/test/models/ref-holder.test.js
+++ b/test/models/ref-holder.test.js
@@ -71,6 +71,21 @@ describe('RefHolder', function() {
     });
   });
 
+  describe('getOr', function() {
+    it("returns the RefHolder's value if it is non-empty", function() {
+      const h = new RefHolder();
+      h.setter(1234);
+
+      assert.strictEqual(h.getOr(5678), 1234);
+    });
+
+    it('returns its argument if the RefHolder is empty', function() {
+      const h = new RefHolder();
+
+      assert.strictEqual(h.getOr(5678), 5678);
+    });
+  });
+
   it('notifies subscribers when it becomes available', function() {
     const h = new RefHolder();
     const callback = sinon.spy();
@@ -95,6 +110,37 @@ describe('RefHolder', function() {
     const callback = sinon.spy();
     sub = h.observe(callback);
     assert.isTrue(callback.calledWith(12));
+  });
+
+  it('does not notify subscribers when it is assigned the same value', function() {
+    const h = new RefHolder();
+    h.setter(12);
+
+    const callback = sinon.spy();
+    sub = h.observe(callback);
+
+    callback.resetHistory();
+    h.setter(12);
+    assert.isFalse(callback.called);
+  });
+
+  it('does not notify subscribers when it becomes empty', function() {
+    const h = new RefHolder();
+    h.setter(12);
+    assert.isFalse(h.isEmpty());
+
+    const callback = sinon.spy();
+    sub = h.observe(callback);
+
+    callback.resetHistory();
+    h.setter(null);
+    assert.isTrue(h.isEmpty());
+    assert.isFalse(callback.called);
+
+    callback.resetHistory();
+    h.setter(undefined);
+    assert.isTrue(h.isEmpty());
+    assert.isFalse(callback.called);
   });
 
   it('resolves a promise when it becomes available', async function() {

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,4 +1,4 @@
-import {createRunner} from 'atom-mocha-test-runner';
+import {createRunner} from '@smashwilson/atom-mocha-test-runner';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import path from 'path';

--- a/test/views/commit-view.test.js
+++ b/test/views/commit-view.test.js
@@ -321,13 +321,128 @@ describe('CommitView', function() {
     assert.isTrue(abortMerge.calledOnce);
   });
 
+  it('detects when the component has focus', function() {
+    const wrapper = mount(app);
+    const rootElement = wrapper.find('.github-CommitView').getDOMNode();
+
+    sinon.stub(rootElement, 'contains').returns(true);
+    assert.isTrue(wrapper.instance().hasFocus());
+
+    rootElement.contains.returns(false);
+    assert.isFalse(wrapper.instance().hasFocus());
+
+    rootElement.contains.returns(true);
+    wrapper.instance().refRoot.setter(null);
+    assert.isFalse(wrapper.instance().hasFocus());
+  });
+
+  it('detects when the editor has focus', function() {
+    const wrapper = mount(app);
+
+    const editorNode = wrapper.find('atom-text-editor').getDOMNode();
+    sinon.stub(editorNode, 'contains').returns(true);
+    assert.isTrue(wrapper.instance().hasFocusEditor());
+
+    editorNode.contains.returns(false);
+    assert.isFalse(wrapper.instance().hasFocusEditor());
+
+    editorNode.contains.returns(true);
+    wrapper.instance().refEditor.setter(null);
+    assert.isFalse(wrapper.instance().hasFocusEditor());
+  });
+
+  it('remembers the current focus', function() {
+    const wrapper = mount(React.cloneElement(app, {isMerging: true}));
+    wrapper.instance().toggleCoAuthorInput();
+    wrapper.update();
+
+    const foci = [
+      ['atom-text-editor', CommitView.focus.EDITOR],
+      ['.github-CommitView-abortMerge', CommitView.focus.ABORT_MERGE_BUTTON],
+      ['.github-CommitView-commit', CommitView.focus.COMMIT_BUTTON],
+      ['.github-CommitView-coAuthorEditor input', CommitView.focus.COAUTHOR_INPUT],
+    ];
+    for (const [selector, focus] of foci) {
+      const event = {target: wrapper.find(selector).getDOMNode()};
+      assert.strictEqual(wrapper.instance().rememberFocus(event), focus);
+    }
+
+    assert.isNull(wrapper.instance().rememberFocus({target: document.body}));
+
+    const holders = [
+      'refEditor', 'refAbortMergeButton', 'refCommitButton', 'refCoAuthorSelect',
+    ].map(ivar => wrapper.instance()[ivar]);
+    for (const holder of holders) {
+      holder.setter(null);
+    }
+    assert.isNull(wrapper.instance().rememberFocus({target: document.body}));
+  });
+
   describe('restoring focus', function() {
+    it('to the editor', function() {
+      const wrapper = mount(app);
+      sinon.spy(wrapper.find('atom-text-editor').getDOMNode(), 'focus');
+
+      assert.isTrue(wrapper.instance().setFocus(CommitView.focus.EDITOR));
+      assert.isTrue(wrapper.find('atom-text-editor').getDOMNode().focus.called);
+    });
+
+    it('to the abort merge button', function() {
+      const wrapper = mount(React.cloneElement(app, {isMerging: true}));
+      sinon.spy(wrapper.find('.github-CommitView-abortMerge').getDOMNode(), 'focus');
+
+      assert.isTrue(wrapper.instance().setFocus(CommitView.focus.ABORT_MERGE_BUTTON));
+      assert.isTrue(wrapper.find('.github-CommitView-abortMerge').getDOMNode().focus.called);
+    });
+
     it('to the commit button', function() {
       const wrapper = mount(app);
-      sinon.spy(wrapper.instance().refCommitButton.get(), 'focus');
+      sinon.spy(wrapper.find('.github-CommitView-commit').getDOMNode(), 'focus');
 
-      wrapper.instance().setFocus(CommitView.focus.COMMIT_BUTTON);
-      assert.isTrue(wrapper.instance().refCommitButton.get().focus.called);
+      assert.isTrue(wrapper.instance().setFocus(CommitView.focus.COMMIT_BUTTON));
+      assert.isTrue(wrapper.find('.github-CommitView-commit').getDOMNode().focus.called);
+    });
+
+    it('to the co-author input', function() {
+      const wrapper = mount(app);
+      wrapper.instance().toggleCoAuthorInput();
+
+      sinon.spy(wrapper.update().find('.github-CommitView-coAuthorEditor input').getDOMNode(), 'focus');
+
+      assert.isTrue(wrapper.instance().setFocus(CommitView.focus.COAUTHOR_INPUT));
+      assert.isTrue(wrapper.find('.github-CommitView-coAuthorEditor input').getDOMNode().focus.called);
+    });
+
+    it('with an unrecognized symbol', function() {
+      const wrapper = mount(app);
+      assert.isFalse(wrapper.instance().setFocus(Symbol('lolno')));
+    });
+
+    it('when the named element is no longer rendered', function() {
+      const wrapper = mount(app);
+      sinon.spy(wrapper.find('atom-text-editor').getDOMNode(), 'focus');
+
+      assert.isTrue(wrapper.instance().setFocus(CommitView.focus.ABORT_MERGE_BUTTON));
+      assert.strictEqual(wrapper.find('atom-text-editor').getDOMNode().focus.callCount, 1);
+
+      assert.isTrue(wrapper.instance().setFocus(CommitView.focus.COAUTHOR_INPUT));
+      assert.strictEqual(wrapper.find('atom-text-editor').getDOMNode().focus.callCount, 2);
+    });
+
+    it('when refs have not been assigned yet', function() {
+      const wrapper = mount(app);
+
+      // Simulate an unmounted component by clearing out RefHolders manually.
+      const holders = [
+        'refEditor', 'refAbortMergeButton', 'refCommitButton', 'refCoAuthorSelect',
+      ].map(ivar => wrapper.instance()[ivar]);
+      for (const holder of holders) {
+        holder.setter(null);
+      }
+
+      for (const focusKey of Object.keys(CommitView.focus)) {
+        assert.isFalse(wrapper.instance().setFocus(CommitView.focus[focusKey]));
+      }
     });
   });
 });

--- a/test/views/git-tab-view.test.js
+++ b/test/views/git-tab-view.test.js
@@ -1,0 +1,226 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+
+import {cloneRepository, buildRepository} from '../helpers';
+import GitTabView from '../../lib/views/git-tab-view';
+import {gitTabViewProps} from '../fixtures/props/git-tab-props';
+
+describe('GitTabView', function() {
+  let atomEnv, repository;
+
+  beforeEach(async function() {
+    atomEnv = global.buildAtomEnvironment();
+    repository = await buildRepository(await cloneRepository());
+  });
+
+  afterEach(function() {
+    atomEnv.destroy();
+  });
+
+  async function buildApp(overrides = {}) {
+    return <GitTabView {...await gitTabViewProps(atomEnv, repository, overrides)} />;
+  }
+
+  it('remembers the current focus', async function() {
+    const wrapper = mount(await buildApp());
+
+    assert.strictEqual(
+      wrapper.instance().rememberFocus({target: wrapper.find('div.github-StagingView').getDOMNode()}),
+      GitTabView.focus.STAGING,
+    );
+
+    assert.strictEqual(
+      wrapper.instance().rememberFocus({target: wrapper.find('atom-text-editor').getDOMNode()}),
+      GitTabView.focus.EDITOR,
+    );
+
+    assert.isNull(wrapper.instance().rememberFocus({target: document.body}));
+  });
+
+  it('sets a new focus', async function() {
+    const wrapper = mount(await buildApp());
+    const stagingElement = wrapper.find('div.github-StagingView').getDOMNode();
+    const editorElement = wrapper.find('atom-text-editor').getDOMNode();
+
+    sinon.spy(stagingElement, 'focus');
+    assert.isTrue(wrapper.instance().setFocus(GitTabView.focus.STAGING));
+    assert.isTrue(stagingElement.focus.called);
+
+    sinon.spy(editorElement, 'focus');
+    assert.isTrue(wrapper.instance().setFocus(GitTabView.focus.EDITOR));
+    assert.isTrue(editorElement.focus.called);
+
+    assert.isFalse(wrapper.instance().setFocus(Symbol('nah')));
+  });
+
+  it('blurs by focusing the workspace center', async function() {
+    const editor = await atomEnv.workspace.open(__filename);
+    atomEnv.workspace.getLeftDock().activate();
+    assert.notStrictEqual(atomEnv.workspace.getActivePaneItem(), editor);
+
+    const wrapper = shallow(await buildApp());
+    wrapper.instance().blur();
+
+    assert.strictEqual(atomEnv.workspace.getActivePaneItem(), editor);
+  });
+
+  it('no-ops focus management methods when refs are unavailable', async function() {
+    const wrapper = shallow(await buildApp());
+    assert.isNull(wrapper.instance().rememberFocus({}));
+    assert.isFalse(wrapper.instance().setFocus(GitTabView.focus.EDITOR));
+  });
+
+  describe('advanceFocus', function() {
+    let wrapper, event, commitController, stagingView;
+
+    beforeEach(async function() {
+      wrapper = mount(await buildApp());
+
+      commitController = wrapper.instance().refCommitController.get();
+      stagingView = wrapper.prop('refStagingView').get();
+
+      event = {stopPropagation: sinon.spy()};
+    });
+
+    it('does nothing if the commit controller has focus', async function() {
+      sinon.stub(commitController, 'hasFocus').returns(true);
+      sinon.spy(stagingView, 'activateNextList');
+
+      await wrapper.instance().advanceFocus(event);
+
+      assert.isFalse(event.stopPropagation.called);
+      assert.isFalse(stagingView.activateNextList.called);
+    });
+
+    it('activates the next staging view list and stops', async function() {
+      sinon.stub(stagingView, 'activateNextList').resolves(true);
+      sinon.spy(commitController, 'setFocus');
+
+      await wrapper.instance().advanceFocus(event);
+
+      assert.isTrue(stagingView.activateNextList.called);
+      assert.isTrue(event.stopPropagation.called);
+      assert.isFalse(commitController.setFocus.called);
+    });
+
+    it('moves focus to the commit message editor from the end of the staging view', async function() {
+      sinon.stub(stagingView, 'activateNextList').resolves(false);
+      sinon.stub(commitController, 'setFocus').returns(true);
+
+      await wrapper.instance().advanceFocus(event);
+
+      assert.isTrue(commitController.setFocus.calledWith(GitTabView.focus.EDITOR));
+      assert.isTrue(event.stopPropagation.called);
+    });
+
+    it('does nothing if refs are unavailable', async function() {
+      wrapper.instance().refCommitController.setter(null);
+
+      await wrapper.instance().advanceFocus(event);
+
+      assert.isFalse(event.stopPropagation.called);
+    });
+  });
+
+  describe('retreatFocus', function() {
+    let wrapper, event, commitController, stagingView;
+
+    beforeEach(async function() {
+      wrapper = mount(await buildApp());
+
+      commitController = wrapper.instance().refCommitController.get();
+      stagingView = wrapper.prop('refStagingView').get();
+
+      event = {stopPropagation: sinon.spy()};
+    });
+
+    it('focuses the last staging list if the commit editor has focus', async function() {
+      sinon.stub(commitController, 'hasFocus').returns(true);
+      sinon.stub(commitController, 'hasFocusEditor').returns(true);
+      sinon.stub(stagingView, 'activateLastList').resolves(true);
+
+      await wrapper.instance().retreatFocus(event);
+
+      assert.isTrue(stagingView.activateLastList.called);
+      assert.isTrue(event.stopPropagation.called);
+    });
+
+    it('does nothing if the commit controller has focus but not in its editor', async function() {
+      sinon.stub(commitController, 'hasFocus').returns(true);
+      sinon.stub(commitController, 'hasFocusEditor').returns(false);
+      sinon.spy(stagingView, 'activateLastList');
+      sinon.spy(stagingView, 'activatePreviousList');
+
+      await wrapper.instance().retreatFocus(event);
+
+      assert.isFalse(stagingView.activateLastList.called);
+      assert.isFalse(stagingView.activatePreviousList.called);
+      assert.isFalse(event.stopPropagation.called);
+    });
+
+    it('activates the previous staging list and stops', async function() {
+      sinon.stub(commitController, 'hasFocus').returns(false);
+      sinon.stub(stagingView, 'activatePreviousList').resolves(true);
+
+      await wrapper.instance().retreatFocus(event);
+
+      assert.isTrue(stagingView.activatePreviousList.called);
+      assert.isTrue(event.stopPropagation.called);
+    });
+
+    it('does nothing if refs are unavailable', async function() {
+      wrapper.instance().refCommitController.setter(null);
+      wrapper.prop('refStagingView').setter(null);
+
+      await wrapper.instance().retreatFocus(event);
+
+      assert.isFalse(event.stopPropagation.called);
+    });
+  });
+
+  it('selects a staging item', async function() {
+    const wrapper = mount(await buildApp({
+      unstagedChanges: [{filePath: 'aaa.txt', status: 'modified'}],
+    }));
+
+    const stagingView = wrapper.prop('refStagingView').get();
+    sinon.spy(stagingView, 'quietlySelectItem');
+    sinon.spy(stagingView, 'setFocus');
+
+    await wrapper.instance().quietlySelectItem('aaa.txt', 'unstaged');
+
+    assert.isTrue(stagingView.quietlySelectItem.calledWith('aaa.txt', 'unstaged'));
+    assert.isFalse(stagingView.setFocus.calledWith(GitTabView.focus.STAGING));
+  });
+
+  it('selects a staging item and focuses itself', async function() {
+    const wrapper = mount(await buildApp({
+      unstagedChanges: [{filePath: 'aaa.txt', status: 'modified'}],
+    }));
+
+    const stagingView = wrapper.prop('refStagingView').get();
+    sinon.spy(stagingView, 'quietlySelectItem');
+    sinon.spy(stagingView, 'setFocus');
+
+    await wrapper.instance().focusAndSelectStagingItem('aaa.txt', 'unstaged');
+
+    assert.isTrue(stagingView.quietlySelectItem.calledWith('aaa.txt', 'unstaged'));
+    assert.isTrue(stagingView.setFocus.calledWith(GitTabView.focus.STAGING));
+  });
+
+  it('detects when it has focus', async function() {
+    const wrapper = mount(await buildApp());
+    const rootElement = wrapper.prop('refRoot').get();
+    sinon.stub(rootElement, 'contains');
+
+    rootElement.contains.returns(true);
+    assert.isTrue(wrapper.instance().hasFocus());
+
+    rootElement.contains.returns(false);
+    assert.isFalse(wrapper.instance().hasFocus());
+
+    rootElement.contains.returns(true);
+    wrapper.prop('refRoot').setter(null);
+    assert.isFalse(wrapper.instance().hasFocus());
+  });
+});

--- a/test/views/staging-view.test.js
+++ b/test/views/staging-view.test.js
@@ -740,4 +740,49 @@ describe('StagingView', function() {
       });
     });
   }
+
+  it('remembers the current focus', function() {
+    const wrapper = mount(app);
+    const rootElement = wrapper.find('.github-StagingView').getDOMNode();
+
+    assert.strictEqual(wrapper.instance().rememberFocus({target: rootElement}), StagingView.focus.STAGING);
+    assert.isNull(wrapper.instance().rememberFocus({target: document.body}));
+
+    wrapper.instance().refRoot.setter(null);
+    assert.isNull(wrapper.instance().rememberFocus({target: rootElement}));
+  });
+
+  it('sets a new focus', function() {
+    const wrapper = mount(app);
+    const rootElement = wrapper.find('.github-StagingView').getDOMNode();
+
+    sinon.stub(rootElement, 'focus');
+
+    assert.isFalse(wrapper.instance().setFocus(Symbol('nope')));
+    assert.isFalse(rootElement.focus.called);
+
+    assert.isTrue(wrapper.instance().setFocus(StagingView.focus.STAGING));
+    assert.isTrue(rootElement.focus.called);
+
+    wrapper.instance().refRoot.setter(null);
+    rootElement.focus.resetHistory();
+    assert.isTrue(wrapper.instance().setFocus(StagingView.focus.STAGING));
+    assert.isFalse(rootElement.focus.called);
+  });
+
+  it('detects when the component does have focus', function() {
+    const wrapper = mount(app);
+    const rootElement = wrapper.find('.github-StagingView').getDOMNode();
+    sinon.stub(rootElement, 'contains');
+
+    rootElement.contains.returns(true);
+    assert.isTrue(wrapper.instance().hasFocus());
+
+    rootElement.contains.returns(false);
+    assert.isFalse(wrapper.instance().hasFocus());
+
+    rootElement.contains.returns(true);
+    wrapper.instance().refRoot.setter(null);
+    assert.isFalse(wrapper.instance().hasFocus());
+  });
 });


### PR DESCRIPTION
Backport bugfix pull requests from the 0.19.0 release to 0.18-releases. This includes the following pull requests:

* #1639: Proxy items need to be more resilient to unexpected properties
* #1637: Use my fork of atom-mocha-test-runner
* #1635: Undo an initial commit
* #1634: Don't attempt to stage or unstage with no selection
* #1633: Don't detect executable mode changes on added or deleted files
* #1632: Detached DOM nodes have no parents
* #1631: Prevent race conditions in focus management code (0.18-releases)
* #1629: Activate the git tab on item activation
* #1627: 🐛 Fix default dir for git repo init