### PR TITLE
Fix typo in selector

### DIFF
--- a/lib/views/commit-view.js
+++ b/lib/views/commit-view.js
@@ -146,7 +146,7 @@ export default class CommitView extends React.Component {
             callback={this.toggleExpandedCommitMessageEditor}
           />
         </Commands>
-        <Commands registry={this.props.commandRegistry} target="github-CommitView-coAuthorEditor">
+        <Commands registry={this.props.commandRegistry} target=".github-CommitView-coAuthorEditor">
           <Command command="github:co-author:down" callback={this.proxyKeyCode(40)} />
           <Command command="github:co-author:up" callback={this.proxyKeyCode(38)} />
           <Command command="github:co-author:enter" callback={this.proxyKeyCode(13)} />


### PR DESCRIPTION
Fixes https://github.com/atom/github/issues/1675

### Requirements


### Description of the Change

When I migrated to use the `Command` component instead of the command registry, I made a typo in the registry target.  That means that none of these events were bubbling up to the correct selector, which broke keyboard input on the co author dialog.

I spent a half day trying to write unit tests for these changes to prevent future regressions.  However, it ended up being tricker than I anticipated, because:

- Enzyme doesn't have great support for key events.
- I don't really understand why this whole `proxyKeyCode` was necessary to make keyboard events work with react-select in the first place.  I'm sure there's a good reason, I just don't know what it is. I reached out to @niik in case he remembers. Knowing this will help me write a better test. 
