### PR TITLE
Ignore diagnostic view files for cache and git timing information

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -4,7 +4,7 @@
   "include": [
     "lib/**/*.js"
   ],
-  exclude: [
+  "exclude": [
     "lib/views/git-cache-view.js",
     "lib/views/git-timings-view.js"
   ]

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -3,5 +3,9 @@
   "source-map": false,
   "include": [
     "lib/**/*.js"
+  ],
+  exclude: [
+    "lib/views/git-cache-view.js",
+    "lib/views/git-timings-view.js"
   ]
 }


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

We track code coverage using Coveralls. Some of our files are for diagnostic purposes and don't require tests. This PR excludes these files so that we can get a more accurate sense of how we're doing in terms of code coverage.

Files excluded:
* lib/views/git-cache-view.js -- for displaying cache diagnostics
* lib/views/git-timings-view.js -- for displaying git command timings in a waterfall view

### Alternate Designs

Not applicable.

### Benefits

More accurate test coverage reports. That is, the percentage coverage will convey what we've covered relative to all that we intend/hope to cover.

### Possible Drawbacks

None that I can think of.

### Applicable Issues

None
