### PR TITLE
Fix: handle branch names mismatch

### DIFF
--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -171,14 +171,19 @@ export default class StatusBarTileController extends React.Component {
 
   push(data) {
     return ({force, setUpstream} = {}) => {
-      const upstream = data.currentBranch.getUpstream();
-      const branchRef = upstream.getShortRemoteRef() !== data.currentBranch.getName()
-        ? `${data.currentBranch.getName()}:${upstream.getShortRemoteRef()}`
-        : data.currentBranch.getName();
-      return this.props.repository.push(branchRef, {
+      // const upstream = data.currentBranch.getUpstream();
+      // const branchRef = upstream.getShortRemoteRef() !== data.currentBranch.getName()
+      //   ? `${data.currentBranch.getName()}:${upstream.getShortRemoteRef()}`
+      //   : data.currentBranch.getName();
+      // return this.props.repository.push(branchRef, {
+      //   force,
+      //   setUpstream,
+      //   remoteName: upstream.getRemoteName(),
+      // });
+      return this.props.repository.push(data.currentBranch.getName(), {
         force,
         setUpstream,
-        remoteName: upstream.getRemoteName(),
+        refSpec: data.currentBranch.getRefSpec('PUSH'),
       });
     };
   }
@@ -186,8 +191,8 @@ export default class StatusBarTileController extends React.Component {
   pull(data) {
     return () => {
       debugger;
-      const upstream = data.currentBranch.getUpstream();
-      return this.props.repository.pull(upstream.getRemoteRef(), {remoteName: upstream.getRemoteName()});
+      // const upstream = data.currentBranch.getUpstream();
+      return this.props.repository.pull(data.currentBranch.getName(), {refSpec: data.currentBranch.getRefSpec('PULL')});
     };
   }
 

--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -176,10 +176,10 @@ export default class StatusBarTileController extends React.Component {
   }
 
   pull(data) {
-    return () => this.props.repository.pull(data.currentBranch.getName());
+    return () => this.props.repository.pull(data.currentBranch.getFullRef());
   }
 
   fetch(data) {
-    return () => this.props.repository.fetch(data.currentBranch.getName());
+    return () => this.props.repository.fetch(data.currentBranch.getFullRef());
   }
 }

--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -182,7 +182,7 @@ export default class StatusBarTileController extends React.Component {
   pull(data) {
     return () => {
       return this.props.repository.pull(data.currentBranch.getName(), {
-        // refSpec: data.currentBranch.getRefSpec("PULL")
+        refSpec: data.currentBranch.getRefSpec('PULL'),
       });
     };
   }
@@ -191,7 +191,7 @@ export default class StatusBarTileController extends React.Component {
     return () => {
       const upstream = data.currentBranch.getUpstream();
       return this.props.repository.fetch(upstream.getRemoteRef(), {
-        remoteName: upstream.getRemoteName()
+        remoteName: upstream.getRemoteName(),
       });
     };
   }

--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -171,15 +171,6 @@ export default class StatusBarTileController extends React.Component {
 
   push(data) {
     return ({force, setUpstream} = {}) => {
-      // const upstream = data.currentBranch.getUpstream();
-      // const branchRef = upstream.getShortRemoteRef() !== data.currentBranch.getName()
-      //   ? `${data.currentBranch.getName()}:${upstream.getShortRemoteRef()}`
-      //   : data.currentBranch.getName();
-      // return this.props.repository.push(branchRef, {
-      //   force,
-      //   setUpstream,
-      //   remoteName: upstream.getRemoteName(),
-      // });
       return this.props.repository.push(data.currentBranch.getName(), {
         force,
         setUpstream,
@@ -190,16 +181,18 @@ export default class StatusBarTileController extends React.Component {
 
   pull(data) {
     return () => {
-      debugger;
-      // const upstream = data.currentBranch.getUpstream();
-      return this.props.repository.pull(data.currentBranch.getName(), {refSpec: data.currentBranch.getRefSpec('PULL')});
+      return this.props.repository.pull(data.currentBranch.getName(), {
+        // refSpec: data.currentBranch.getRefSpec("PULL")
+      });
     };
   }
 
   fetch(data) {
     return () => {
       const upstream = data.currentBranch.getUpstream();
-      return this.props.repository.fetch(upstream.getRemoteRef(), {remoteName: upstream.getRemoteName()});
+      return this.props.repository.fetch(upstream.getRemoteRef(), {
+        remoteName: upstream.getRemoteName()
+      });
     };
   }
 }

--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -171,19 +171,30 @@ export default class StatusBarTileController extends React.Component {
 
   push(data) {
     return ({force, setUpstream} = {}) => {
-      return this.props.repository.push(data.currentBranch.getName(), {force, setUpstream});
+      const upstream = data.currentBranch.getUpstream();
+      const branchRef = upstream.getShortRemoteRef() !== data.currentBranch.getName()
+        ? `${data.currentBranch.getName()}:${upstream.getShortRemoteRef()}`
+        : data.currentBranch.getName();
+      return this.props.repository.push(branchRef, {
+        force,
+        setUpstream,
+        remoteName: upstream.getRemoteName(),
+      });
     };
   }
 
   pull(data) {
-    return () => this.props.repository.pull(data.currentBranch.getFullRef(), {
-      remoteName: data.currentRemote.getName(),
-    });
+    return () => {
+      debugger;
+      const upstream = data.currentBranch.getUpstream();
+      return this.props.repository.pull(upstream.getRemoteRef(), {remoteName: upstream.getRemoteName()});
+    };
   }
 
   fetch(data) {
-    return () => this.props.repository.fetch(data.currentBranch.getFullRef(), {
-      remoteName: data.currentRemote.getName(),
-    });
+    return () => {
+      const upstream = data.currentBranch.getUpstream();
+      return this.props.repository.fetch(upstream.getRemoteRef(), {remoteName: upstream.getRemoteName()});
+    };
   }
 }

--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -176,10 +176,14 @@ export default class StatusBarTileController extends React.Component {
   }
 
   pull(data) {
-    return () => this.props.repository.pull(data.currentBranch.getFullRef());
+    return () => this.props.repository.pull(data.currentBranch.getFullRef(), {
+      remoteName: data.currentRemote.getName(),
+    });
   }
 
   fetch(data) {
-    return () => this.props.repository.fetch(data.currentBranch.getFullRef());
+    return () => this.props.repository.fetch(data.currentBranch.getFullRef(), {
+      remoteName: data.currentRemote.getName(),
+    });
   }
 }

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -787,7 +787,7 @@ export default class GitShellOutStrategy {
   }
 
   pull(remoteName, branchName, options = {}) {
-    const args = ["pull", remoteName, options.refSpec || branchName];
+    const args = ['pull', remoteName, options.refSpec || branchName];
     if (options.ffOnly) {
       args.push('--ff-only');
     }

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -787,7 +787,7 @@ export default class GitShellOutStrategy {
   }
 
   pull(remoteName, branchName, options = {}) {
-    const args = ['pull', remoteName, branchName];
+    const args = ["pull", remoteName, options.refSpec || branchName];
     if (options.ffOnly) {
       args.push('--ff-only');
     }
@@ -795,7 +795,7 @@ export default class GitShellOutStrategy {
   }
 
   push(remoteName, branchName, options = {}) {
-    const args = ['push', remoteName || 'origin', `refs/heads/${branchName}`];
+    const args = ['push', remoteName || 'origin', options.refSpec || `refs/heads/${branchName}`];
     if (options.setUpstream) { args.push('--set-upstream'); }
     if (options.force) { args.push('--force'); }
     return this.exec(args, {useGitPromptServer: true, writeOperation: true});

--- a/lib/models/branch.js
+++ b/lib/models/branch.js
@@ -67,6 +67,23 @@ export default class Branch {
     return this.getRemoteRef().replace(/^(refs\/)?((heads|remotes)\/)?/, '');
   }
 
+  getRefSpec(action) {
+    debugger
+    if (this.isRemoteTracking()) {
+      return '';
+    }
+    const remoteBranch = action === 'PUSH' ? this.push : this.upstream;
+    const remoteBranchName = remoteBranch.getShortRemoteRef();
+    const localBranchName = this.getName();
+    if (remoteBranchName !== localBranchName) {
+      const refSpec = action === 'PUSH'
+        ? `${localBranchName}:${remoteBranchName}`
+        : `${remoteBranchName}:${localBranchName}`;
+      return refSpec;
+    }
+    return localBranchName;
+  }
+
   getSha() {
     return this.attributes.sha || '';
   }
@@ -94,6 +111,7 @@ export default class Branch {
   isPresent() {
     return true;
   }
+
 }
 
 export const nullBranch = {

--- a/lib/models/branch.js
+++ b/lib/models/branch.js
@@ -75,10 +75,11 @@ export default class Branch {
     const remoteBranchName = remoteBranch.getShortRemoteRef();
     const localBranchName = this.getName();
     if (remoteBranchName && remoteBranchName !== localBranchName) {
-      const refSpec = action === 'PUSH'
-        ? `${localBranchName}:${remoteBranchName}`
-        : `${remoteBranchName}:${localBranchName}`;
-      return refSpec;
+      if (action === 'PUSH') {
+        return `${localBranchName}:${remoteBranchName}`;
+      } else if (action === 'PULL') {
+        return `${remoteBranchName}:${localBranchName}`;
+      }
     }
     return localBranchName;
   }

--- a/lib/models/branch.js
+++ b/lib/models/branch.js
@@ -68,14 +68,13 @@ export default class Branch {
   }
 
   getRefSpec(action) {
-    debugger
     if (this.isRemoteTracking()) {
       return '';
     }
     const remoteBranch = action === 'PUSH' ? this.push : this.upstream;
     const remoteBranchName = remoteBranch.getShortRemoteRef();
     const localBranchName = this.getName();
-    if (remoteBranchName !== localBranchName) {
+    if (remoteBranchName && remoteBranchName !== localBranchName) {
       const refSpec = action === 'PUSH'
         ? `${localBranchName}:${remoteBranchName}`
         : `${remoteBranchName}:${localBranchName}`;

--- a/test/controllers/status-bar-tile-controller.test.js
+++ b/test/controllers/status-bar-tile-controller.test.js
@@ -12,7 +12,7 @@ import StatusBarTileController from '../../lib/controllers/status-bar-tile-contr
 import BranchView from '../../lib/views/branch-view';
 import ChangedFilesCountView from '../../lib/views/changed-files-count-view';
 
-describe.only('StatusBarTileController', function() {
+describe('StatusBarTileController', function() {
   let atomEnvironment;
   let workspace, workspaceElement, commandRegistry, notificationManager, tooltips, confirm;
 

--- a/test/controllers/status-bar-tile-controller.test.js
+++ b/test/controllers/status-bar-tile-controller.test.js
@@ -654,7 +654,7 @@ describe('StatusBarTileController', function() {
 
   describe('when the local branch is named differently from the remote branch it\'s tracking', function() {
     let repository, wrapper;
-    
+
     beforeEach(async function() {
       const {localRepoPath} = await setUpLocalAndRemoteRepositories();
       repository = await buildRepository(localRepoPath);
@@ -669,7 +669,7 @@ describe('StatusBarTileController', function() {
         .instance()
         .fetch(await wrapper.instance().fetchData(repository))();
       assert.isTrue(repository.fetch.calledWith('refs/heads/master', {
-        remoteName: 'origin'
+        remoteName: 'origin',
       }));
     });
 

--- a/test/controllers/status-bar-tile-controller.test.js
+++ b/test/controllers/status-bar-tile-controller.test.js
@@ -661,7 +661,9 @@ describe('StatusBarTileController', function() {
       await wrapper
         .instance()
         .fetch(await wrapper.instance().fetchData(repository))();
-      assert.isTrue(repository.fetch.called);
+      assert.isTrue(repository.fetch.calledWith('refs/heads/master', {
+        remoteName: 'origin'
+      }));
     });
 
     it('pulls from the correct branch', async function() {
@@ -672,7 +674,9 @@ describe('StatusBarTileController', function() {
         .instance()
         .pull(await wrapper.instance().fetchData(repository))();
       const postPullSHA = await repository.git.exec(['rev-parse', 'HEAD']);
-      assert.isTrue(repository.pull.called);
+      assert.isTrue(repository.pull.calledWith('another-name', {
+        refSpec: 'master:another-name',
+      }));
       assert.equal(prePullSHA, postPullSHA);
     });
 
@@ -684,7 +688,9 @@ describe('StatusBarTileController', function() {
         .instance()
         .push(await wrapper.instance().fetchData(repository))();
       const remoteSHA = await repository.git.exec(['rev-parse', 'origin/master']);
-      assert.isTrue(repository.push.called);
+      assert.isTrue(repository.push.calledWith('another-name',
+        sinon.match({refSpec: 'another-name:master'}),
+      ));
       assert.equal(localSHA, remoteSHA);
     });
 


### PR DESCRIPTION
### Description of the Change

This PR introduces the use of `refspec` in push and pull operations (fetch does it a bit differently), in order to handle situations where the local branch is named differently from its tracking branch. This set of circumstances has become less of an edge case since the introduction of PR-checkout -- we prefix the branch name with PR number, etc. 

### Benefits

- Able to fetch, pull, push checked out PRs
- Able to be creative in naming your local branches 👯 

### Possible Drawbacks

This PR changes how the underlying git operations work, which is used by many things in the package; so the possible setback is if things break in edge cases that I haven't thought of.

### Applicable Issues

fixes: #1697 
fixes: #918 

### Metrics

N/A

### Tests

Added unit tests to verify that push & pull & fetch work as expected despite the difference between local branch name and its upstream branch name. 

Manually tested push & pull & fetch operations in these cases:
- local branch named differently from upstream
- local branch named the same as upstream
- checked out PR from a branch in the original repo
- checked out PR opened from a forked repo

