### PR TITLE
Fix the React devtools installer

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -408,8 +408,7 @@ export default class RootController extends React.Component {
     await fs.ensureDir(extensionFolder, 0o755);
     await devTools.default(devTools.REACT_DEVELOPER_TOOLS);
 
-    // eslint-disable-next-line no-console
-    console.log('🌈 Reload your window to start using the React dev tools!');
+    this.props.notificationManager.addSuccess('🌈 Reload your window to start using the React dev tools!');
   }
 
   getRepositoryForWorkdir(workdir) {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
+import {remote} from 'electron';
 
 import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
@@ -373,11 +374,38 @@ export default class RootController extends React.Component {
     }
   }
 
-  installReactDevTools() {
+  async installReactDevTools() {
     // Prevent electron-link from attempting to descend into electron-devtools-installer, which is not available
     // when we're bundled in Atom.
     const devToolsName = 'electron-devtools-installer';
     const devTools = require(devToolsName);
+
+    const crossUnzipName = 'cross-unzip';
+    const unzip = require(crossUnzipName);
+
+    const reactId = devTools.REACT_DEVELOPER_TOOLS.id;
+
+    const url =
+      'https://clients2.google.com/service/update2/crx?' +
+      `response=redirect&x=id%3D${reactId}%26uc&prodversion=32`;
+    const extensionFolder = path.resolve(remote.app.getPath('userData'), `extensions/${reactId}`);
+    const extensionFile = `${extensionFolder}.crx`;
+    await fs.ensureDir(path.dirname(extensionFile));
+    const response = await fetch(url, {method: 'GET'});
+    const body = Buffer.from(await response.arrayBuffer());
+    await fs.writeFile(extensionFile, body);
+
+    await new Promise((resolve, reject) => {
+      unzip(extensionFile, extensionFolder, async err => {
+        if (err && !await fs.exists(path.join(extensionFolder, 'manifest.json'))) {
+          reject(err);
+        }
+
+        resolve();
+      });
+    });
+
+    await fs.ensureDir(extensionFolder, 0o755);
     devTools.default(devTools.REACT_DEVELOPER_TOOLS);
   }
 

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -406,7 +406,10 @@ export default class RootController extends React.Component {
     });
 
     await fs.ensureDir(extensionFolder, 0o755);
-    devTools.default(devTools.REACT_DEVELOPER_TOOLS);
+    await devTools.default(devTools.REACT_DEVELOPER_TOOLS);
+
+    // eslint-disable-next-line no-console
+    console.log('🌈 Reload your window to start using the React dev tools!');
   }
 
   getRepositoryForWorkdir(workdir) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2197,9 +2197,9 @@
       }
     },
     "cross-unzip": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/cross-unzip/-/cross-unzip-0.0.2.tgz",
-      "integrity": "sha1-UYO8R6CVWb78+YzEZXlkmZNZNy8=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cross-unzip/-/cross-unzip-0.2.1.tgz",
+      "integrity": "sha1-Ae0dS7JDujObLD8Dxbp6eIGJhMY=",
       "dev": true
     },
     "cryptiles": {
@@ -2644,6 +2644,14 @@
         "cross-unzip": "0.0.2",
         "rimraf": "^2.5.2",
         "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "cross-unzip": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/cross-unzip/-/cross-unzip-0.0.2.tgz",
+          "integrity": "sha1-UYO8R6CVWb78+YzEZXlkmZNZNy8=",
+          "dev": true
+        }
       }
     },
     "electron-download": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "chai-as-promised": "7.1.1",
     "coveralls": "^3.0.1",
     "cross-env": "5.2.0",
+    "cross-unzip": "0.2.1",
     "dedent-js": "1.0.1",
     "electron-devtools-installer": "2.2.4",
     "electron-link": "0.2.2",


### PR DESCRIPTION
Download the React devtools installer ourselves to work around issues using electron-devtools-installer in a renderer process.

Fixes #1738.