### PR TITLE
Add some instrumentation

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -472,6 +472,7 @@ export default class RootController extends React.Component {
         {detail: e.stdErr, dismissable: true},
       );
     } finally {
+      addEvent('clone-repo', {package: 'github'});
       this.setState({cloneDialogInProgress: false, cloneDialogActive: false});
     }
   }

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -94,6 +94,16 @@ export default class RootController extends React.Component {
     this.subscription = new CompositeDisposable(
       this.props.repository.onMergeError(this.gitTabTracker.ensureVisible),
     );
+
+    this.props.commandRegistry.onDidDispatch(event => {
+      if (event.type && event.type.startsWith('github:')
+      && event.detail && event.detail[0] && event.detail[0].contextCommand) {
+        addEvent('context-menu-action', {
+          package: 'github',
+          command: event.type,
+        });
+      }
+    });
   }
 
   componentDidMount() {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -476,13 +476,13 @@ export default class RootController extends React.Component {
     this.setState({cloneDialogInProgress: true});
     try {
       await this.props.cloneRepositoryForProjectPath(remoteUrl, projectPath);
+      addEvent('clone-repo', {package: 'github'});
     } catch (e) {
       this.props.notificationManager.addError(
         `Unable to clone ${remoteUrl}`,
         {detail: e.stdErr, dismissable: true},
       );
     } finally {
-      addEvent('clone-repo', {package: 'github'});
       this.setState({cloneDialogInProgress: false, cloneDialogActive: false});
     }
   }

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -342,7 +342,8 @@ describe('RootController', function() {
       assert.lengthOf(wrapper.find('Panel').find({location: 'modal'}).find('CloneDialog'), 1);
     });
 
-    it('triggers the clone callback on accept', function() {
+    it('triggers the clone callback on accept and fires `clone-repo` event', function() {
+      sinon.stub(reporterProxy, 'addEvent');
       wrapper.instance().openCloneDialog();
       wrapper.update();
 
@@ -351,6 +352,7 @@ describe('RootController', function() {
       resolveClone();
 
       assert.isTrue(cloneRepositoryForProjectPath.calledWith('git@github.com:atom/github.git', '/home/me/github'));
+      assert.isTrue(reporterProxy.addEvent.calledWith('clone-repo', {package: 'github'}))
     });
 
     it('marks the clone dialog as in progress during clone', async function() {
@@ -372,8 +374,9 @@ describe('RootController', function() {
       assert.isFalse(wrapper.find('CloneDialog').exists());
     });
 
-    it('creates a notification if the clone fails', async function() {
+    it('creates a notification if the clone fails and does not fire `clone-repo` event', async function() {
       sinon.stub(notificationManager, 'addError');
+      sinon.stub(reporterProxy, 'addEvent');
 
       wrapper.instance().openCloneDialog();
       wrapper.update();
@@ -393,6 +396,7 @@ describe('RootController', function() {
         'Unable to clone git@github.com:nope/nope.git',
         sinon.match({detail: sinon.match(/this is stderr/)}),
       ));
+      assert.isFalse(reporterProxy.addEvent.called);
     });
 
     it('dismisses the clone panel on cancel', function() {

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -1109,7 +1109,11 @@ describe('RootController', function() {
         'github:toggle-expanded-commit-message-editor',
         [{contextCommand: true}],
       );
-      assert.isTrue(reporterProxy.addEvent.called);
+      assert.isTrue(reporterProxy.addEvent.calledWith(
+        'context-menu-action', {
+          package: 'github',
+          command: 'github:toggle-expanded-commit-message-editor',
+        }));
     });
 
     it('does not send an event when a command is triggered in other ways', function() {

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -1088,4 +1088,45 @@ describe('RootController', function() {
       });
     });
   });
+
+  describe('context commands trigger event reporting', function() {
+    let wrapper;
+
+    beforeEach(async function() {
+      const repository = await buildRepository(await cloneRepository('multiple-commits'));
+      app = React.cloneElement(app, {
+        repository,
+        startOpen: true,
+        startRevealed: true,
+      });
+      wrapper = mount(app);
+      sinon.stub(reporterProxy, 'addEvent');
+    });
+
+    it('sends an event when a command is triggered via a context menu', function() {
+      commandRegistry.dispatch(
+        wrapper.find('CommitView').getDOMNode(),
+        'github:toggle-expanded-commit-message-editor',
+        [{contextCommand: true}],
+      );
+      assert.isTrue(reporterProxy.addEvent.called);
+    });
+
+    it('does not send an event when a command is triggered in other ways', function() {
+      commandRegistry.dispatch(
+        wrapper.find('CommitView').getDOMNode(),
+        'github:toggle-expanded-commit-message-editor',
+      );
+      assert.isFalse(reporterProxy.addEvent.called);
+    });
+
+    it('does not send an event when a command not starting with github: is triggered via a context menu', function() {
+      commandRegistry.dispatch(
+        wrapper.find('CommitView').getDOMNode(),
+        'core:copy',
+        [{contextCommand: true}],
+      );
+      assert.isFalse(reporterProxy.addEvent.called);
+    });
+  });
 });

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -342,17 +342,18 @@ describe('RootController', function() {
       assert.lengthOf(wrapper.find('Panel').find({location: 'modal'}).find('CloneDialog'), 1);
     });
 
-    it('triggers the clone callback on accept and fires `clone-repo` event', function() {
+    it('triggers the clone callback on accept and fires `clone-repo` event', async function() {
       sinon.stub(reporterProxy, 'addEvent');
       wrapper.instance().openCloneDialog();
       wrapper.update();
 
       const dialog = wrapper.find('CloneDialog');
-      dialog.prop('didAccept')('git@github.com:atom/github.git', '/home/me/github');
+      const promise = dialog.prop('didAccept')('git@github.com:atom/github.git', '/home/me/github');
       resolveClone();
+      await promise;
 
       assert.isTrue(cloneRepositoryForProjectPath.calledWith('git@github.com:atom/github.git', '/home/me/github'));
-      assert.isTrue(reporterProxy.addEvent.calledWith('clone-repo', {package: 'github'}))
+      await assert.isTrue(reporterProxy.addEvent.calledWith('clone-repo', {package: 'github'}));
     });
 
     it('marks the clone dialog as in progress during clone', async function() {


### PR DESCRIPTION
### Description of the Change

This PR adds reporting metrics for cloning repos, as well as various context menu actions within the package. 

### Alternate Designs

This implementation listens to all command dispatch event, filters out the ones triggered via context menus, and acts upon them. The drawback is that it won't be clear _exactly_ which context menu was used to trigger that command. An alternative approach would be to hook into each event we're interested in individually, and reports back if the event came from a context menu, and which one. But this approach would result in the same code scattered all over the place, which isn't ideal either. 

### Metrics

We can know how much usage context menus get, how discoverable the `clone repo` functionality is. 

### Tests

I only added tests for the clone repo instrumentation, but not the context menu ones as I can't think of how one can test context menus in our situation. 

### Related Issues

resolves #1727 
resolves #1728