### PR TITLE
Add metrics collection for opening issueish in pane or browser

### DIFF
--- a/lib/controllers/issueish-searches-controller.js
+++ b/lib/controllers/issueish-searches-controller.js
@@ -8,6 +8,7 @@ import Search from '../models/search';
 import IssueishSearchContainer from '../containers/issueish-search-container';
 import CurrentPullRequestContainer from '../containers/current-pull-request-container';
 import IssueishDetailItem from '../items/issueish-detail-item';
+import {addEvent} from '../reporter-proxy';
 
 export default class IssueishSearchesController extends React.Component {
   static propTypes = {
@@ -93,7 +94,9 @@ export default class IssueishSearchesController extends React.Component {
         this.props.workingDirectory,
       ),
       {pending: true, searchAllPanes: true},
-    );
+    ).then(() => {
+      addEvent('open-issueish-in-pane', {package: 'github', from: 'issueish-list'});
+    });
   }
 
   onOpenSearch(search) {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -26,7 +26,7 @@ import Switchboard from '../switchboard';
 import {WorkdirContextPoolPropType} from '../prop-types';
 import {destroyFilePatchPaneItems, destroyEmptyFilePatchPaneItems, autobind} from '../helpers';
 import {GitError} from '../git-shell-out-strategy';
-import {incrementCounter} from '../reporter-proxy';
+import {incrementCounter, addEvent} from '../reporter-proxy';
 
 export default class RootController extends React.Component {
   static propTypes = {
@@ -471,7 +471,9 @@ export default class RootController extends React.Component {
   acceptOpenIssueish({repoOwner, repoName, issueishNumber}) {
     const uri = IssueishDetailItem.buildURI('https://api.github.com', repoOwner, repoName, issueishNumber);
     this.setState({openIssueishDialogActive: false});
-    this.props.workspace.open(uri);
+    this.props.workspace.open(uri).then(() => {
+      addEvent('open-issueish-in-pane', {package: 'github', from: 'dialog'});
+    });
   }
 
   cancelOpenIssueish() {

--- a/lib/items/issueish-detail-item.js
+++ b/lib/items/issueish-detail-item.js
@@ -6,6 +6,7 @@ import {autobind} from '../helpers';
 import {GithubLoginModelPropType, WorkdirContextPoolPropType} from '../prop-types';
 import Repository from '../models/repository';
 import IssueishDetailContainer from '../containers/issueish-detail-container';
+import {addEvent} from '../reporter-proxy';
 
 export default class IssueishDetailItem extends Component {
   static propTypes = {
@@ -98,6 +99,7 @@ export default class IssueishDetailItem extends Component {
           prevState.repo === prev.repo &&
           prevState.issueishNumber === prev.issueishNumber
         ) {
+          addEvent('open-issueish-in-pane', {package: 'github', from: 'issueish-link', target: 'current-tab'});
           return {
             owner,
             repo,

--- a/lib/views/github-dotcom-markdown.js
+++ b/lib/views/github-dotcom-markdown.js
@@ -98,7 +98,9 @@ export class BareGithubDotcomMarkdown extends React.Component {
 
   handleClick(event) {
     if (event.target.dataset.url) {
-      this.props.handleClickEvent(event, event.target.dataset.url);
+      return this.props.handleClickEvent(event, event.target.dataset.url);
+    } else {
+      return null;
     }
   }
 

--- a/lib/views/issueish-detail-view.js
+++ b/lib/views/issueish-detail-view.js
@@ -12,6 +12,7 @@ import GithubDotcomMarkdown from '../views/github-dotcom-markdown';
 import PeriodicRefresher from '../periodic-refresher';
 import {EnableableOperationPropType} from '../prop-types';
 import {autobind} from '../helpers';
+import {addEvent} from '../reporter-proxy';
 
 const reactionTypeToEmoji = {
   THUMBS_UP: '👍',
@@ -157,7 +158,7 @@ export class BareIssueishDetailView extends React.Component {
                   state={issueish.state}
                 />
                 <a className="github-IssueishDetailView-headerLink"
-                  href={issueish.url}>{repo.owner.login}/{repo.name}#{issueish.number}
+                  href={issueish.url} onClick={this.recordOpenInBrowserEvent}>{repo.owner.login}/{repo.name}#{issueish.number}
                 </a>
                 {isPr && <span className="github-IssueishDetailView-headerStatus">
                   <PrStatusesView pullRequest={issueish} displayType="check" />
@@ -251,6 +252,10 @@ export class BareIssueishDetailView extends React.Component {
   handleRefreshClick(e) {
     e.preventDefault();
     this.refresher.refreshNow(true);
+  }
+
+  recordOpenInBrowserEvent() {
+    addEvent('open-issueish-in-browser', {package: 'github', from: 'issueish-header'});
   }
 
   refresh() {

--- a/lib/views/issueish-detail-view.js
+++ b/lib/views/issueish-detail-view.js
@@ -158,7 +158,8 @@ export class BareIssueishDetailView extends React.Component {
                   state={issueish.state}
                 />
                 <a className="github-IssueishDetailView-headerLink"
-                  href={issueish.url} onClick={this.recordOpenInBrowserEvent}>{repo.owner.login}/{repo.name}#{issueish.number}
+                  href={issueish.url} onClick={this.recordOpenInBrowserEvent}>
+                  {repo.owner.login}/{repo.name}#{issueish.number}
                 </a>
                 {isPr && <span className="github-IssueishDetailView-headerStatus">
                   <PrStatusesView pullRequest={issueish} displayType="check" />

--- a/lib/views/issueish-link.js
+++ b/lib/views/issueish-link.js
@@ -27,10 +27,10 @@ export function handleClickEvent(event, url) {
   if (!event.shiftKey) {
     event.preventDefault();
     event.stopPropagation();
-    openIssueishLinkInNewTab(url, {activate: !(event.metaKey || event.ctrlKey)});
+    return openIssueishLinkInNewTab(url, {activate: !(event.metaKey || event.ctrlKey)});
   } else {
     // Open in browser if shift key held
-    openLinkInBrowser(url);
+    return openLinkInBrowser(url);
   }
 }
 
@@ -38,7 +38,9 @@ export function handleClickEvent(event, url) {
 export function openIssueishLinkInNewTab(url, options = {}) {
   const uri = getAtomUriForGithubUrl(url);
   if (uri) {
-    openInNewTab(uri, options);
+    return openInNewTab(uri, options);
+  } else {
+    return null;
   }
 }
 

--- a/lib/views/issueish-link.js
+++ b/lib/views/issueish-link.js
@@ -43,8 +43,16 @@ export function openIssueishLinkInNewTab(url, options = {}) {
 }
 
 export function openLinkInBrowser(uri) {
-  shell.openExternal(uri);
-  addEvent('open-issueish-in-browser', {package: 'github', from: 'issueish-link'});
+  return new Promise((resolve, reject) => {
+    shell.openExternal(uri, {}, err => {
+      if (err) {
+        reject(err);
+      } else {
+        addEvent('open-issueish-in-browser', {package: 'github', from: 'issueish-link'});
+        resolve();
+      }
+    });
+  });
 }
 
 function getAtomUriForGithubUrl(githubUrl) {
@@ -66,14 +74,7 @@ function getUriForData({hostname, repoOwner, repoName, type, issueishNumber}) {
 }
 
 function openInNewTab(uri, {activate} = {activate: true}) {
-  let promise;
-  if (activate) {
-    promise = atom.workspace.open(uri, {activateItem: activate});
-  } else {
-    const item = IssueishDetailItem.opener(uri);
-    promise = atom.workspace.getActivePane().addItem(item);
-  }
-  promise.then(() => {
+  return atom.workspace.open(uri, {activateItem: activate}).then(() => {
     addEvent('open-issueish-in-pane', {package: 'github', from: 'issueish-link', target: 'new-tab'});
   });
 }

--- a/lib/views/issueish-link.js
+++ b/lib/views/issueish-link.js
@@ -24,9 +24,9 @@ IssueishLink.propTypes = {
 
 // eslint-disable-next-line no-shadow
 export function handleClickEvent(event, url) {
+  event.preventDefault();
+  event.stopPropagation();
   if (!event.shiftKey) {
-    event.preventDefault();
-    event.stopPropagation();
     return openIssueishLinkInNewTab(url, {activate: !(event.metaKey || event.ctrlKey)});
   } else {
     // Open in browser if shift key held

--- a/lib/views/issueish-link.js
+++ b/lib/views/issueish-link.js
@@ -5,6 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import IssueishDetailItem from '../items/issueish-detail-item';
+import {addEvent} from '../reporter-proxy';
 
 // eslint-disable-next-line no-shadow
 export default function IssueishLink({url, children, ...others}) {
@@ -43,6 +44,7 @@ export function openIssueishLinkInNewTab(url, options = {}) {
 
 export function openLinkInBrowser(uri) {
   shell.openExternal(uri);
+  addEvent('open-issueish-in-browser', {package: 'github', from: 'issueish-link'});
 }
 
 function getAtomUriForGithubUrl(githubUrl) {
@@ -64,10 +66,14 @@ function getUriForData({hostname, repoOwner, repoName, type, issueishNumber}) {
 }
 
 function openInNewTab(uri, {activate} = {activate: true}) {
+  let promise;
   if (activate) {
-    atom.workspace.open(uri, {activateItem: activate});
+    promise = atom.workspace.open(uri, {activateItem: activate});
   } else {
     const item = IssueishDetailItem.opener(uri);
-    atom.workspace.getActivePane().addItem(item);
+    promise = atom.workspace.getActivePane().addItem(item);
   }
+  promise.then(() => {
+    addEvent('open-issueish-in-pane', {package: 'github', from: 'issueish-link', target: 'new-tab'});
+  });
 }

--- a/test/atom/decoration.test.js
+++ b/test/atom/decoration.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import sinon from 'sinon';
 import {mount} from 'enzyme';
 
 import Decoration from '../../lib/atom/decoration';

--- a/test/controllers/issueish-searches-controller.test.js
+++ b/test/controllers/issueish-searches-controller.test.js
@@ -10,6 +10,7 @@ import Branch from '../../lib/models/branch';
 import BranchSet from '../../lib/models/branch-set';
 import Issueish from '../../lib/models/issueish';
 import {nullOperationStateObserver} from '../../lib/models/operation-state-observer';
+import * as reporterProxy from '../../lib/reporter-proxy';
 
 describe('IssueishSearchesController', function() {
   let atomEnv;
@@ -87,7 +88,7 @@ describe('IssueishSearchesController', function() {
     }
   });
 
-  it('passes a handler to open an issueish pane', async function() {
+  it('passes a handler to open an issueish pane and reports an event', async function() {
     sinon.spy(atomEnv.workspace, 'open');
 
     const wrapper = shallow(buildApp());
@@ -95,6 +96,7 @@ describe('IssueishSearchesController', function() {
 
     const issueish = new Issueish(createPullRequestResult({number: 123}));
 
+    sinon.stub(reporterProxy, 'addEvent');
     await container.prop('onOpenIssueish')(issueish);
     assert.isTrue(
       atomEnv.workspace.open.calledWith(
@@ -102,5 +104,6 @@ describe('IssueishSearchesController', function() {
         {pending: true, searchAllPanes: true},
       ),
     );
+    assert.isTrue(reporterProxy.addEvent.calledWith('open-issueish-in-pane', {package: 'github', from: 'issueish-list'}));
   });
 });

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -1072,5 +1072,15 @@ describe('RootController', function() {
       assert.strictEqual(item.getTitle(), 'owner/repo#123');
       assert.lengthOf(wrapper.update().find('IssueishDetailItem'), 1);
     });
+
+    describe('acceptOpenIssueish', function() {
+      it('records an event', async function() {
+        const wrapper = mount(app);
+        sinon.stub(reporterProxy, 'addEvent');
+        sinon.stub(workspace, 'open').returns(Promise.resolve());
+        await wrapper.instance().acceptOpenIssueish({repoOwner: 'owner', repoName: 'repo', issueishNumber: 123});
+        assert.isTrue(reporterProxy.addEvent.calledWith('open-issueish-in-pane', {package: 'github', from: 'dialog'}));
+      });
+    });
   });
 });

--- a/test/items/issueish-detail-item.test.js
+++ b/test/items/issueish-detail-item.test.js
@@ -7,6 +7,7 @@ import IssueishDetailItem from '../../lib/items/issueish-detail-item';
 import PaneItem from '../../lib/atom/pane-item';
 import WorkdirContextPool from '../../lib/models/workdir-context-pool';
 import {issueishPaneItemProps} from '../fixtures/props/issueish-pane-props';
+import * as reporterProxy from '../../lib/reporter-proxy';
 
 describe('IssueishDetailItem', function() {
   let atomEnv, subs;
@@ -169,6 +170,17 @@ describe('IssueishDetailItem', function() {
       assert.strictEqual(wrapper.find('IssueishDetailContainer').prop('repo'), 'atom');
       assert.strictEqual(wrapper.find('IssueishDetailContainer').prop('issueishNumber'), 100);
       assert.isTrue(wrapper.find('IssueishDetailContainer').prop('repository').isAbsent());
+    });
+
+    it('records an event after switching', async function() {
+      const wrapper = mount(buildApp({workdirContextPool}));
+      await atomEnv.workspace.open(IssueishDetailItem.buildURI('host.com', 'me', 'original', 1, __dirname));
+
+      wrapper.update();
+
+      sinon.stub(reporterProxy, 'addEvent');
+      await wrapper.find('IssueishDetailContainer').prop('switchToIssueish')('atom', 'github', 2);
+      assert.isTrue(reporterProxy.addEvent.calledWith('open-issueish-in-pane', {package: 'github', from: 'issueish-link', target: 'current-tab'}));
     });
   });
 

--- a/test/views/changed-files-count-view.test.js
+++ b/test/views/changed-files-count-view.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import sinon from 'sinon';
 
 import ChangedFilesCountView from '../../lib/views/changed-files-count-view';
 import * as reporterProxy from '../../lib/reporter-proxy';

--- a/test/views/github-dotcom-markdown.test.js
+++ b/test/views/github-dotcom-markdown.test.js
@@ -239,6 +239,8 @@ describe('GithubDotcomMarkdown', function() {
               url: 'https://github.com/aaa/bbb/issues/123',
             },
           },
+          preventDefault: () => {},
+          stopPropagation: () => {},
         }),
       );
 

--- a/test/views/github-dotcom-markdown.test.js
+++ b/test/views/github-dotcom-markdown.test.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import {mount} from 'enzyme';
+import {shell} from 'electron';
 
 import {BareGithubDotcomMarkdown} from '../../lib/views/github-dotcom-markdown';
+import {handleClickEvent, openIssueishLinkInNewTab, openLinkInBrowser} from '../../lib/views/issueish-link';
 import RelayNetworkLayerManager from '../../lib/relay-network-layer-manager';
+import * as reporterProxy from '../../lib/reporter-proxy';
 
 describe('GithubDotcomMarkdown', function() {
   let relayEnvironment;
@@ -34,7 +37,7 @@ describe('GithubDotcomMarkdown', function() {
   });
 
   it('intercepts click events on issueish links', function() {
-    const handleClickEvent = sinon.stub();
+    const handleClickEventStub = sinon.stub();
 
     const wrapper = mount(buildApp({
       html: `
@@ -57,7 +60,7 @@ describe('GithubDotcomMarkdown', function() {
           in it
         </p>
       `,
-      handleClickEvent,
+      handleClickEvent: handleClickEventStub,
     }));
 
     const issueishLink = wrapper.getDOMNode().querySelector('a.issue-link');
@@ -66,7 +69,7 @@ describe('GithubDotcomMarkdown', function() {
       cancelable: true,
     }));
 
-    assert.strictEqual(handleClickEvent.callCount, 1);
+    assert.strictEqual(handleClickEventStub.callCount, 1);
 
     const nonIssueishLink = wrapper.getDOMNode().querySelector('a.other');
     nonIssueishLink.dispatchEvent(new MouseEvent('click', {
@@ -74,7 +77,7 @@ describe('GithubDotcomMarkdown', function() {
       cancelable: true,
     }));
 
-    assert.strictEqual(handleClickEvent.callCount, 1);
+    assert.strictEqual(handleClickEventStub.callCount, 1);
 
     // Force a componentDidUpdate to exercise tooltip handler re-registration
     wrapper.setProps({});
@@ -84,9 +87,9 @@ describe('GithubDotcomMarkdown', function() {
   });
 
   it('registers command handlers', function() {
-    const openIssueishLinkInNewTab = sinon.stub();
-    const openLinkInBrowser = sinon.stub();
-    const switchToIssueish = sinon.stub();
+    const openIssueishLinkInNewTabStub = sinon.stub();
+    const openLinkInBrowserStub = sinon.stub();
+    const switchToIssueishStub = sinon.stub();
 
     const wrapper = mount(buildApp({
       html: `
@@ -94,21 +97,108 @@ describe('GithubDotcomMarkdown', function() {
           <a data-url="https://github.com/aaa/bbb/issue/123" href="https://github.com/aaa/bbb/issue/123">#123</a>
         </p>
       `,
-      openIssueishLinkInNewTab,
-      openLinkInBrowser,
-      switchToIssueish,
+      openIssueishLinkInNewTab: openIssueishLinkInNewTabStub,
+      openLinkInBrowser: openLinkInBrowserStub,
+      switchToIssueish: switchToIssueishStub,
     }));
 
     const link = wrapper.getDOMNode().querySelector('a');
     const href = 'https://github.com/aaa/bbb/issue/123';
 
     atom.commands.dispatch(link, 'github:open-link-in-new-tab');
-    assert.isTrue(openIssueishLinkInNewTab.calledWith(href));
+    assert.isTrue(openIssueishLinkInNewTabStub.calledWith(href));
 
     atom.commands.dispatch(link, 'github:open-link-in-this-tab');
-    assert.isTrue(switchToIssueish.calledWith('aaa', 'bbb', 123));
+    assert.isTrue(switchToIssueishStub.calledWith('aaa', 'bbb', 123));
 
     atom.commands.dispatch(link, 'github:open-link-in-browser');
-    assert.isTrue(openLinkInBrowser.calledWith(href));
+    assert.isTrue(openLinkInBrowserStub.calledWith(href));
+  });
+
+  describe('opening issueish links', function() {
+    let wrapper;
+
+    beforeEach(function() {
+      wrapper = mount(buildApp({
+        html: `
+          <p>
+            <a
+              class="issue-link"
+              data-url="https://github.com/aaa/bbb/issues/123"
+              href="https://github.com/aaa/bbb/issues/123">
+              an issueish link
+            </a>
+          </p>
+        `,
+        handleClickEvent,
+        openIssueishLinkInNewTab,
+        openLinkInBrowser,
+      }));
+    });
+
+    it('opens item in pane and activates accordingly', async function() {
+      sinon.stub(atom.workspace, 'open').returns(Promise.resolve());
+      const issueishLink = wrapper.getDOMNode().querySelector('a.issue-link');
+
+      // regular click opens item and activates it
+      issueishLink.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }));
+
+      await assert.async.isTrue(atom.workspace.open.called);
+      assert.deepEqual(atom.workspace.open.lastCall.args[1], {activateItem: true});
+
+      // holding down meta key simply opens item
+      issueishLink.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        metaKey: true,
+      }));
+
+      await assert.async.isTrue(atom.workspace.open.calledTwice);
+      assert.deepEqual(atom.workspace.open.lastCall.args[1], {activateItem: false});
+    });
+
+    it('records event for opening issueish in pane item', async function() {
+      sinon.stub(atom.workspace, 'open').returns(Promise.resolve());
+      sinon.stub(reporterProxy, 'addEvent');
+      const issueishLink = wrapper.getDOMNode().querySelector('a.issue-link');
+      issueishLink.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }));
+
+      await assert.async.isTrue(reporterProxy.addEvent.calledWith('open-issueish-in-pane', {package: 'github', from: 'issueish-link', target: 'new-tab'}));
+    });
+
+    it('opens item in browser if shift key is pressed', function() {
+      sinon.stub(shell, 'openExternal').callsArg(2);
+
+      const issueishLink = wrapper.getDOMNode().querySelector('a.issue-link');
+
+      issueishLink.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        shiftKey: true,
+      }));
+
+      assert.isTrue(shell.openExternal.called);
+    });
+
+    it('records event for opening issueish in browser', async function() {
+      sinon.stub(shell, 'openExternal').callsArg(2);
+      sinon.stub(reporterProxy, 'addEvent');
+
+      const issueishLink = wrapper.getDOMNode().querySelector('a.issue-link');
+
+      issueishLink.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        shiftKey: true,
+      }));
+
+      await assert.async.isTrue(reporterProxy.addEvent.calledWith('open-issueish-in-browser', {package: 'github', from: 'issueish-link'}));
+    });
   });
 });

--- a/test/views/github-dotcom-markdown.test.js
+++ b/test/views/github-dotcom-markdown.test.js
@@ -175,11 +175,21 @@ describe('GithubDotcomMarkdown', function() {
     it('does not record event if opening issueish in pane item fails', function() {
       sinon.stub(atom.workspace, 'open').returns(Promise.reject());
       sinon.stub(reporterProxy, 'addEvent');
-      const issueishLink = wrapper.getDOMNode().querySelector('a.issue-link');
-      issueishLink.dispatchEvent(new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      }));
+
+      // calling `handleClick` directly rather than dispatching event so that we can catch the error thrown and prevent errors in the console
+      assert.isRejected(
+        wrapper.instance().handleClick({
+          bubbles: true,
+          cancelable: true,
+          target: {
+            dataset: {
+              url: 'https://github.com/aaa/bbb/issues/123',
+            },
+          },
+          preventDefault: () => {},
+          stopPropagation: () => {},
+        }),
+      );
 
       assert.isTrue(atom.workspace.open.called);
       assert.isFalse(reporterProxy.addEvent.called);
@@ -232,6 +242,7 @@ describe('GithubDotcomMarkdown', function() {
         }),
       );
 
+      assert.isTrue(shell.openExternal.called);
       assert.isFalse(reporterProxy.addEvent.called);
     });
   });

--- a/test/views/issueish-detail-view.test.js
+++ b/test/views/issueish-detail-view.test.js
@@ -4,6 +4,7 @@ import {shallow} from 'enzyme';
 import {BareIssueishDetailView, checkoutStates} from '../../lib/views/issueish-detail-view';
 import {issueishDetailViewProps} from '../fixtures/props/issueish-pane-props';
 import EnableableOperation from '../../lib/models/enableable-operation';
+import * as reporterProxy from '../../lib/reporter-proxy';
 
 describe('IssueishDetailView', function() {
   function buildApp(opts, overrideProps = {}) {
@@ -230,6 +231,25 @@ describe('IssueishDetailView', function() {
       const wrapper = shallow(buildApp({}, {checkoutOp}));
 
       assert.isFalse(wrapper.find('.github-IssueishDetailView-checkoutButton').exists());
+    });
+  });
+
+  describe('clicking link to view issueish link', function() {
+    it('records an event', function() {
+      const wrapper = shallow(buildApp({
+        repositoryName: 'repo',
+        ownerLogin: 'user0',
+        issueishNumber: 100,
+      }));
+
+      sinon.stub(reporterProxy, 'addEvent');
+
+      const link = wrapper.find('a.github-IssueishDetailView-headerLink');
+      assert.strictEqual(link.text(), 'user0/repo#100');
+      assert.strictEqual(link.prop('href'), 'https://github.com/user0/repo/pull/100');
+      link.simulate('click');
+
+      assert.isTrue(reporterProxy.addEvent.calledWith('open-issueish-in-browser', {package: 'github', from: 'issueish-header'}));
     });
   });
 });


### PR DESCRIPTION
### Description of the Change

There are currently six ways of viewing details for an issueish from our package (at least as far as I can tell... please let me know if you can think of another!). I have instrumented each of them and added a corresponding test. 

Added the following events and metadata:
* clicking an issueish link in an IssueishDetailView opens another IssueishDetailView in a new tab
`'open-issueish-in-pane', {from: 'issueish-link', target: 'new-tab'}`
* cmd-clicking an issueish link in an IssueishDetailView opens another IssueishDetailView in the current tab
`'open-issueish-in-pane', {from: 'issueish-link', target: 'current-tab'}`
* clicking an issueish item in the IssueishListView opens an IssueishDetailView in a new tab
`'open-issueish-in-pane', {from: 'issueish-list'}`
* pasting an issueish link in the OpenIssueishDialog opens an IssueishDetailView in a new tab
`'open-issueish-in-pane', {from: 'dialog'}`
* shift-clicking an issueish link in an IssueishDetailView opens the issueish page on dotcom
`'open-issueish-in-browser', {from: 'issueish-link'}`
* clicking the issueish reference in the header of the IssueishDetailView opens the corresponding issueish page on dotcom
`'open-issueish-in-browser', {from: 'issueish-header'}`

In the process I also caught a bug -- cmd-clicking an issueish link used to throw the following error:
<details>
<summary>Uncaught TypeError: _issueishDetailItem2.default.opener is not a function</summary>
Thrown From: [github](https://github.com/atom/github) package 0.19.0
At /Users/kuychaco/.atom/packages/github/lib/views/issueish-link.js:70
TypeError: _issueishDetailItem2.default.opener is not a function
    at openInNewTab (/packages/github/lib/views/issueish-link.js:70:37)
    at openIssueishLinkInNewTab (/packages/github/lib/views/issueish-link.js:40:5)
    at Object.handleClickEvent (/packages/github/lib/views/issueish-link.js:29:5)
    at BareGithubDotcomMarkdown.handleClick (/packages/github/lib/views/github-dotcom-markdown.js:101:18)
</details>


### Alternate Designs

Rather than having separate events for viewing the issueish in a pane or browser, I considered using only one event type of `open-issueish` and adding target pane/browser information to the metadata. I decided to keep them separate because there is a clear distinction between the intention as well as the impact of the two types of events, namely that `open-issueish-in-pane` keeps you in Atom whereas `open-issueish-in-browser` takes you out of Atom. 

### Benefits

These changes will shed light on behavior when viewing PR and issue information, potentially inform decisions around product and project work, as well as help us assess the impact of future changes we make. 

Here are some questions we might get insight into from collecting these metrics:
* How frequently are people leaving Atom to view information in the browser?
  * How does this change as we add more GitHub information and features into Atom?
* What entry points are being used to view issueish information? 
* Are people using the open issue dialog to specify a PR/issue to view? Currently you can only access this using a command `github:open-issue-or-pull-request`
* Are there discoverability issues for any of the entry points listed above? What is the impact of taking steps to improve discoverability?
* What are the usage statistics for the issue list view in the GitHub tab?
* What are the usage statistics for viewing issues/PRs that are referenced as part of an issue/PR that is being viewed?

### Possible Drawbacks

None that I can think of...

### Applicable Issues

#1591
