### PR TITLE
send GitHub username with usage metrics

### DIFF
--- a/lib/containers/__generated__/currentPullRequestContainerQuery.graphql.js
+++ b/lib/containers/__generated__/currentPullRequestContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 5821e0667d3f593dc75d2c4ac34985ca
+ * @relayHash 40b7bc7d6c17a665a1fe95116c6f6719
  */
 
 /* eslint-disable */
@@ -27,10 +27,6 @@ export type currentPullRequestContainerQueryResponse = {|
       |}
     |}
   |}
-|};
-export type currentPullRequestContainerQuery = {|
-  variables: currentPullRequestContainerQueryVariables,
-  response: currentPullRequestContainerQueryResponse,
 |};
 */
 

--- a/lib/containers/__generated__/issueishSearchContainerQuery.graphql.js
+++ b/lib/containers/__generated__/issueishSearchContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 4f7294887e96b0a41dd57f0f3164f765
+ * @relayHash 39c0b6593d96d2f8436bff9ca0d239c4
  */
 
 /* eslint-disable */
@@ -21,10 +21,6 @@ export type issueishSearchContainerQueryResponse = {|
       +$fragmentRefs: issueishListController_results$ref
     |}>,
   |}
-|};
-export type issueishSearchContainerQuery = {|
-  variables: issueishSearchContainerQueryVariables,
-  response: issueishSearchContainerQueryResponse,
 |};
 */
 

--- a/lib/containers/__generated__/remoteContainerQuery.graphql.js
+++ b/lib/containers/__generated__/remoteContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 982797d241da7600c6e95299dff83585
+ * @relayHash 7fbd7496eff90270ea34a304108aa100
  */
 
 /* eslint-disable */
@@ -21,10 +21,6 @@ export type remoteContainerQueryResponse = {|
       +name: string,
     |},
   |}
-|};
-export type remoteContainerQuery = {|
-  variables: remoteContainerQueryVariables,
-  response: remoteContainerQueryResponse,
 |};
 */
 

--- a/lib/controllers/__generated__/issueTimelineControllerQuery.graphql.js
+++ b/lib/controllers/__generated__/issueTimelineControllerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash f743b45dcda2d5c1204b416ba482392d
+ * @relayHash 11a080534b1e9e618daa153d559f5efc
  */
 
 /* eslint-disable */
@@ -19,10 +19,6 @@ export type issueTimelineControllerQueryResponse = {|
   +resource: ?{|
     +$fragmentRefs: issueTimelineController_issue$ref
   |}
-|};
-export type issueTimelineControllerQuery = {|
-  variables: issueTimelineControllerQueryVariables,
-  response: issueTimelineControllerQueryResponse,
 |};
 */
 
@@ -234,56 +230,42 @@ v4 = {
   "args": null,
   "storageKey": null
 },
-v5 = [
-  {
-    "kind": "Variable",
-    "name": "after",
-    "variableName": "timelineCursor",
-    "type": "String"
-  },
-  {
-    "kind": "Variable",
-    "name": "first",
-    "variableName": "timelineCount",
-    "type": "Int"
-  }
-],
-v6 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "login",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "avatarUrl",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "number",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v10 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "user",
@@ -292,7 +274,7 @@ v11 = {
   "concreteType": "User",
   "plural": false,
   "selections": [
-    v6,
+    v5,
     v3
   ]
 };
