### PR TITLE
Retry known test flakes

### DIFF
--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -1518,6 +1518,8 @@ import * as reporterProxy from '../lib/reporter-proxy';
       });
 
       it('prefers user-configured credential helpers if present', async function() {
+        this.retries(5); // FLAKE
+
         let query = null;
         const git = await withHttpRemote({
           prompt: q => {

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -1457,6 +1457,8 @@ import * as reporterProxy from '../lib/reporter-proxy';
       }
 
       it('prompts for authentication data through Atom', async function() {
+        this.retries(5); // FLAKE
+
         let query = null;
         const git = await withHttpRemote({
           prompt: q => {

--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -608,6 +608,8 @@ describe('GithubPackage', function() {
     let workdirPath2, atomGitRepository2, repository2;
 
     beforeEach(async function() {
+      this.retries(5); // FLAKE
+
       [workdirPath1, workdirPath2] = await Promise.all([
         cloneRepository('three-files'),
         cloneRepository('three-files'),
@@ -645,6 +647,7 @@ describe('GithubPackage', function() {
       if (process.platform === 'linux') {
         this.skip();
       }
+      this.retries(5); // FLAKE
 
       fs.writeFileSync(path.join(workdirPath1, 'a.txt'), 'some changes', 'utf8');
 
@@ -656,6 +659,7 @@ describe('GithubPackage', function() {
       if (process.platform === 'linux') {
         this.skip();
       }
+      this.retries(5); // FLAKE
 
       fs.writeFileSync(path.join(workdirPath2, 'b.txt'), 'other changes', 'utf8');
 

--- a/test/integration/file-patch.test.js
+++ b/test/integration/file-patch.test.js
@@ -732,6 +732,8 @@ describe('integration: file patches', function() {
       });
 
       it('may be partially staged', async function() {
+        this.retries(5); // FLAKE
+
         getPatchEditor('unstaged', 'sample.js').setSelectedBufferRanges([
           [[2, 0], [2, 0]],
           [[10, 0], [10, 0]],

--- a/test/models/file-system-change-observer.test.js
+++ b/test/models/file-system-change-observer.test.js
@@ -25,6 +25,8 @@ describe('FileSystemChangeObserver', function() {
   });
 
   it('emits an event when a project file is modified, created, or deleted', async function() {
+    this.retries(5); // FLAKE
+
     const workdirPath = await cloneRepository('three-files');
     const repository = await buildRepository(workdirPath);
     observer = createObserver(repository);

--- a/test/worker-manager.test.js
+++ b/test/worker-manager.test.js
@@ -149,6 +149,8 @@ describe('WorkerManager', function() {
 
   describe('when the manager process is destroyed', function() {
     it('destroys all the renderer processes that were created', async function() {
+      this.retries(5); // FLAKE
+
       const browserWindow = new BrowserWindow({show: !!process.env.ATOM_GITHUB_SHOW_RENDERER_WINDOW});
       browserWindow.loadURL('about:blank');
       sinon.stub(Worker.prototype, 'getWebContentsId').returns(browserWindow.webContents.id);


### PR DESCRIPTION
Flag known test flakes with `this.retries(5)` to limit the pain until we can schedule time to work them down again. Each of these flakes has already been filed with [an issue labelled flaky-test](https://github.com/atom/github/issues?q=is%3Aopen+is%3Aissue+label%3Aflaky-test).