### PR TITLE
Handle staged changes with special characters in the filename

### DIFF
--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -37,7 +37,7 @@ export default class FilePatchController extends React.Component {
 
   static buildURI(relPath, workdir, stagingStatus) {
     return 'atom-github://file-patch/' +
-      relPath +
+      encodeURIComponent(relPath) +
       `?workdir=${encodeURIComponent(workdir)}` +
       `&stagingStatus=${encodeURIComponent(stagingStatus)}`;
   }

--- a/test/controllers/file-patch-controller.test.js
+++ b/test/controllers/file-patch-controller.test.js
@@ -96,6 +96,18 @@ describe('FilePatchController', function() {
 
       getFilePatchForPath = sinon.stub(repository, 'getFilePatchForPath');
     });
+    describe('buildURI', function() {
+      it('correctly uri encodes all components', function() {
+        const filePath = '???.txt';
+        const stagingStatus = 'staged';
+        const URI = FilePatchController.buildURI(filePath, workdirPath, stagingStatus);
+        assert.isTrue(URI.includes(encodeURIComponent(filePath)));
+        assert.isTrue(URI.includes(encodeURIComponent(workdirPath)));
+        assert.isTrue(URI.includes(encodeURIComponent(stagingStatus)));
+      });
+
+    });
+
 
     describe('when the FilePatch is too large', function() {
       it('renders a confirmation widget', async function() {

--- a/test/controllers/file-patch-controller.test.js
+++ b/test/controllers/file-patch-controller.test.js
@@ -98,10 +98,10 @@ describe('FilePatchController', function() {
     });
     describe('buildURI', function() {
       it('correctly uri encodes all components', function() {
-        const filePath = '???.txt';
+        const filePathWithSpecialChars = '???.txt';
         const stagingStatus = 'staged';
-        const URI = FilePatchController.buildURI(filePath, workdirPath, stagingStatus);
-        assert.isTrue(URI.includes(encodeURIComponent(filePath)));
+        const URI = FilePatchController.buildURI(filePathWithSpecialChars, workdirPath, stagingStatus);
+        assert.isTrue(URI.includes(encodeURIComponent(filePathWithSpecialChars)));
         assert.isTrue(URI.includes(encodeURIComponent(workdirPath)));
         assert.isTrue(URI.includes(encodeURIComponent(stagingStatus)));
       });


### PR DESCRIPTION

### Description of the Change
when a user clicks on a changed file in the `StagingView`, the github package creates a uri to pass to `atom.workspace.open()` so the user can open the file and view its contents.

However, we were not properly encoding all components of this URI.  Which is only a problem if there are special characters in the filename that need to be escaped.  In this case, an invalid URI would be generated, Atom would look for a file that doesn't exist, and show an error state thinking that the entire repository had only been a dream.

This PR addresses this issue by URI encoding the relative path to the file.

### Applicable Issues

https://github.com/atom/github/issues/1610

