### PR TITLE
empty all queues in `reporterProxy` once data has been sent.

### DIFF
--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -24,14 +24,17 @@ class ReporterProxy {
     this.events.forEach(customEvent => {
       this.reporter.addCustomEvent(customEvent.eventType, customEvent.event);
     });
+    this.events = [];
 
     this.timings.forEach(timing => {
       this.reporter.addTiming(timing.eventType, timing.durationInMilliseconds, timing.metadata);
     });
+    this.timings = [];
 
     this.counters.forEach(counterName => {
       this.reporter.incrementCounter(counterName);
     });
+    this.counters = [];
   }
 
   incrementCounter(counterName) {

--- a/test/reporter-proxy.test.js
+++ b/test/reporter-proxy.test.js
@@ -109,6 +109,11 @@ describe('reporterProxy', function() {
       assert.deepEqual(addTimingArgs[2], {gitHubPackageVersion: version});
 
       assert.deepEqual(incrementCounterStub.lastCall.args, [counterName]);
+
+      assert.deepEqual(reporterProxy.events.length, 0);
+      assert.deepEqual(reporterProxy.timings.length, 0);
+      assert.deepEqual(reporterProxy.counters.length, 0);
+
     });
     it('calls addCustomEvent directly, bypassing queue', function() {
       assert.isFalse(addCustomEventStub.called);


### PR DESCRIPTION
### Description of the Change

Recently, I was working on some improvements to the `welcome` package in https://github.com/atom/welcome/pull/67.  I noticed that the `welcome` package, which also consumes the `reporter` service, empties all queues after the reporter has been set.  I believe the queues are emptied to guard against the possibility of the queued data being sent again if the reporter service is re-set.

This change empties the queues in the github package's `ReporterProxy` after data has been sent.  This change also adds unit tests to verify this new functionality works as expected.


### Alternate Designs
Is re-sending the same data actually something we need to worry about?

I tried to reproduce a situation where data might be re-sent to see if this is really a problem. I put a `setTimeout` in the `metrics` package so that it loads in a deferred fashion, and performed some actions that are instrumented (staging and unstaging changes).  This adds data to the queues before the reporter has been set.  It appears that a new `ReporterProxy` class is created in memory each time Atom reloads, so old events sticking around isn't a problem.  However, I'm not super confident that I'm testing this in the same conditions that would occur in the wild.  Clearing the queues is a simple enough change that I'd just rather do this and put any lingering worries to rest about the accuracy of our data.

### Benefits

Guard against the possibility that we are re-sending data that has already been sent, which keeps our metrics accurate.

### Possible Drawbacks
I can't think of any but am open to feedback.
