### PR TITLE
Add metrics collection for committing partial changes, undoing the last commit, and opening an expanded commit msg editor

### DIFF
--- a/lib/controllers/commit-controller.js
+++ b/lib/controllers/commit-controller.js
@@ -9,6 +9,7 @@ import CommitView from '../views/commit-view';
 import RefHolder from '../models/ref-holder';
 import {AuthorPropType, UserStorePropType} from '../prop-types';
 import {autobind} from '../helpers';
+import {addEvent} from '../reporter-proxy';
 
 export const COMMIT_GRAMMAR_SCOPE = 'text.git-commit';
 
@@ -219,6 +220,7 @@ export default class CommitController extends React.Component {
   async openCommitMessageEditor(messageFromBox) {
     await fs.writeFile(this.getCommitMessagePath(), messageFromBox, 'utf8');
     const commitEditor = await this.props.workspace.open(this.getCommitMessagePath());
+    addEvent('open-commit-message-editor', {package: 'github'});
 
     const grammar = this.props.grammars.grammarForScopeName(COMMIT_GRAMMAR_SCOPE);
     if (grammar) {

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -17,6 +17,7 @@ import Remote from '../remote';
 import RemoteSet from '../remote-set';
 import Commit from '../commit';
 import OperationStates from '../operation-states';
+import {addEvent} from '../../reporter-proxy';
 
 /**
  * State used when the working directory contains a valid git repository and can be interacted with. Performs
@@ -344,6 +345,7 @@ export default class Present extends State {
       async () => {
         try {
           await this.git().reset('soft', 'HEAD~');
+          addEvent('undoLastCommit', {package: 'github'});
         } catch (e) {
           if (/unknown revision/.test(e.stdErr)) {
             // Initial commit

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -250,6 +250,7 @@ export default class Present extends State {
         addEvent('commit', {
           package: 'github',
           partial: unstagedCount > 0,
+          amend: !!options.amend,
           coAuthorCount: coAuthors ? coAuthors.length : 0,
         });
         // note: this is somewhat redundant to the `incrementCounter` call in `GitShellOutStrategy` on all git commands,

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -234,7 +234,7 @@ export default class Present extends State {
         Keys.branches,
       ],
       // eslint-disable-next-line no-shadow
-      () => this.executePipelineAction('COMMIT', (message, options) => {
+      () => this.executePipelineAction('COMMIT', async (message, options) => {
         const opts = (!options || !options.coAuthors)
           ? options
           : {
@@ -244,7 +244,16 @@ export default class Present extends State {
             }),
           };
 
-        return this.git().commit(message, opts);
+        await this.git().commit(message, opts);
+        const {unstagedFiles, mergeConflictFiles} = await this.getStatusesForChangedFiles();
+        const unstagedCount = Object.keys({...unstagedFiles, ...mergeConflictFiles}).length;
+        const {amend, expandedCommitMessageEditor} = opts || {};
+        addEvent('commit', {
+          package: 'github',
+          partial: unstagedCount > 0,
+        });
+        // note: this is somewhat redundant to the `incrementCounter` call in `GitShellOutStrategy` on all git commands,
+        // here we get useful additional metadata
       }, message, options),
     );
   }
@@ -530,9 +539,9 @@ export default class Present extends State {
           this.transitionTo('TooLarge');
           return {
             branch: {},
-            stagedFiles: [],
-            unstagedFiles: [],
-            mergeConflictFiles: [],
+            stagedFiles: {},
+            unstagedFiles: {},
+            mergeConflictFiles: {},
           };
         } else {
           throw err;

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -235,22 +235,22 @@ export default class Present extends State {
       ],
       // eslint-disable-next-line no-shadow
       () => this.executePipelineAction('COMMIT', async (message, options) => {
-        const opts = (!options || !options.coAuthors)
-          ? options
-          : {
-            ...options,
-            coAuthors: options.coAuthors.map(author => {
-              return {email: author.getEmail(), name: author.getFullName()};
-            }),
-          };
+        // check with Ash that I retained the logic he was going for...
+        const coAuthors = options && options.coAuthors;
+        const opts = !coAuthors ? options : {
+          ...options,
+          coAuthors: coAuthors.map(author => {
+            return {email: author.getEmail(), name: author.getFullName()};
+          }),
+        };
 
         await this.git().commit(message, opts);
         const {unstagedFiles, mergeConflictFiles} = await this.getStatusesForChangedFiles();
         const unstagedCount = Object.keys({...unstagedFiles, ...mergeConflictFiles}).length;
-        const {amend, expandedCommitMessageEditor} = opts || {};
         addEvent('commit', {
           package: 'github',
           partial: unstagedCount > 0,
+          coAuthorCount: coAuthors ? coAuthors.length : 0,
         });
         // note: this is somewhat redundant to the `incrementCounter` call in `GitShellOutStrategy` on all git commands,
         // here we get useful additional metadata

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -235,7 +235,6 @@ export default class Present extends State {
       ],
       // eslint-disable-next-line no-shadow
       () => this.executePipelineAction('COMMIT', async (message, options) => {
-        // check with Ash that I retained the logic he was going for...
         const coAuthors = options && options.coAuthors;
         const opts = !coAuthors ? options : {
           ...options,
@@ -245,6 +244,10 @@ export default class Present extends State {
         };
 
         await this.git().commit(message, opts);
+
+        // Collect commit metadata metrics
+        // note: in GitShellOutStrategy we have counters for all git commands, including `commit`, but here we have
+        //       access to additional metadata (unstaged file count) so it makes sense to collect commit events here
         const {unstagedFiles, mergeConflictFiles} = await this.getStatusesForChangedFiles();
         const unstagedCount = Object.keys({...unstagedFiles, ...mergeConflictFiles}).length;
         addEvent('commit', {
@@ -253,8 +256,6 @@ export default class Present extends State {
           amend: !!options.amend,
           coAuthorCount: coAuthors ? coAuthors.length : 0,
         });
-        // note: this is somewhat redundant to the `incrementCounter` call in `GitShellOutStrategy` on all git commands,
-        // here we get useful additional metadata
       }, message, options),
     );
   }

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -355,7 +355,7 @@ export default class Present extends State {
       async () => {
         try {
           await this.git().reset('soft', 'HEAD~');
-          addEvent('undoLastCommit', {package: 'github'});
+          addEvent('undo-last-commit', {package: 'github'});
         } catch (e) {
           if (/unknown revision/.test(e.stdErr)) {
             // Initial commit

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -234,8 +234,8 @@ export default class Present extends State {
         Keys.branches,
       ],
       // eslint-disable-next-line no-shadow
-      () => this.executePipelineAction('COMMIT', async (message, options) => {
-        const coAuthors = options && options.coAuthors;
+      () => this.executePipelineAction('COMMIT', async (message, options = {}) => {
+        const coAuthors = options.coAuthors;
         const opts = !coAuthors ? options : {
           ...options,
           coAuthors: coAuthors.map(author => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -178,7 +178,7 @@
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "integrity": "sha1-UkryQNGjYFJ7cwR17PoTRKpUDd4=",
       "dev": true,
       "requires": {
         "call-me-maybe": "^1.0.1",
@@ -203,7 +203,7 @@
     "@smashwilson/atom-mocha-test-runner": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@smashwilson/atom-mocha-test-runner/-/atom-mocha-test-runner-1.4.0.tgz",
-      "integrity": "sha512-Zp50XTy2QZEk53PUxXQ1kLTAkSwEuM2X7JXtMGLRWuU68piFghkXGaopTrjXK3CwgzmmFi26m65sTCrXg3zqbg==",
+      "integrity": "sha1-AjOAreJPt5xrC7TlXdTuc7LFdfo=",
       "dev": true,
       "requires": {
         "diff": "3.5.0",
@@ -255,7 +255,7 @@
     "acorn-jsx": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
-      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
+      "integrity": "sha1-6OQeSOov4MiWdAYQq2pP/YrdIl4=",
       "dev": true,
       "requires": {
         "acorn": "^5.0.3"
@@ -300,7 +300,7 @@
     },
     "amdefine": {
       "version": "1.0.1",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
@@ -322,7 +322,7 @@
     },
     "append-transform": {
       "version": "1.0.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
@@ -336,7 +336,7 @@
     },
     "archy": {
       "version": "1.0.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
@@ -430,7 +430,7 @@
     "array.prototype.flat": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
-      "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
+      "integrity": "sha1-gS248CytJNP6tl3WfqvjuJA0lKQ=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -479,7 +479,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
@@ -1383,7 +1383,7 @@
     "babel-preset-fbjs": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.2.0.tgz",
-      "integrity": "sha512-jj0KFJDioYZMtPtZf77dQuU+Ad/1BtN0UnAYlHDa8J8f4tGXr3YrPoJImD5MdueaOPeN/jUdrCgu330EfXr0XQ==",
+      "integrity": "sha1-wluHmpFP7v2WQFKxvOTJDukVAjo=",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "^6.8.0",
@@ -1696,7 +1696,7 @@
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
       "dev": true
     },
     "bser": {
@@ -1757,7 +1757,7 @@
     },
     "caching-transform": {
       "version": "1.0.1",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
       "dev": true,
       "requires": {
@@ -2016,12 +2016,12 @@
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8=",
       "dev": true
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
@@ -2083,7 +2083,7 @@
     "cross-env": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
-      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "integrity": "sha1-bs1MAV1Xc+YUA57lKQdmabnRJvI=",
       "dev": true,
       "requires": {
         "cross-spawn": "^6.0.5",
@@ -2140,7 +2140,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "dev": true,
           "requires": {
             "hoek": "4.x.x"
@@ -2190,7 +2190,7 @@
     },
     "debug-log": {
       "version": "1.0.1",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
@@ -2248,7 +2248,7 @@
     },
     "default-require-extensions": {
       "version": "2.0.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
@@ -2353,7 +2353,7 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
       "dev": true
     },
     "discontinuous-range": {
@@ -2413,7 +2413,7 @@
     "domhandler": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
       "dev": true,
       "requires": {
         "domelementtype": "1"
@@ -2466,7 +2466,7 @@
     "emoji-regex": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+      "integrity": "sha1-m66pKbFVVlwR6kHGYm6qZc75ksI=",
       "dev": true
     },
     "encoding": {
@@ -2494,7 +2494,7 @@
     "enzyme": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.4.1.tgz",
-      "integrity": "sha512-XBZbyUy36WipNSBVZKIR1sg9iF6zXfkfDEzwTc10T9zhB61UPnMo+c3WE17T/jyhfmPJOz6X073NXXsR7G/1rA==",
+      "integrity": "sha1-0wWvW9swuKylbRmREEIViMZw6g4=",
       "dev": true,
       "requires": {
         "array.prototype.flat": "^1.2.1",
@@ -2519,7 +2519,7 @@
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
           "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
@@ -2528,7 +2528,7 @@
         "is-callable": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+          "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
           "dev": true
         }
       }
@@ -2536,7 +2536,7 @@
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2595,7 +2595,7 @@
     "eslint": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.0.1.tgz",
-      "integrity": "sha512-D5nG2rErquLUstgUaxJlWB5+gu+U/3VDY0fk/Iuq8y9CUFy/7Y6oF4N2cR1tV8knzQvciIbfqfohd359xTLIKQ==",
+      "integrity": "sha1-EJuQq396c29U4PNByLudCXd0lMM=",
       "dev": true,
       "requires": {
         "ajv": "^6.5.0",
@@ -2716,13 +2716,13 @@
         "globals": {
           "version": "11.7.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "integrity": "sha1-pYP6pDBVsayncZFL9oJY4vwSVnM=",
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
           "dev": true
         },
         "strip-ansi": {
@@ -2784,7 +2784,7 @@
     "eslint-plugin-jsx-a11y": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.1.tgz",
-      "integrity": "sha512-JsxNKqa3TwmPypeXNnI75FntkUktGzI1wSa1LgNZdSOMI+B4sxnr1lSF8m8lPiz4mKiC+14ysZQM4scewUrP7A==",
+      "integrity": "sha1-e/Vtvn1H2BHRTbs93/ZEqmVs6OE=",
       "dev": true,
       "requires": {
         "aria-query": "^3.0.0",
@@ -2800,7 +2800,7 @@
         "has": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
           "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
@@ -2839,7 +2839,7 @@
     "eslint-scope": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "integrity": "sha1-UL8wcekzi83EMzF5Sgy1M/ATYXI=",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -2855,7 +2855,7 @@
     "espree": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
-      "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
+      "integrity": "sha1-JTmY8goPgttdhmOFeZ2RKoOjZjQ=",
       "dev": true,
       "requires": {
         "acorn": "^5.6.0",
@@ -3101,7 +3101,7 @@
     "fast-glob": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
-      "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
+      "integrity": "sha1-cXIzOKybTg4v/x1nSKKhPV7TUr8=",
       "dev": true,
       "requires": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
@@ -3212,7 +3212,7 @@
     },
     "find-cache-dir": {
       "version": "1.0.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true,
       "requires": {
@@ -3256,7 +3256,7 @@
     },
     "foreground-child": {
       "version": "1.5.6",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
@@ -3341,7 +3341,7 @@
     "function.prototype.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
-      "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+      "integrity": "sha1-i9djzAr4YKhZzF1JOE10uTLNIyc=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -3504,7 +3504,7 @@
     "graphql-compiler": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/graphql-compiler/-/graphql-compiler-1.6.2.tgz",
-      "integrity": "sha512-ZpnZm6ijwfphsnJpUvWd/M4taRR0xy5wYf1JR9LC29IGobORjAhXtEng41hYL4hAiSIpqep8zcac1yGCknaVMg==",
+      "integrity": "sha1-Rd/RCV+K8IfgyWPQKIMaveB9xgU=",
       "dev": true,
       "requires": {
         "chalk": "^1.1.1",
@@ -3515,7 +3515,7 @@
     "grim": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/grim/-/grim-2.0.2.tgz",
-      "integrity": "sha512-Qj7hTJRfd87E/gUgfvM0YIH/g2UA2SV6niv6BYXk1o6w4mhgv+QyYM1EjOJQljvzgEj4SqSsRWldXIeKHz3e3Q==",
+      "integrity": "sha1-52CinKe4NDsMH/r2ziDyGkbuiu0=",
       "dev": true,
       "requires": {
         "event-kit": "^2.0.0"
@@ -3529,7 +3529,7 @@
     },
     "handlebars": {
       "version": "4.0.11",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
@@ -3557,7 +3557,7 @@
         },
         "source-map": {
           "version": "0.4.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -3648,7 +3648,7 @@
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
       "dev": true,
       "requires": {
         "boom": "4.x.x",
@@ -3666,7 +3666,7 @@
     "hock": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/hock/-/hock-1.3.3.tgz",
-      "integrity": "sha512-bEX7KH/KSv2Q5zA+o1EdyeH52+gD2cfpYyAsHMEwjb9txXWttityKVf7cG0y3UVA4D8bxKDzH8LVXCQIr9rClg==",
+      "integrity": "sha1-aWHj3wUpsu08vBPkuNgfvYi5xg0=",
       "dev": true,
       "requires": {
         "deep-equal": "0.2.1",
@@ -3676,7 +3676,7 @@
     "hoek": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs=",
       "dev": true
     },
     "home-or-tmp": {
@@ -3776,7 +3776,7 @@
     "inquirer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+      "integrity": "sha1-2zUMK3Paynf/EkOWLp8i8JloVyY=",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -4179,7 +4179,7 @@
     },
     "istanbul-lib-hook": {
       "version": "2.0.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-qm3dt628HKpCVtIjbdZLuQyXn0+LO8qz+YHQDfkeXuSk5D+p299SEV5DrnUUnPi2SXvdMmWapMYWiuE75o2rUQ==",
       "dev": true,
       "requires": {
@@ -4249,7 +4249,7 @@
     },
     "istanbul-lib-report": {
       "version": "2.0.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-RiELmy9oIRYUv36ITOAhVum9PUvuj6bjyXVEKEHNiD1me6qXtxfx7vSEJWnjOGk2QmYw/GRFjLXWJv3qHpLceQ==",
       "dev": true,
       "requires": {
@@ -4271,7 +4271,7 @@
     },
     "istanbul-lib-source-maps": {
       "version": "2.0.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-jenUeC0gMSSMGkvqD9xuNfs3nD7XWeXLhqaIkqHsNZ3DJBWPdlKEydE7Ya5aTgdWjrEQhrCYTv+J606cGC2vuQ==",
       "dev": true,
       "requires": {
@@ -4293,7 +4293,7 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
@@ -4301,7 +4301,7 @@
     },
     "istanbul-reports": {
       "version": "1.5.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-HeZG0WHretI9FXBni5wZ9DOgNziqDCEwetxnme5k1Vv5e81uTqcsy3fMH99gXGDGKr1ea87TyGseDMa2h4HEUA==",
       "dev": true,
       "requires": {
@@ -4565,7 +4565,7 @@
     },
     "make-dir": {
       "version": "1.3.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
@@ -4574,7 +4574,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -4597,7 +4597,7 @@
     },
     "md5-hex": {
       "version": "1.3.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
       "dev": true,
       "requires": {
@@ -4606,7 +4606,7 @@
     },
     "md5-o-matic": {
       "version": "0.1.1",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
       "dev": true
     },
@@ -4621,7 +4621,7 @@
     },
     "merge-source-map": {
       "version": "1.1.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
       "dev": true,
       "requires": {
@@ -4630,7 +4630,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
@@ -4639,7 +4639,7 @@
     "merge2": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
-      "integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==",
+      "integrity": "sha1-AyEuPajYbE2FI869YxgZNBT5TjQ=",
       "dev": true
     },
     "micromatch": {
@@ -4666,7 +4666,7 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
       "dev": true,
       "optional": true
     },
@@ -4779,7 +4779,7 @@
     "mocha": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "integrity": "sha1-bYrlCPWRZ/lA8rWzxKYSrlDJCuY=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.1",
@@ -4798,7 +4798,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -4807,7 +4807,7 @@
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -4818,7 +4818,7 @@
     "mocha-appveyor-reporter": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/mocha-appveyor-reporter/-/mocha-appveyor-reporter-0.4.1.tgz",
-      "integrity": "sha512-3FOlmBP3DemyvmboFK2vMoPRAJ/7Co8gyvcdxctYMynofouRQAVFwpgO/f/mRCLCMn7GLEq7/sOyuj2HXave/g==",
+      "integrity": "sha1-N2KAKrIrdOv4aPZrW4AI2IOUI5Y=",
       "dev": true,
       "requires": {
         "request-json": "^0.6.3"
@@ -4837,7 +4837,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -4859,7 +4859,7 @@
     "moo": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+      "integrity": "sha1-P4R6JvMc9iWpVqh/KxD7wBO/0Q4=",
       "dev": true
     },
     "ms": {
@@ -4917,7 +4917,7 @@
     "nearley": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz",
-      "integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
+      "integrity": "sha1-ll5Obsnta4D8gUU+Fh77zrs20kc=",
       "dev": true,
       "requires": {
         "moo": "^0.4.3",
@@ -4971,7 +4971,7 @@
     "node-fetch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
-      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
+      "integrity": "sha1-Tueb3pCSYvl3X3MeNlbQ21XO1bU=",
       "dev": true
     },
     "node-int64": {
@@ -5076,7 +5076,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
@@ -5134,7 +5134,7 @@
         },
         "md5-hex": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
           "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
           "dev": true,
           "requires": {
@@ -5157,18 +5157,18 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -5185,7 +5185,7 @@
         },
         "test-exclude": {
           "version": "4.2.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.2.tgz",
           "integrity": "sha512-2kTGf+3tykCfrWVREgyTR0bmVO0afE6i7zVXi/m+bZZ8ujV89Aulxdcdv32yH+unVFg3Y5o6GA8IzsHnGQuFgQ==",
           "dev": true,
           "requires": {
@@ -5197,7 +5197,7 @@
           "dependencies": {
             "load-json-file": {
               "version": "4.0.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
               "dev": true,
               "requires": {
@@ -5209,7 +5209,7 @@
             },
             "parse-json": {
               "version": "4.0.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
               "dev": true,
               "requires": {
@@ -5227,7 +5227,7 @@
             },
             "path-type": {
               "version": "3.0.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
               "dev": true,
               "requires": {
@@ -5236,13 +5236,13 @@
             },
             "pify": {
               "version": "3.0.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
               "dev": true
             },
             "read-pkg": {
               "version": "3.0.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
               "dev": true,
               "requires": {
@@ -5253,7 +5253,7 @@
             },
             "read-pkg-up": {
               "version": "3.0.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
               "dev": true,
               "requires": {
@@ -5263,7 +5263,7 @@
             },
             "strip-bom": {
               "version": "3.0.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
               "dev": true
             }
@@ -5276,7 +5276,7 @@
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
@@ -5296,13 +5296,13 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             },
             "cliui": {
               "version": "4.1.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
               "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "dev": true,
               "requires": {
@@ -5313,7 +5313,7 @@
             },
             "yargs-parser": {
               "version": "9.0.2",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
               "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
               "dev": true,
               "requires": {
@@ -5324,7 +5324,7 @@
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
@@ -5333,7 +5333,7 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             }
@@ -5385,7 +5385,7 @@
     "object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
       "dev": true
     },
     "object-is": {
@@ -5564,7 +5564,7 @@
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -5657,7 +5657,7 @@
     },
     "pkg-dir": {
       "version": "2.0.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
@@ -5718,7 +5718,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
     },
     "progress": {
       "version": "2.0.0",
@@ -5776,7 +5776,7 @@
     "raf": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
-      "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+      "integrity": "sha1-ooh2iBtLwsqRF9QTgWPduA94FXU=",
       "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
@@ -5791,7 +5791,7 @@
     "randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "integrity": "sha1-6YatXl4x2uE93W97MBmqfIf2DKM=",
       "dev": true,
       "requires": {
         "discontinuous-range": "1.0.0",
@@ -5812,7 +5812,7 @@
     "react": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.4.0.tgz",
-      "integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
+      "integrity": "sha1-QCwtuDM1M2+6GWLAi5jGJyYX1YU=",
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
@@ -5823,7 +5823,7 @@
     "react-dom": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.0.tgz",
-      "integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
+      "integrity": "sha1-CZ8GfdWCfONqKer5ps3Hy/Yhax4=",
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
@@ -5997,7 +5997,7 @@
     "regexp.prototype.flags": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "integrity": "sha1-azByTjBqJ4M+6xcbZqyIkLo35Bw=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2"
@@ -6012,7 +6012,7 @@
     "relay-compiler": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-1.6.2.tgz",
-      "integrity": "sha512-p2dYbQR4up4ZPLbTQ7GRP0ySlN3Btr1eT4PBhzCC+z4iJxZJczUPJnCvmxTvIHaxgoSjlUS88TR0Dbl13s7gDw==",
+      "integrity": "sha1-hF4nu0RumTUk0Xaw70WTyXV+1mI=",
       "dev": true,
       "requires": {
         "@babel/generator": "7.0.0-beta.54",
@@ -6166,7 +6166,7 @@
         "relay-runtime": {
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-1.6.2.tgz",
-          "integrity": "sha512-eWjdlK+OvzW35fbYcFrO+S4dMyxb1LqrCU9HBh1OEEK465Te+l+l2Rmg9RCdcvaPuq7zGC6+Anec2/2aNXtiUA==",
+          "integrity": "sha1-Xs1D2SeZ52FFQgC0Vd0cDLAlllk=",
           "dev": true,
           "requires": {
             "babel-runtime": "^6.23.0",
@@ -6176,7 +6176,7 @@
         "ua-parser-js": {
           "version": "0.7.18",
           "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-          "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
+          "integrity": "sha1-p7/ZL1bt+xFwg7aeMdKqiILUse0=",
           "dev": true
         }
       }
@@ -6254,7 +6254,7 @@
     "request-json": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/request-json/-/request-json-0.6.3.tgz",
-      "integrity": "sha512-5TVnMD3LaeK0GRCyFlsNgJf5Fjg8J8j7VEfsoJESSWZlWRgPIf7IojsBLbTHcg2798JrrRkJ6L3k1+wj4sglgw==",
+      "integrity": "sha1-wi+gKMs2DRMhToHH1Y5WniB5tZU=",
       "dev": true,
       "requires": {
         "depd": "1.1.2",
@@ -6279,7 +6279,7 @@
         "request": {
           "version": "2.83.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
           "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -6425,7 +6425,7 @@
     "semver": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+      "integrity": "sha1-ff3YgUvbfKvHvg+x1zTPtmyUBHc="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -6551,7 +6551,7 @@
     },
     "slide": {
       "version": "1.1.6",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
@@ -6665,7 +6665,7 @@
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
       "dev": true,
       "requires": {
         "hoek": "4.x.x"
@@ -6705,7 +6705,7 @@
     },
     "spawn-wrap": {
       "version": "1.4.2",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
       "dev": true,
       "requires": {
@@ -6860,7 +6860,7 @@
     "string.prototype.matchall": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-2.0.0.tgz",
-      "integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
+      "integrity": "sha1-Kvj+PS1txTyipZvTdrCJw8FSs8g=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -6923,7 +6923,7 @@
     "table": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
-      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+      "integrity": "sha1-ALXitgLxeUuayvnKkIp2OGp4E7w=",
       "dev": true,
       "requires": {
         "ajv": "^6.0.1",
@@ -6975,7 +6975,7 @@
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
           "dev": true
         },
         "supports-color": {
@@ -7304,7 +7304,7 @@
     },
     "uglify-js": {
       "version": "2.8.29",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
@@ -7342,7 +7342,7 @@
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "optional": true,
@@ -7357,7 +7357,7 @@
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
@@ -7457,7 +7457,7 @@
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -7466,7 +7466,7 @@
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
           "dev": true
         }
       }
@@ -7608,7 +7608,7 @@
     },
     "window-size": {
       "version": "0.1.0",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true
@@ -7657,7 +7657,7 @@
     },
     "write-file-atomic": {
       "version": "1.3.4",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
       "dev": true,
       "requires": {

--- a/test/controllers/commit-controller.test.js
+++ b/test/controllers/commit-controller.test.js
@@ -306,20 +306,14 @@ describe('CommitController', function() {
           sinon.stub(reporterProxy, 'addEvent');
           // open expanded commit message editor
           await wrapper.find('CommitView').prop('toggleExpandedCommitMessageEditor')('message in box');
-          assert.deepEqual(reporterProxy.addEvent.callCount, 1);
-          let args = reporterProxy.addEvent.lastCall.args;
-          assert.deepEqual(args[0], 'open-commit-message-editor');
-          assert.deepEqual(args[1], {package: 'github'});
+          assert.isTrue(reporterProxy.addEvent.calledWith('open-commit-message-editor', {package: 'github'}));
           // close expanded commit message editor
+          reporterProxy.addEvent.reset();
           await wrapper.find('CommitView').prop('toggleExpandedCommitMessageEditor')('message in box');
-          assert.deepEqual(reporterProxy.addEvent.callCount, 1);
-          args = reporterProxy.addEvent.lastCall.args;
-          assert.deepEqual(args[0], 'open-commit-message-editor');
+          assert.isFalse(reporterProxy.addEvent.called);
           // open expanded commit message editor again
           await wrapper.find('CommitView').prop('toggleExpandedCommitMessageEditor')('message in box');
-          assert.deepEqual(reporterProxy.addEvent.callCount, 2);
-          args = reporterProxy.addEvent.lastCall.args;
-          assert.deepEqual(args[0], 'open-commit-message-editor');
+          assert.isTrue(reporterProxy.addEvent.calledWith('open-commit-message-editor', {package: 'github'}));
         });
       });
     });

--- a/test/controllers/commit-controller.test.js
+++ b/test/controllers/commit-controller.test.js
@@ -9,6 +9,7 @@ import UserStore from '../../lib/models/user-store';
 
 import CommitController, {COMMIT_GRAMMAR_SCOPE} from '../../lib/controllers/commit-controller';
 import {cloneRepository, buildRepository, buildRepositoryWithPipeline} from '../helpers';
+import * as reporterProxy from '../../lib/reporter-proxy';
 
 describe('CommitController', function() {
   let atomEnvironment, workspace, commandRegistry, notificationManager, lastCommit, config, confirm, tooltips;
@@ -296,6 +297,23 @@ describe('CommitController', function() {
         await assert.async.lengthOf(wrapper.instance().getCommitMessageEditors(), 0);
         assert.isTrue(atomEnvironment.applicationDelegate.confirm.called);
         await assert.async.strictEqual(wrapper.update().find('CommitView').prop('message'), 'make some new changes');
+      });
+
+      describe('openCommitMessageEditor', function() {
+        it.only('records an event', async function() {
+          const wrapper = shallow(app, {disableLifecycleMethods: true});
+
+          sinon.stub(reporterProxy, 'addEvent');
+          // open expanded commit message editor
+          await wrapper.find('CommitView').prop('toggleExpandedCommitMessageEditor')('message in box');
+          assert.deepEqual(reporterProxy.addEvent.callCount, 1);
+          // close expanded commit message editor
+          await wrapper.find('CommitView').prop('toggleExpandedCommitMessageEditor')('message in box');
+          assert.deepEqual(reporterProxy.addEvent.callCount, 1);
+          // open expanded commit message editor again
+          await wrapper.find('CommitView').prop('toggleExpandedCommitMessageEditor')('message in box');
+          assert.deepEqual(reporterProxy.addEvent.callCount, 2);
+        });
       });
     });
 

--- a/test/controllers/commit-controller.test.js
+++ b/test/controllers/commit-controller.test.js
@@ -300,19 +300,26 @@ describe('CommitController', function() {
       });
 
       describe('openCommitMessageEditor', function() {
-        it.only('records an event', async function() {
+        it('records an event', async function() {
           const wrapper = shallow(app, {disableLifecycleMethods: true});
 
           sinon.stub(reporterProxy, 'addEvent');
           // open expanded commit message editor
           await wrapper.find('CommitView').prop('toggleExpandedCommitMessageEditor')('message in box');
           assert.deepEqual(reporterProxy.addEvent.callCount, 1);
+          let args = reporterProxy.addEvent.lastCall.args;
+          assert.deepEqual(args[0], 'open-commit-message-editor');
+          assert.deepEqual(args[1], {package: 'github'});
           // close expanded commit message editor
           await wrapper.find('CommitView').prop('toggleExpandedCommitMessageEditor')('message in box');
           assert.deepEqual(reporterProxy.addEvent.callCount, 1);
+          args = reporterProxy.addEvent.lastCall.args;
+          assert.deepEqual(args[0], 'open-commit-message-editor');
           // open expanded commit message editor again
           await wrapper.find('CommitView').prop('toggleExpandedCommitMessageEditor')('message in box');
           assert.deepEqual(reporterProxy.addEvent.callCount, 2);
+          args = reporterProxy.addEvent.lastCall.args;
+          assert.deepEqual(args[0], 'open-commit-message-editor');
         });
       });
     });

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -642,6 +642,29 @@ describe('Repository', function() {
         assert.isFalse(args[1].partial);
       });
 
+      it.only('reports if the commit was an amend', async function() {
+        const workingDirPath = await cloneRepository('three-files');
+        const repo = new Repository(workingDirPath);
+        await repo.getLoadPromise();
+
+        sinon.stub(reporterProxy, 'addEvent');
+
+        assert.deepEqual(reporterProxy.addEvent.callCount, 0);
+        await repo.commit('Regular commit', {allowEmpty: true});
+        assert.deepEqual(reporterProxy.addEvent.callCount, 1);
+        let args = reporterProxy.addEvent.lastCall.args;
+        assert.deepEqual(args[0], 'commit');
+        assert.isFalse(args[1].amend);
+
+        reporterProxy.addEvent.reset();
+        assert.deepEqual(reporterProxy.addEvent.callCount, 0);
+        await repo.commit('Amended commit', {allowEmpty: true, amend: true});
+        assert.deepEqual(reporterProxy.addEvent.callCount, 1);
+        args = reporterProxy.addEvent.lastCall.args;
+        assert.deepEqual(args[0], 'commit');
+        assert.isTrue(args[1].amend);
+      });
+
       it('reports number of coAuthors for commit', async function() {
         const workingDirPath = await cloneRepository('three-files');
         const repo = new Repository(workingDirPath);

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -779,7 +779,7 @@ describe('Repository', function() {
       assert.deepEqual(reporterProxy.addEvent.callCount, 1);
 
       const args = reporterProxy.addEvent.lastCall.args;
-      assert.deepEqual(args[0], 'undoLastCommit');
+      assert.deepEqual(args[0], 'undo-last-commit');
       assert.deepEqual(args[1], {package: 'github'});
     });
 

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -642,7 +642,7 @@ describe('Repository', function() {
         assert.isFalse(args[1].partial);
       });
 
-      it.only('reports if the commit was an amend', async function() {
+      it('reports if the commit was an amend', async function() {
         const workingDirPath = await cloneRepository('three-files');
         const repo = new Repository(workingDirPath);
         await repo.getLoadPromise();

--- a/test/views/changed-files-count-view.test.js
+++ b/test/views/changed-files-count-view.test.js
@@ -30,13 +30,8 @@ describe('ChangedFilesCountView', function() {
 
   it('records an event on click', function() {
     sinon.stub(reporterProxy, 'addEvent');
-    reporterProxy.addEvent.reset();
     wrapper = shallow(<ChangedFilesCountView />);
-    assert.deepEqual(reporterProxy.addEvent.callCount, 0);
     wrapper.simulate('click');
-    assert.deepEqual(reporterProxy.addEvent.callCount, 1);
-    const args = reporterProxy.addEvent.lastCall.args;
-    assert.deepEqual(args[0], 'click');
-    assert.deepEqual(args[1], {package: 'github', component: 'ChangedFileCountView'});
+    assert.isTrue(reporterProxy.addEvent.calledWith('click', {package: 'github', component: 'ChangedFileCountView'}));
   });
 });


### PR DESCRIPTION
### Description of the Change

This PR introduces some of the additional metrics discussed in #1591. 

So far I've added events for the following:
* undo last commit 
  * _I use this feature A LOT. would be interesting to see how frequently others use it._
* commit, with metadata indicating:
  * if the commit included partial changes (that is, unstaged changes remained uncommitted in the working directory) 
    * _are people taking advantage of how easy it is to stage/unstage subsets of changes in Atom? what percentage of total commits commit partial changes? As we make changes to our diff view and implement other discoverability/usability improvements, how will this be affected?_ 
  * the number of co-authors for the commit 
    * _what percentage of users are committing with co-authors? as we ship more features that promote collaboration how does this change?_

Other thoughts and considerations:

**Expanded commit message editor usage**
I considered using the "verbatim" option passed to Repository#commit to report whether the commit was made from an expanded commit editor or the small commit box in the Git Panel because I know that is what dictates its value, but it seemed icky to be relying on that inference. It also felt not great to pass down an additional option such as `expandedCommitMessageEditor` to the repository model strictly for collecting metrics on it. If we decide this is something we really want to instrument, it's better and more direct to do so where the expanded editor is opened (such as CommitController#openCommitMessageEditor).

**Gathering data on button use vs. keyboard shortcuts vs. context menu use**
It could be interesting and useful to gather data on how users are initiating operations in our package. This info could yield insights about how discoverable each of these entry points are. That said, the way that keybindings and context-menus are set up in Atom is based on commands which result in functions being called. We can easily instrument the function calls in this package as well as button presses, but I don't think there's an easy/straight-forward way to instrument the keyboard shortcut or context menu usage. @smashwilson @annthurium 💭s?

### Alternate Designs

To gather information on partial-staging I considered tracking staging/unstaging events. At the end of the day though, I think what we care most about is how frequently users are taking advantage of the fact that you can easily make commits with partial changes using our UI. Tracking all of the staging/unstaging events seems like it would be a lot of noise with little additional value. Open to thoughts and suggestions though!

### Benefits

We'll have interesting insights into user behavior, and be able to ask/answer questions such as those above in italics. This information could potentially help us identify UX issues, inform project decisions and priorities, and track the impact of future work and features introduced.

### Possible Drawbacks

This PR simply introduces additional metrics collection. No drawbacks that I can think of. 

### Applicable Issues

#1591

TODO: 
- [x] Possibly instrument commit editor expansion