### PR TITLE
Commit Preview

### DIFF
--- a/lib/items/commit-preview-item.js
+++ b/lib/items/commit-preview-item.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Emitter} from 'event-kit';
+
+import {WorkdirContextPoolPropType} from '../prop-types';
+
+export default class CommitPreviewItem extends React.Component {
+  static propTypes = {
+    workdirContextPool: WorkdirContextPoolPropType.isRequired,
+    workingDirectory: PropTypes.string.isRequired,
+  }
+
+  static uriPattern = 'atom-github://commit-preview?workdir={workingDirectory}'
+
+  static buildURI(relPath, workingDirectory) {
+    return `atom-github://commit-preview?workdir=${encodeURIComponent(workingDirectory)}`;
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.emitter = new Emitter();
+    this.isDestroyed = false;
+    this.hasTerminatedPendingState = false;
+  }
+
+  terminatePendingState() {
+    if (!this.hasTerminatedPendingState) {
+      this.emitter.emit('did-terminate-pending-state');
+      this.hasTerminatedPendingState = true;
+    }
+  }
+
+  onDidTerminatePendingState(callback) {
+    return this.emitter.on('did-terminate-pending-state', callback);
+  }
+
+  destroy() {
+    /* istanbul ignore else */
+    if (!this.isDestroyed) {
+      this.emitter.emit('did-destroy');
+      this.isDestroyed = true;
+    }
+  }
+
+  onDidDestroy(callback) {
+    return this.emitter.on('did-destroy', callback);
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/test/items/commit-preview-item.test.js
+++ b/test/items/commit-preview-item.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import CommitPreviewItem from '../../lib/items/commit-preview-item';
+import PaneItem from '../../lib/atom/pane-item';
+import WorkdirContextPool from '../../lib/models/workdir-context-pool';
+import {cloneRepository} from '../helpers';
+
+describe('CommitPreviewItem', function() {
+  let atomEnv, repository, pool;
+
+  beforeEach(async function() {
+    atomEnv = global.buildAtomEnvironment();
+    const workdir = await cloneRepository();
+
+    pool = new WorkdirContextPool({
+      workspace: atomEnv.workspace,
+    });
+
+    repository = pool.add(workdir).getRepository();
+  });
+
+  afterEach(function() {
+    atomEnv.destroy();
+    pool.clear();
+  });
+
+  function buildPaneApp(override = {}) {
+    const props = {
+      workdirContextPool: pool,
+      ...override,
+    };
+
+    return (
+      <PaneItem workspace={atomEnv.workspace} uriPattern={CommitPreviewItem.uriPattern}>
+        {({itemHolder, params}) => {
+          return (
+            <CommitPreviewItem
+              ref={itemHolder.setter}
+              workingDirectory={params.workingDirectory}
+              {...props}
+            />
+          );
+        }}
+      </PaneItem>
+    );
+  }
+
+  function open(wrapper, options = {}) {
+    const opts = {
+      workingDirectory: repository.getWorkingDirectoryPath(),
+      ...options,
+    };
+    const uri = CommitPreviewItem.buildURI(opts.workingDirectory);
+    return atomEnv.workspace.open(uri);
+  }
+
+  it('constructs and opens the correct URI', async function() {
+    const wrapper = mount(buildPaneApp());
+    await open(wrapper);
+    assert.isTrue(wrapper.update().find('CommitPreviewItem').exists());
+  });
+});


### PR DESCRIPTION
🌐 Collaborative pull request to implement the first chunk of behavior described in #1753.

- [ ] Let's have a `MultiFilePatch` model that includes an ordered list of `FilePatch` objects.
- [ ] We'll need to extend the parser to understand multi-file `git diff` output. There may be some tricky work in here in relation to the deleted-symlink-and-created-file and deleted-file-and-created-symlink edge cases.
- [ ] Add a method to our git repository plumbing to get the multi-diff from all staged changes, _or_, preferably, find a way to get this information using existing git repository methods.
- [ ] Let's have a `CommitPreview` component hierarchy for the React side of things: `CommitPreviewItem` for the workspace item stuff, `CommitPreviewContainer` for the loading and error logic.
- [ ] For the rest of the components, we have a decision to make. We can either: _(a)_ generalize the existing `FilePatch` classes (controller and view) to be usable in both situations, or _(b)_ create new components that are specialized for the multi-file case. I'm leaning a little toward (a) but that might change when we get down into the code.
- [ ] Finally, we'll need to do the addition of the "preview" button within the `CommitView` and the corresponding wiring for the preview action in `CommitController`.