### PR TITLE
Sort staged and unstaged files by path.

### DIFF
--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -183,12 +183,16 @@ export default class Repository {
 
   async getUnstagedChanges() {
     const {unstagedFiles} = await this.getStatusBundle();
-    return Object.keys(unstagedFiles).map(filePath => { return {filePath, status: unstagedFiles[filePath]}; });
+    return Object.keys(unstagedFiles)
+      .sort()
+      .map(filePath => { return {filePath, status: unstagedFiles[filePath]}; });
   }
 
   async getStagedChanges() {
     const {stagedFiles} = await this.getStatusBundle();
-    return Object.keys(stagedFiles).map(filePath => { return {filePath, status: stagedFiles[filePath]}; });
+    return Object.keys(stagedFiles)
+      .sort()
+      .map(filePath => { return {filePath, status: stagedFiles[filePath]}; });
   }
 
   async getMergeConflicts() {

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -370,6 +370,29 @@ describe('Repository', function() {
 
       `);
     });
+
+    it('sorts staged and unstaged files', async function() {
+      const workingDirPath = await cloneRepository('three-files');
+      const repo = new Repository(workingDirPath);
+      await repo.getLoadPromise();
+
+      const zFilePath = path.join(workingDirPath, 'z-dir', 'a.txt');
+      const wFilePath = path.join(workingDirPath, 'w.txt');
+      fs.mkdirSync(path.join(workingDirPath, 'z-dir'))
+      fs.renameSync(path.join(workingDirPath, 'a.txt'), zFilePath);
+      fs.renameSync(path.join(workingDirPath, 'b.txt'), wFilePath);
+      const unstagedChanges = await repo.getUnstagedChanges()
+      const unstagedPaths = unstagedChanges.map(change => change.filePath)
+
+      assert.deepStrictEqual(unstagedPaths, ['a.txt', 'b.txt', 'w.txt', 'z-dir/a.txt'])
+
+      await repo.stageFiles([zFilePath])
+      await repo.stageFiles([wFilePath])
+      const stagedChanges = await repo.getStagedChanges()
+      const stagedPaths = stagedChanges.map(change => change.filePath)
+
+      assert.deepStrictEqual(stagedPaths, ['w.txt', 'z-dir/a.txt'])
+    });
   });
 
   describe('getFilePatchForPath', function() {

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -378,20 +378,20 @@ describe('Repository', function() {
 
       const zFilePath = path.join(workingDirPath, 'z-dir', 'a.txt');
       const wFilePath = path.join(workingDirPath, 'w.txt');
-      fs.mkdirSync(path.join(workingDirPath, 'z-dir'))
+      fs.mkdirSync(path.join(workingDirPath, 'z-dir'));
       fs.renameSync(path.join(workingDirPath, 'a.txt'), zFilePath);
       fs.renameSync(path.join(workingDirPath, 'b.txt'), wFilePath);
-      const unstagedChanges = await repo.getUnstagedChanges()
-      const unstagedPaths = unstagedChanges.map(change => change.filePath)
+      const unstagedChanges = await repo.getUnstagedChanges();
+      const unstagedPaths = unstagedChanges.map(change => change.filePath);
 
-      assert.deepStrictEqual(unstagedPaths, ['a.txt', 'b.txt', 'w.txt', 'z-dir/a.txt'])
+      assert.deepStrictEqual(unstagedPaths, ['a.txt', 'b.txt', 'w.txt', 'z-dir/a.txt']);
 
-      await repo.stageFiles([zFilePath])
-      await repo.stageFiles([wFilePath])
-      const stagedChanges = await repo.getStagedChanges()
-      const stagedPaths = stagedChanges.map(change => change.filePath)
+      await repo.stageFiles([zFilePath]);
+      await repo.stageFiles([wFilePath]);
+      const stagedChanges = await repo.getStagedChanges();
+      const stagedPaths = stagedChanges.map(change => change.filePath);
 
-      assert.deepStrictEqual(stagedPaths, ['w.txt', 'z-dir/a.txt'])
+      assert.deepStrictEqual(stagedPaths, ['w.txt', 'z-dir/a.txt']);
     });
   });
 

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -376,7 +376,8 @@ describe('Repository', function() {
       const repo = new Repository(workingDirPath);
       await repo.getLoadPromise();
 
-      const zFilePath = path.join(workingDirPath, 'z-dir', 'a.txt');
+      const zShortPath = path.join('z-dir', 'a.txt');
+      const zFilePath = path.join(workingDirPath, zShortPath);
       const wFilePath = path.join(workingDirPath, 'w.txt');
       fs.mkdirSync(path.join(workingDirPath, 'z-dir'));
       fs.renameSync(path.join(workingDirPath, 'a.txt'), zFilePath);
@@ -384,14 +385,14 @@ describe('Repository', function() {
       const unstagedChanges = await repo.getUnstagedChanges();
       const unstagedPaths = unstagedChanges.map(change => change.filePath);
 
-      assert.deepStrictEqual(unstagedPaths, ['a.txt', 'b.txt', 'w.txt', 'z-dir/a.txt']);
+      assert.deepStrictEqual(unstagedPaths, ['a.txt', 'b.txt', 'w.txt', zShortPath]);
 
       await repo.stageFiles([zFilePath]);
       await repo.stageFiles([wFilePath]);
       const stagedChanges = await repo.getStagedChanges();
       const stagedPaths = stagedChanges.map(change => change.filePath);
 
-      assert.deepStrictEqual(stagedPaths, ['w.txt', 'z-dir/a.txt']);
+      assert.deepStrictEqual(stagedPaths, ['w.txt', zShortPath]);
     });
   });
 


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
Previously, staged and unstaged files returned from Git were sorted alphabetically by path in the "Staged Changes" pane, but grouped by change status in the "Unstaged Changes" pane:

![before](https://user-images.githubusercontent.com/2207980/44773506-c5d20e80-ab3e-11e8-96d9-5e5cafbd0f5c.png)

This made navigating the two panes counterintuitive, as the rhyme and reason behind the groupings in "Unstaged" was not immediately obvious and the sort pattern changed midway through a typical Git workflow.

This small change simply drops a `sort()` call into `Repository#getUnstagedChanges` and `Repository#getStagedChanges`. With this fix, both panes show files sorted by pathname:

![after](https://user-images.githubusercontent.com/2207980/44773719-455fdd80-ab3f-11e8-9580-b1e5ea5368e4.png)

### Alternate Designs
I considered diving a little deeper into the Git API and exploring _why_ the two results were sorted so differently, but settled on this as a comfortable middle ground between actually shipping a change and extensive Talmudic study of the code base.

### Benefits
For my money, at least, this is a fast and easy way of ironing out a frustrating UX tic.

### Possible Drawbacks
Folks may have become accustomed to the bad behavior, but otherwise, I can't see any issues.

### Applicable Issues
#1278