### PR TITLE
Temporarily disable keytar-reliant tests on AppVeyor

### DIFF
--- a/test/models/github-login-model.test.js
+++ b/test/models/github-login-model.test.js
@@ -14,6 +14,10 @@ describe('GithubLoginModel', function() {
       // once the underlying problem is solved.  See atom/github#1568 for details.
       if (process.env.CI_PROVIDER === 'VSTS') { return; }
 
+      // NOTE: Native modules, including keytar, are not currently building correctly on
+      // AppVeyor. Re-enable these once the underlying problem is solved.
+      if (process.env.APPVEYOR === 'True') { return; }
+
       it('manages passwords', async function() {
         if (!Strategy || await Strategy.isValid()) {
           const loginModel = new GithubLoginModel(Strategy);


### PR DESCRIPTION
All Atom beta and dev-channel builds are currently experiencing issues building native modules correctly. See atom/atom#17997 for the tracking issue. Because it doesn't look like a trivial thing, I'm disabling the failing tests here on AppVeyor until we can work out the root cause.