@@ -373,7 +355,20 @@ return {
                 "alias": null,
                 "name": "timeline",
                 "storageKey": null,
-                "args": v5,
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "after",
+                    "variableName": "timelineCursor",
+                    "type": "String"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "first",
+                    "variableName": "timelineCount",
+                    "type": "Int"
+                  }
+                ],
                 "concreteType": "IssueTimelineConnection",
                 "plural": false,
                 "selections": [
@@ -457,8 +452,8 @@ return {
                                 "plural": false,
                                 "selections": [
                                   v2,
+                                  v5,
                                   v6,
-                                  v7,
                                   v3
                                 ]
                               },
@@ -481,7 +476,7 @@ return {
                                     "concreteType": "Repository",
                                     "plural": false,
                                     "selections": [
-                                      v8,
+                                      v7,
                                       {
                                         "kind": "LinkedField",
                                         "alias": null,
@@ -492,7 +487,7 @@ return {
                                         "plural": false,
                                         "selections": [
                                           v2,
-                                          v6,
+                                          v5,
                                           v3
                                         ]
                                       },
@@ -511,8 +506,8 @@ return {
                                     "kind": "InlineFragment",
                                     "type": "PullRequest",
                                     "selections": [
+                                      v8,
                                       v9,
-                                      v10,
                                       v4,
                                       {
                                         "kind": "ScalarField",
@@ -527,8 +522,8 @@ return {
                                     "kind": "InlineFragment",
                                     "type": "Issue",
                                     "selections": [
+                                      v8,
                                       v9,
-                                      v10,
                                       v4,
                                       {
                                         "kind": "ScalarField",
@@ -557,8 +552,8 @@ return {
                                 "plural": false,
                                 "selections": [
                                   v2,
-                                  v7,
                                   v6,
+                                  v5,
                                   v3
                                 ]
                               },
@@ -592,9 +587,9 @@ return {
                                 "concreteType": "GitActor",
                                 "plural": false,
                                 "selections": [
-                                  v8,
-                                  v11,
-                                  v7
+                                  v7,
+                                  v10,
+                                  v6
                                 ]
                               },
                               {
@@ -606,9 +601,9 @@ return {
                                 "concreteType": "GitActor",
                                 "plural": false,
                                 "selections": [
-                                  v8,
                                   v7,
-                                  v11
+                                  v6,
+                                  v10
                                 ]
                               },
                               {
@@ -658,7 +653,20 @@ return {
                 "kind": "LinkedHandle",
                 "alias": null,
                 "name": "timeline",
-                "args": v5,
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "after",
+                    "variableName": "timelineCursor",
+                    "type": "String"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "first",
+                    "variableName": "timelineCount",
+                    "type": "Int"
+                  }
+                ],
                 "handle": "connection",
                 "key": "IssueTimelineController_timeline",
                 "filters": null

--- a/lib/controllers/__generated__/prTimelineControllerQuery.graphql.js
+++ b/lib/controllers/__generated__/prTimelineControllerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 1a3787f5d7fae81fbb3897db8f0bae46
+ * @relayHash af853f1ab5f7d7727fafd178050ec61a
  */
 
 /* eslint-disable */
@@ -19,10 +19,6 @@ export type prTimelineControllerQueryResponse = {|
   +resource: ?{|
     +$fragmentRefs: prTimelineController_pullRequest$ref
   |}
-|};
-export type prTimelineControllerQuery = {|
-  variables: prTimelineControllerQueryVariables,
-  response: prTimelineControllerQueryResponse,
 |};
 */
 
@@ -348,66 +344,52 @@ v7 = {
   "plural": false,
   "selections": v6
 },
-v8 = [
-  {
-    "kind": "Variable",
-    "name": "after",
-    "variableName": "timelineCursor",
-    "type": "String"
-  },
-  {
-    "kind": "Variable",
-    "name": "first",
-    "variableName": "timelineCount",
-    "type": "Int"
-  }
-],
-v9 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "avatarUrl",
   "args": null,
   "storageKey": null
 },
-v10 = [
+v9 = [
   v2,
   v5,
-  v9,
+  v8,
   v3
 ],
-v11 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v12 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "number",
   "args": null,
   "storageKey": null
 },
-v13 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v14 = {
+v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "oid",
   "args": null,
   "storageKey": null
 },
-v15 = [
-  v14,
+v14 = [
+  v13,
   v3
 ],
-v16 = {
+v15 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "commit",
@@ -415,29 +397,29 @@ v16 = {
   "args": null,
   "concreteType": "Commit",
   "plural": false,
-  "selections": v15
+  "selections": v14
 },
-v17 = {
+v16 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "bodyHTML",
   "args": null,
   "storageKey": null
 },
-v18 = {
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "createdAt",
   "args": null,
   "storageKey": null
 },
-v19 = [
+v18 = [
   v2,
-  v9,
+  v8,
   v5,
   v3
 ],
-v20 = {
+v19 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "actor",
@@ -445,9 +427,9 @@ v20 = {
   "args": null,
   "concreteType": null,
   "plural": false,
-  "selections": v19
+  "selections": v18
 },
-v21 = {
+v20 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "user",
@@ -567,7 +549,20 @@ return {
                 "alias": null,
                 "name": "timeline",
                 "storageKey": null,
-                "args": v8,
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "after",
+                    "variableName": "timelineCursor",
+                    "type": "String"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "first",
+                    "variableName": "timelineCount",
+                    "type": "Int"
+                  }
+                ],
                 "concreteType": "PullRequestTimelineConnection",
                 "plural": false,
                 "selections": [
@@ -649,7 +644,7 @@ return {
                                 "args": null,
                                 "concreteType": null,
                                 "plural": false,
-                                "selections": v10
+                                "selections": v9
                               },
                               {
                                 "kind": "LinkedField",
@@ -670,7 +665,7 @@ return {
                                     "concreteType": "Repository",
                                     "plural": false,
                                     "selections": [
-                                      v11,
+                                      v10,
                                       v7,
                                       v3,
                                       {
@@ -687,8 +682,8 @@ return {
                                     "kind": "InlineFragment",
                                     "type": "PullRequest",
                                     "selections": [
+                                      v11,
                                       v12,
-                                      v13,
                                       v4,
                                       {
                                         "kind": "ScalarField",
@@ -703,8 +698,8 @@ return {
                                     "kind": "InlineFragment",
                                     "type": "Issue",
                                     "selections": [
+                                      v11,
                                       v12,
-                                      v13,
                                       v4,
                                       {
                                         "kind": "ScalarField",
@@ -723,7 +718,7 @@ return {
                             "kind": "InlineFragment",
                             "type": "CommitCommentThread",
                             "selections": [
-                              v16,
+                              v15,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -767,11 +762,11 @@ return {
                                             "args": null,
                                             "concreteType": null,
                                             "plural": false,
-                                            "selections": v10
+                                            "selections": v9
                                           },
+                                          v15,
                                           v16,
                                           v17,
-                                          v18,
                                           {
                                             "kind": "ScalarField",
                                             "alias": null,
@@ -798,7 +793,7 @@ return {
                             "kind": "InlineFragment",
                             "type": "HeadRefForcePushedEvent",
                             "selections": [
-                              v20,
+                              v19,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -807,7 +802,7 @@ return {
                                 "args": null,
                                 "concreteType": "Commit",
                                 "plural": false,
-                                "selections": v15
+                                "selections": v14
                               },
                               {
                                 "kind": "LinkedField",
@@ -817,17 +812,17 @@ return {
                                 "args": null,
                                 "concreteType": "Commit",
                                 "plural": false,
-                                "selections": v15
+                                "selections": v14
                               },
-                              v18
+                              v17
                             ]
                           },
                           {
                             "kind": "InlineFragment",
                             "type": "MergedEvent",
                             "selections": [
-                              v20,
-                              v16,
+                              v19,
+                              v15,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -835,7 +830,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v18
+                              v17
                             ]
                           },
                           {
@@ -850,10 +845,10 @@ return {
                                 "args": null,
                                 "concreteType": null,
                                 "plural": false,
-                                "selections": v19
+                                "selections": v18
                               },
+                              v16,
                               v17,
-                              v18,
                               v4
                             ]
                           },
@@ -870,9 +865,9 @@ return {
                                 "concreteType": "GitActor",
                                 "plural": false,
                                 "selections": [
-                                  v11,
-                                  v21,
-                                  v9
+                                  v10,
+                                  v20,
+                                  v8
                                 ]
                               },
                               {
@@ -884,9 +879,9 @@ return {
                                 "concreteType": "GitActor",
                                 "plural": false,
                                 "selections": [
-                                  v11,
-                                  v9,
-                                  v21
+                                  v10,
+                                  v8,
+                                  v20
                                 ]
                               },
                               {
@@ -896,7 +891,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v14,
+                              v13,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -930,7 +925,20 @@ return {
                 "kind": "LinkedHandle",
                 "alias": null,
                 "name": "timeline",
-                "args": v8,
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "after",
+                    "variableName": "timelineCursor",
+                    "type": "String"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "first",
+                    "variableName": "timelineCount",
+                    "type": "Int"
+                  }
+                ],
                 "handle": "connection",
                 "key": "prTimelineContainer_timeline",
                 "filters": null

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -24,9 +24,7 @@ import WorkerManager from './worker-manager';
 import getRepoPipelineManager from './get-repo-pipeline-manager';
 import {reporterProxy} from './reporter-proxy';
 import ModelObserver from './models/model-observer';
-// FIXME: move the following dependencies to new file when you extract the graphQL stuff
-import RelayNetworkLayerManager from './relay-network-layer-manager';
-import {UNAUTHENTICATED, INSUFFICIENT} from './shared/keytar-strategy';
+import getGitHubUser from './github-user';
 
 const defaultState = {
   newProject: true,
@@ -105,38 +103,13 @@ export default class GithubPackage {
 
     this.loginObserver = new ModelObserver({
       didUpdate: async () => {
-        const gitHubUser = await this.getGitHubUser();
+        const gitHubUser = await getGitHubUser(this.loginModel);
         reporterProxy.setGitHubUser(gitHubUser);
       }
     });
     this.loginObserver.setActiveModel(this.loginModel);
 
     this.setupYardstick();
-  }
-
-  async getGitHubUser() {
-    const token = await this.loginModel.getToken('https://api.github.com');
-    if (token === UNAUTHENTICATED || token === INSUFFICIENT) {
-      return null;
-    }
-
-    const fetchQuery = RelayNetworkLayerManager.getFetchQuery('https://api.github.com/graphql', token);
-    const response = await fetchQuery({
-      name: 'GetGitHubUser',
-      text: `
-      query {
-        viewer {
-          login
-            }
-          }
-    `,
-    });
-    if (response.errors && response.errors.length > 1) {
-      // eslint-disable-next-line no-console
-      console.error(`Error fetching GitHub username:\n${response.errors.map(e => e.message).join('\n')}`);
-    }
-    // do I need to guard against data not containing "viewer" here?
-    return response.data.viewer.login;
   }
 
   setupYardstick() {

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -105,7 +105,7 @@ export default class GithubPackage {
       didUpdate: async () => {
         const gitHubUser = await getGitHubUser(this.loginModel);
         reporterProxy.setGitHubUser(gitHubUser);
-      }
+      },
     });
     this.loginObserver.setActiveModel(this.loginModel);
 

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -23,6 +23,10 @@ import AsyncQueue from './async-queue';
 import WorkerManager from './worker-manager';
 import getRepoPipelineManager from './get-repo-pipeline-manager';
 import {reporterProxy} from './reporter-proxy';
+import ModelObserver from './models/model-observer';
+// FIXME: move the following dependencies to new file when you extract the graphQL stuff
+import RelayNetworkLayerManager from './relay-network-layer-manager';
+import {UNAUTHENTICATED, INSUFFICIENT} from './shared/keytar-strategy';
 
 const defaultState = {
   newProject: true,
@@ -99,7 +103,40 @@ export default class GithubPackage {
       ContextMenuInterceptor,
     );
 
+    this.loginObserver = new ModelObserver({
+      didUpdate: async () => {
+        const gitHubUser = await this.getGitHubUser();
+        reporterProxy.setGitHubUser(gitHubUser);
+      }
+    });
+    this.loginObserver.setActiveModel(this.loginModel);
+
     this.setupYardstick();
+  }
+
+  async getGitHubUser() {
+    const token = await this.loginModel.getToken('https://api.github.com');
+    if (token === UNAUTHENTICATED || token === INSUFFICIENT) {
+      return null;
+    }
+
+    const fetchQuery = RelayNetworkLayerManager.getFetchQuery('https://api.github.com/graphql', token);
+    const response = await fetchQuery({
+      name: 'GetGitHubUser',
+      text: `
+      query {
+        viewer {
+          login
+            }
+          }
+    `,
+    });
+    if (response.errors && response.errors.length > 1) {
+      // eslint-disable-next-line no-console
+      console.error(`Error fetching GitHub username:\n${response.errors.map(e => e.message).join('\n')}`);
+    }
+    // do I need to guard against data not containing "viewer" here?
+    return response.data.viewer.login;
   }
 
   setupYardstick() {

--- a/lib/github-user.js
+++ b/lib/github-user.js
@@ -1,0 +1,30 @@
+import RelayNetworkLayerManager from './relay-network-layer-manager';
+import {UNAUTHENTICATED, INSUFFICIENT} from './shared/keytar-strategy';
+
+export default async function getGitHubUser(loginModel) {
+  const token = await loginModel.getToken('https://api.github.com');
+  if (token === UNAUTHENTICATED || token === INSUFFICIENT) {
+    return null;
+  }
+
+  const fetchQuery = RelayNetworkLayerManager.getFetchQuery('https://api.github.com/graphql', token);
+  const response = await fetchQuery({
+    name: 'GetGitHubUser',
+    text: `
+    query {
+      viewer {
+        login
+          }
+        }
+  `,
+  });
+  if (response.errors && response.errors.length > 1) {
+    // eslint-disable-next-line no-console
+    console.error(`Error fetching GitHub username:\n${response.errors.map(e => e.message).join('\n')}`);
+  }
+  const viewer = response.data && response.data.viewer && response.data.viewer.login ?
+    response.data.viewer.login : null;
+
+  console.log(viewer);
+  return viewer;
+}

--- a/lib/github-user.js
+++ b/lib/github-user.js
@@ -25,6 +25,5 @@ export default async function getGitHubUser(loginModel) {
   const viewer = response.data && response.data.viewer && response.data.viewer.login ?
     response.data.viewer.login : null;
 
-  console.log(viewer);
   return viewer;
 }

--- a/lib/items/__generated__/issueishTooltipItemQuery.graphql.js
+++ b/lib/items/__generated__/issueishTooltipItemQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash ec7add21f4125e294e4679a0fed3dfc9
+ * @relayHash e8e09ef59fd58c211220126ee7dcd2a5
  */
 
 /* eslint-disable */
@@ -17,10 +17,6 @@ export type issueishTooltipItemQueryResponse = {|
   +resource: ?{|
     +$fragmentRefs: issueishTooltipContainer_resource$ref
   |}
-|};
-export type issueishTooltipItemQuery = {|
-  variables: issueishTooltipItemQueryVariables,
-  response: issueishTooltipItemQueryResponse,
 |};
 */
 

--- a/lib/items/__generated__/userMentionTooltipItemQuery.graphql.js
+++ b/lib/items/__generated__/userMentionTooltipItemQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 618ef28f16a644f2aa8240535a6b5ea4
+ * @relayHash 65b45175c8b30ca98da00fa016b8a0dc
  */
 
 /* eslint-disable */
@@ -17,10 +17,6 @@ export type userMentionTooltipItemQueryResponse = {|
   +repositoryOwner: ?{|
     +$fragmentRefs: userMentionTooltipContainer_repositoryOwner$ref
   |}
-|};
-export type userMentionTooltipItemQuery = {|
-  variables: userMentionTooltipItemQueryVariables,
-  response: userMentionTooltipItemQueryResponse,
 |};
 */
 

--- a/lib/relay-network-layer-manager.js
+++ b/lib/relay-network-layer-manager.js
@@ -47,6 +47,9 @@ const fetchPerURL = new Map();
 function createFetchQuery(url) {
   if (atom.inSpecMode()) {
     return function specFetchQuery(operation, variables, cacheConfig, uploadables) {
+      if (variables === undefined) {
+        variables = [];
+      }
       const expectations = responsesByQuery.get(operation.name) || [];
       const match = expectations.find(expectation => {
         if (Object.keys(expectation.variables).length !== Object.keys(variables).length) {

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -19,7 +19,8 @@ class ReporterProxy {
 
   setGitHubUser(gitHubUser) {
     if (this.reporter !== null) {
-      this.reporter.setGitHubUser(gitHubUser);
+      // depends on merging https://github.com/atom/metrics/pull/97 first
+      // this.reporter.setGitHubUser(gitHubUser);
     }
     this.gitHubUser = gitHubUser;
   }
@@ -30,7 +31,8 @@ class ReporterProxy {
     this.reporter = reporter;
 
     if (this.gitHubUser !== null) {
-      this.reporter.setGitHubUser(this.gitHubUser);
+      // depends on merging https://github.com/atom/metrics/pull/97 first
+      // this.reporter.setGitHubUser(this.gitHubUser);
     }
 
     this.events.forEach(customEvent => {

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -20,7 +20,7 @@ class ReporterProxy {
   setGitHubUser(gitHubUser) {
     if (this.reporter !== null) {
       // depends on merging https://github.com/atom/metrics/pull/97 first
-      // this.reporter.setGitHubUser(gitHubUser);
+      this.reporter.setGitHubUser(gitHubUser);
     }
     this.gitHubUser = gitHubUser;
   }
@@ -32,7 +32,7 @@ class ReporterProxy {
 
     if (this.gitHubUser !== null) {
       // depends on merging https://github.com/atom/metrics/pull/97 first
-      // this.reporter.setGitHubUser(this.gitHubUser);
+      this.reporter.setGitHubUser(this.gitHubUser);
     }
 
     this.events.forEach(customEvent => {

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -14,12 +14,24 @@ class ReporterProxy {
     this.gitHubPackageVersion = pjson.version;
 
     this.timeout = null;
+    this.gitHubUser = null;
+  }
+
+  setGitHubUser(gitHubUser) {
+    if (this.reporter !== null) {
+      this.reporter.setGitHubUser(gitHubUser);
+    }
+    this.gitHubUser = gitHubUser;
   }
 
   // function that is called after the reporter is actually loaded, to
   // set the reporter and send any data that have accumulated while it was loading.
   setReporter(reporter) {
     this.reporter = reporter;
+
+    if (this.gitHubUser !== null) {
+      this.reporter.setGitHubUser(this.gitHubUser);
+    }
 
     this.events.forEach(customEvent => {
       this.reporter.addCustomEvent(customEvent.eventType, customEvent.event);
@@ -91,6 +103,8 @@ export class FakeReporter {
   addTiming() {}
 
   incrementCounter() {}
+
+  setGitHubUser() {}
 }
 
 export function incrementCounter(counterName) {
@@ -105,4 +119,8 @@ export function addTiming(eventType, durationInMilliseconds, metadata = {}) {
 export function addEvent(eventType, event) {
   event.gitHubPackageVersion = reporterProxy.gitHubPackageVersion;
   reporterProxy.addEvent(eventType, event);
+}
+
+export function setGitHubUser(gitHubUser) {
+  reporterProxy.setGitHubUser(gitHubUser);
 }

--- a/lib/views/__generated__/prStatusesViewRefetchQuery.graphql.js
+++ b/lib/views/__generated__/prStatusesViewRefetchQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 5b2061918400a59074629fc3e4800b18
+ * @relayHash 785a8d24aba2ef8a8145215f0bff78a0
  */
 
 /* eslint-disable */
@@ -17,10 +17,6 @@ export type prStatusesViewRefetchQueryResponse = {|
   +node: ?{|
     +$fragmentRefs: prStatusesView_pullRequest$ref
   |}
-|};
-export type prStatusesViewRefetchQuery = {|
-  variables: prStatusesViewRefetchQueryVariables,
-  response: prStatusesViewRefetchQueryResponse,
 |};
 */
 

--- a/test/github-user.test.js
+++ b/test/github-user.test.js
@@ -7,29 +7,57 @@ describe.only('getGitHubUser', function() {
   let login;
   const gitHubUser = 'annthurium';
   function useResult() {
-    return expectRelayQuery({name: 'GetGitHubUser'}, {
+    return expectRelayQuery({name: 'GetGitHubUser', variables: {}}, {
       viewer: {login: gitHubUser}
     });
   }
   beforeEach(function() {
     login = new GithubLoginModel(InMemoryStrategy);
-    sinon.stub(login, 'getScopes').returns(Promise.resolve(GithubLoginModel.REQUIRED_SCOPES));
-  })
-  it('returns the GitHub user if one exists', async function() {
-    await login.setToken('https://api.github.com', '1234');
-    useResult();
-    const user = await getGitHubUser();
-    assert.deepEqual(user, gitHubUser);
   });
-  // it('returns null if token has insufficient scope', function() {
-  //
-  // });
-  // it('handles errors gracefully', function() {
-  //
-  // });
-  // it('returns null if response does not contain viewer', function() {
-  //
-  // });
-
-
+  describe('sufficiently scoped tokens', async function() {
+    beforeEach(async function() {
+      sinon.stub(login, 'getScopes').returns(Promise.resolve(GithubLoginModel.REQUIRED_SCOPES));
+      await login.setToken('https://api.github.com', '1234');
+    });
+    it('returns the GitHub user if one exists', async function() {
+      const {resolve} = useResult();
+      resolve();
+      const user = await getGitHubUser(login);
+      await assert.async.deepEqual(user, gitHubUser);
+    });
+    it.only('handles graphql error gracefully', async function() {
+      // sinon.stub(login, 'getScopes').returns(Promise.resolve(GithubLoginModel.REQUIRED_SCOPES));
+      const {reject, promise} = useResult();
+      const e = new Error('wat');
+      e.rawStack = e.stack;
+      reject(e);
+      await promise.catch(() => {});
+      const user = await getGitHubUser(login);
+      await assert.async.isNull(user);
+    });
+    it('returns null if response does not contain viewer', async function() {
+      function useEmptyResult() {
+        return expectRelayQuery({name: 'GetGitHubUser', variables: {}}, {});
+      }
+      const {resolve} = useEmptyResult();
+      resolve();
+      const user = await getGitHubUser(login);
+      await assert.async.isNull(user);
+    });
+  });
+  it('returns null if token has insufficient scope', async function() {
+    sinon.stub(login, 'getScopes').resolves(['not-enough']);
+    const user = await getGitHubUser(login);
+    await assert.async.isNull(user);
+  });
+  it('handles graphql error gracefully', async function() {
+    sinon.stub(login, 'getScopes').returns(Promise.resolve(GithubLoginModel.REQUIRED_SCOPES));
+    const {reject, promise} = useResult();
+    const e = new Error('wat');
+    e.rawStack = e.stack;
+    reject(e);
+    await promise.catch(() => {});
+    const user = await getGitHubUser(login);
+    await assert.async.isNull(user);
+  });
 });

--- a/test/github-user.test.js
+++ b/test/github-user.test.js
@@ -1,0 +1,35 @@
+import getGitHubUser from '../lib/github-user';
+import GithubLoginModel from '../lib/models/github-login-model';
+import {InMemoryStrategy} from '../lib/shared/keytar-strategy';
+import {expectRelayQuery} from '../lib/relay-network-layer-manager';
+
+describe.only('getGitHubUser', function() {
+  let login;
+  const gitHubUser = 'annthurium';
+  function useResult() {
+    return expectRelayQuery({name: 'GetGitHubUser'}, {
+      viewer: {login: gitHubUser}
+    });
+  }
+  beforeEach(function() {
+    login = new GithubLoginModel(InMemoryStrategy);
+    sinon.stub(login, 'getScopes').returns(Promise.resolve(GithubLoginModel.REQUIRED_SCOPES));
+  })
+  it('returns the GitHub user if one exists', async function() {
+    await login.setToken('https://api.github.com', '1234');
+    useResult();
+    const user = await getGitHubUser();
+    assert.deepEqual(user, gitHubUser);
+  });
+  // it('returns null if token has insufficient scope', function() {
+  //
+  // });
+  // it('handles errors gracefully', function() {
+  //
+  // });
+  // it('returns null if response does not contain viewer', function() {
+  //
+  // });
+
+
+});

--- a/test/reporter-proxy.test.js
+++ b/test/reporter-proxy.test.js
@@ -1,4 +1,5 @@
-import {addEvent, addTiming, FIVE_MINUTES_IN_MILLISECONDS, FakeReporter, incrementCounter, reporterProxy} from '../lib/reporter-proxy';
+import {addEvent, addTiming, FIVE_MINUTES_IN_MILLISECONDS,
+  FakeReporter, incrementCounter, reporterProxy, setGitHubUser} from '../lib/reporter-proxy';
 const pjson = require('../package.json');
 
 const version = pjson.version;
@@ -18,6 +19,7 @@ describe('reporterProxy', function() {
     reporterProxy.events = [];
     reporterProxy.timings = [];
     reporterProxy.counters = [];
+    reporterProxy.gitHubUser = null;
   });
 
   describe('before reporter has been set', function() {
@@ -50,6 +52,12 @@ describe('reporterProxy', function() {
       assert.deepEqual(counters.length, 1);
       assert.deepEqual(counters[0], counterName);
     });
+
+    it('sets gitHubUser when setGitHubUser is called', function() {
+      const gitHubUser = 'annthurium';
+      reporterProxy.setGitHubUser(gitHubUser);
+      assert.deepEqual(reporterProxy.gitHubUser, gitHubUser);
+    })
   });
   describe('if reporter is never set', function() {
     it('sets the reporter to no op class once interval has passed', function() {
@@ -142,5 +150,24 @@ describe('reporterProxy', function() {
 
       assert.deepEqual(incrementCounterStub.lastCall.args, [counterName]);
     });
+    it('sets reporter.gitHubUser after reporter is set', function() {
+      const gitHubUser = 'annthurium';
+      const setGitHubUserStub = sinon.stub(fakeReporter, 'setGitHubUser');
+      assert.isFalse(setGitHubUserStub.called);
+      reporterProxy.setGitHubUser(gitHubUser);
+      assert.deepEqual(reporterProxy.gitHubUser, gitHubUser);
+      reporterProxy.setReporter(fakeReporter);
+      const args = setGitHubUserStub.lastCall.args;
+      assert.deepEqual(args[0], gitHubUser);
+    });
+
+    it('does not set reporter.gitHubUser if gitHubUser is null', function() {
+      assert.isNull(reporterProxy.gitHubUser);
+      const setGitHubUserStub = sinon.stub(fakeReporter, 'setGitHubUser');
+      assert.isFalse(setGitHubUserStub.called);
+      reporterProxy.setReporter(fakeReporter);
+      assert.isFalse(setGitHubUserStub.called);
+    });
+
   });
 });

--- a/test/reporter-proxy.test.js
+++ b/test/reporter-proxy.test.js
@@ -53,11 +53,11 @@ describe('reporterProxy', function() {
       assert.deepEqual(counters[0], counterName);
     });
 
-    it('sets gitHubUser when setGitHubUser is called', function() {
+    it.only('sets gitHubUser when setGitHubUser is called', function() {
       const gitHubUser = 'annthurium';
-      reporterProxy.setGitHubUser(gitHubUser);
+      setGitHubUser(gitHubUser);
       assert.deepEqual(reporterProxy.gitHubUser, gitHubUser);
-    })
+    });
   });
   describe('if reporter is never set', function() {
     it('sets the reporter to no op class once interval has passed', function() {


### PR DESCRIPTION
## Rationale

In order to plan a good roadmap for Atom's future, we need to have solid info about how users are interacting with Atom.

In the past we have anonymized all usage metrics.  Keeping the data anonymized impairs our ability to answer questions like:

- How does the Atom GitHub package fit in with GitHub.com workflows?
- How does the Atom GitHub package fit in with workflows in other GitHub tools (such as GitHub Desktop)?
- Does using Atom allow GitHub users to be more productive?

These questions are important. Therefore, we are introducing a change to pass the GitHub username with our usage metrics, if the user has authenticated with the GitHub package.

You do not have to authenticate with GitHub to use Atom, or the GitHub package.  Some functionality does require authenticating, though.

 If users don't want their GitHub username to be included in usability metrics, they can opt-out of sending their usage stats to GitHub.  Or they can choose not to authenticate.

## Approach
Use graphQL to fetch the GitHub username and send it to the `metrics` package.  The `ObserveModel` decorator wraps the login component so that we can re-fetch the data anytime the user performs a new login action.

## Alternate Approaches
We could send the authentication token to the metrics back end and do the username lookup there.  However, anytime you're sending tokens around, that's a security risk. Also, the approach I chose is more 