### PR TITLE
Make merge commit messages and commit message templates play nicely together.

### DIFF
--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -66,11 +66,11 @@ export default class Present extends State {
   }
 
   async getCommitMessageFromTemplate() {
-    const mergeConflicts = await this.repository.getMergeConflicts();
-    if (mergeConflicts) {
+    const mergeMessage = await this.repository.getMergeMessage();
+    if (mergeMessage) {
       // for merge commits, we want to show the merge commit message
       // instead of the template commit message.
-      return null;
+      return mergeMessage;
     }
     return await this.git().getCommitMessageFromTemplate();
   }

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -66,6 +66,12 @@ export default class Present extends State {
   }
 
   async getCommitMessageFromTemplate() {
+    const mergeConflicts = await this.repository.getMergeConflicts();
+    if (mergeConflicts) {
+      // for merge commits, we want to show the merge commit message
+      // instead of the template commit message.
+      return null;
+    }
     return await this.git().getCommitMessageFromTemplate();
   }
 

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1138,7 +1138,7 @@ describe('Repository', function() {
         assertDeepPropertyVals(mergeConflicts, expected);
       });
 
-      it('does not set commit template message if merge conflict is present', async function() {
+      it('uses merge message instead of commit template if merge message exists', async function() {
         const fakeTemplateMessage = 'bar';
         const fakeMergeMessage = 'merge branch new_branch';
         const workdirPath = await cloneRepository('merge-conflict');

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1138,6 +1138,24 @@ describe('Repository', function() {
         assertDeepPropertyVals(mergeConflicts, expected);
       });
 
+      it('does not set commit template message if merge conflict is present', async function() {
+        const fakeTemplateMessage = 'bar';
+        const workdirPath = await cloneRepository('merge-conflict');
+        const repo = new Repository(workdirPath);
+        // todo(tt, 10/2018): it would be better to create a new repo fixture with merge conflicts
+        // and a commit template, rather than stubbing this method.
+        sinon.stub(repo.git, 'getCommitMessageFromTemplate').returns(fakeTemplateMessage);
+        await repo.getLoadPromise();
+
+        const templateCommitMessage = await repo.git.getCommitMessageFromTemplate();
+        assert.strictEqual(templateCommitMessage, fakeTemplateMessage);
+
+        await assert.isRejected(repo.git.merge('origin/branch'));
+
+        const commitMessage = await repo.getCommitMessage();
+        assert.strictEqual('', commitMessage);
+      });
+
       it('returns an empty array if the repo has no merge conflicts', async function() {
         const workingDirPath = await cloneRepository('three-files');
         const repo = new Repository(workingDirPath);

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1145,6 +1145,7 @@ describe('Repository', function() {
         const repo = new Repository(workdirPath);
         // todo(tt, 10/2018): it would be better to create a new repo fixture with merge conflicts
         // and a commit template, rather than stubbing this method.
+        // stubbing is less robust.
         sinon.stub(repo.git, 'getCommitMessageFromTemplate').returns(fakeTemplateMessage);
         sinon.stub(repo, 'getMergeMessage').returns(fakeMergeMessage);
         await repo.getLoadPromise();

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -1140,20 +1140,19 @@ describe('Repository', function() {
 
       it('does not set commit template message if merge conflict is present', async function() {
         const fakeTemplateMessage = 'bar';
+        const fakeMergeMessage = 'merge branch new_branch';
         const workdirPath = await cloneRepository('merge-conflict');
         const repo = new Repository(workdirPath);
         // todo(tt, 10/2018): it would be better to create a new repo fixture with merge conflicts
         // and a commit template, rather than stubbing this method.
         sinon.stub(repo.git, 'getCommitMessageFromTemplate').returns(fakeTemplateMessage);
+        sinon.stub(repo, 'getMergeMessage').returns(fakeMergeMessage);
         await repo.getLoadPromise();
-
-        const templateCommitMessage = await repo.git.getCommitMessageFromTemplate();
-        assert.strictEqual(templateCommitMessage, fakeTemplateMessage);
 
         await assert.isRejected(repo.git.merge('origin/branch'));
 
         const commitMessage = await repo.getCommitMessage();
-        assert.strictEqual('', commitMessage);
+        assert.strictEqual(fakeMergeMessage, commitMessage);
       });
 
       it('returns an empty array if the repo has no merge conflicts', async function() {


### PR DESCRIPTION
### Description of the Change

@kuychaco caught an edge case I hadn't thought of when I was reviewing https://github.com/atom/github/pull/1713.  Namely, if there are merge conflicts present, we should use the merge message instead of the template commit message.

### Alternate Designs

We discussed removing commit message templates entirely.  But I think this feature will be really useful to some users, whose workflows require a standardized commit message.  So IMO it's worth keeping around.  We can always revisit this decision later if other problems are discovered.

### Benefits

When resolving merge conflicts, users with commit message templates will have the standard merge commit message populated into the commit box.  This means they can have consistent merge commit messages with no effort.

### Possible Drawbacks

Always possible that I've introduced another bug.  Other than that, no drawbacks that I can think of. 

### Applicable Issues

N/A

### Metrics

N/A

### Tests

- Tested manually merging a branch that created a conflict.  The merge message shows up in the commit box.
- Tested manually on a repo without merge conflicts and a template message set, to verify that the template message still shows up.
- Wrote a unit test to verify that repository uses merge message instead of template message if a merge conflict is present.

### Documentation

N/A
