### PR TITLE
Single line commits

### DIFF
--- a/lib/views/pr-commit-view.js
+++ b/lib/views/pr-commit-view.js
@@ -34,6 +34,10 @@ export default class PrCommitView extends React.Component {
     return (
       <div className="github-PrCommitView-container">
         <div className="github-PrCommitView-commit">
+          <img className="github-PrCommitView-avatar"
+            src={this.props.committerAvatarUrl}
+            alt={'commiter avatar'} title={'committer avatar'}
+          />
           <h3 className="github-PrCommitView-title">
             {emojify(this.props.messageHeadline)}
             {this.props.messageBody ?
@@ -44,24 +48,19 @@ export default class PrCommitView extends React.Component {
               </button>
             : null}
           </h3>
-          <div className="github-PrCommitView-meta">
-            <img className="github-PrCommitView-avatar"
-              src={this.props.committerAvatarUrl}
-              alt={'commiter avatar'} title={'committer avatar'}
-            />
-            <span className="github-PrCommitView-metaText">
-              {this.props.committerName} committed {this.humanizeTimeSince(this.props.date)}
-            </span>
-          </div>
-          {this.state.showMessageBody ? <pre className="github-PrCommitView-moreText">
+          <span className="github-PrCommitView-timeAgo">
+              {this.humanizeTimeSince(this.props.date)}
+          </span>
+          <span className="github-PrCommitView-sha">
+            <a href={this.props.url}
+              title={`open commit ${this.props.abbreviatedOid} on GitHub.com`}>
+              {this.props.abbreviatedOid}
+            </a>
+          </span>
+        </div>
+        
+        {this.state.showMessageBody ? <pre className="github-PrCommitView-moreText">
             {emojify(this.props.messageBody)}</pre> : null}
-        </div>
-        <div className="github-PrCommitView-sha">
-          <a href={this.props.url}
-            title={`open commit ${this.props.abbreviatedOid} on GitHub.com`}>
-            {this.props.abbreviatedOid}
-          </a>
-        </div>
       </div>
     );
   }

--- a/styles/pr-commit-view.less
+++ b/styles/pr-commit-view.less
@@ -1,13 +1,11 @@
 @import 'variables';
 
 @default-padding: @component-padding;
-@avatar-dimensions: 16px;
+@avatar-dimensions: 20px;
 
 .github-PrCommitView {
 
   &-container {
-    display: flex;
-    align-items: center;
     padding: @default-padding;
     font-size: @font-size;
     border: 1px solid @base-border-color;
@@ -27,26 +25,21 @@
   }
 
   &-commit {
-    flex: 1;
-  }
-
-  &-title {
-    margin: 0 0 .25em 0;
-    font-size: 1.2em;
-    line-height: 1.4;
+    display: flex;
   }
 
   &-avatar {
-    border-radius: @component-border-radius;
-    height: @avatar-dimensions;
-    margin-right: .4em;
     width: @avatar-dimensions;
+    height: @avatar-dimensions;
+    margin-right: @default-padding;
+    border-radius: @component-border-radius;
   }
 
-  &-metaText {
-    line-height: @avatar-dimensions;
-    vertical-align: middle;
-    color: @text-color-subtle;
+  &-title {
+    flex: 1;
+    margin: 0;
+    font-size: 1.2em;
+    line-height: 1.4;
   }
 
   &-moreButton {
@@ -65,8 +58,23 @@
     }
   }
 
+  &-timeAgo {
+    margin-left: @default-padding;
+    color: @text-color-subtle;
+  }
+
+  &-sha {
+    margin-left: @default-padding;
+    color: @text-color-info;
+    font-family: var(--editor-font-family);
+    a {
+      color: inherit;
+    }
+  }
+
   &-moreText {
-    margin-top: @default-padding/2;
+    margin-top: @default-padding;
+    margin-left: @avatar-dimensions + @default-padding;
     padding: 0;
     font-size: inherit;
     font-family: var(--editor-font-family);
@@ -74,16 +82,5 @@
     word-break: break-word;
     white-space: initial;
     background-color: transparent;
-  }
-
-  &-sha {
-    margin-left: @default-padding;
-    line-height: @avatar-dimensions;
-    vertical-align: middle;
-    color: @text-color-info;
-    font-family: var(--editor-font-family);
-    a {
-      color: inherit;
-    }
   }
 }


### PR DESCRIPTION
### Description of the Change

This is on top of #1684. It changes the commits list to just a single line.

Before | After
--- | ---
![screen shot 2018-09-14 at 12 15 09 pm](https://user-images.githubusercontent.com/378023/45531614-89373000-b82b-11e8-95af-044c8b307fd1.png) | ![screen shot 2018-09-14 at 2 18 52 pm](https://user-images.githubusercontent.com/378023/45531615-89373000-b82b-11e8-8553-3af72e521c8f.png)

![commits](https://user-images.githubusercontent.com/378023/45531755-33af5300-b82c-11e8-9644-be43f943a70f.gif)

### Alternate Designs

Is _is_ the alternative. :grinning:

### Benefits

- Easier to scan titles. When moving down the titles, there is no interruption.
- Easier to scan "time ago" since they are shown as a column.

### Possible Drawbacks

The name isn't shown anymore. We might could add a title or tooltip to the avatar. And/or make the avatar link to the user profile.

### Applicable Issues

This PR is on top of PR #1684
