### PR TITLE
Use the pull request target branch as the Coveralls branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
       CI_NAME: Azure Pipeline (Linux)
       CI_BUILD_NUMBER: $(Build.BuildNumber)
       CI_BUILD_URL: https://dev.azure.com/atom-github/GitHub%20package%20for%20Atom/_build/results?buildId=$(Build.BuildId)&view=logs
-      CI_BRANCH: $(Build.SourceBranchName)
+      CI_BRANCH: $(System.PullRequest.TargetBranch)
       CI_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
       COVERALLS_REPO_TOKEN: $(coveralls.repoToken)
     condition: succeededOrFailed()
@@ -107,7 +107,7 @@ jobs:
       CI_NAME: Azure Pipeline (MacOS)
       CI_BUILD_NUMBER: $(Build.BuildNumber)
       CI_BUILD_URL: https://dev.azure.com/atom-github/GitHub%20package%20for%20Atom/_build/results?buildId=$(Build.BuildId)&view=logs
-      CI_BRANCH: $(Build.SourceBranchName)
+      CI_BRANCH: $(System.PullRequest.TargetBranch)
       CI_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
       COVERALLS_REPO_TOKEN: $(coveralls.repoToken)
     condition: succeededOrFailed()
@@ -177,7 +177,7 @@ jobs:
       CI_NAME: Azure Pipeline (Windows)
       CI_BUILD_NUMBER: $(Build.BuildNumber)
       CI_BUILD_URL: https://dev.azure.com/atom-github/GitHub%20package%20for%20Atom/_build/results?buildId=$(Build.BuildId)&view=logs
-      CI_BRANCH: $(Build.SourceBranchName)
+      CI_BRANCH: $(System.PullRequest.TargetBranch)
       CI_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
       COVERALLS_REPO_TOKEN: $(coveralls.repoToken)
     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,12 +26,12 @@ jobs:
       dev:
         atom_channel: dev
         atom_name: atom-dev
-      beta:
-        atom_channel: beta
-        atom_name: atom-beta
-      stable:
-        atom_channel: stable
-        atom_name: atom
+      # beta:
+      #   atom_channel: beta
+      #   atom_name: atom-beta
+      # stable:
+      #   atom_channel: stable
+      #   atom_name: atom
   variables:
     display: ":99"
   steps:
@@ -55,6 +55,12 @@ jobs:
       testRunTitle: Linux $(atom_channel)
     condition: succeededOrFailed()
   - bash: |
+      echo "COVERALLS_SERVICE_NAME=${COVERALLS_SERVICE_NAME}"
+      echo "COVERALLS_SERVICE_JOB_ID=${COVERALLS_SERVICE_JOB_ID}"
+      echo "TRAVIS=${TRAVIS}"
+      echo "TRAVIS_BRANCH=${TRAVIS_BRANCH}"
+      echo "TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}"
+
       if [ -n "${COVERALLS_REPO_TOKEN}" ]; then npm run coveralls; else echo "No Coveralls token"; fi
     displayName: submit coverage data to Coveralls
     env:
@@ -65,157 +71,157 @@ jobs:
       TRAVIS_BRANCH: $(System.PullRequest.TargetBranch)
       TRAVIS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
     condition: succeededOrFailed()
-
-- job: MacOS
-  pool:
-    vmImage: macos-10.13
-  strategy:
-    matrix:
-      dev:
-        atom_channel: dev
-        atom_app: Atom Dev.app
-      beta:
-        atom_channel: beta
-        atom_app: Atom Beta.app
-      stable:
-        atom_channel: stable
-        atom_app: Atom.app
-  steps:
-  - template: script/azure-pipelines/macos-install.yml
-    parameters:
-      atom_channel: $(atom_channel)
-      atom_app: $(atom_app)
-  - bash: |
-      "/tmp/atom/${ATOM_APP}/Contents/Resources/app/atom.sh" --test test/
-    displayName: run tests
-    env:
-      TEST_JUNIT_XML_PATH: $(Agent.HomeDirectory)/test-results.xml
-      ATOM_GITHUB_BABEL_ENV: coverage
-      FORCE_COLOR: 0
-      MOCHA_TIMEOUT: 60000
-      UNTIL_TIMEOUT: 30000
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(Agent.HomeDirectory)/test-results.xml
-      testRunTitle: MacOS $(atom_channel)
-    condition: succeededOrFailed()
-  - bash: |
-      if [ -n "${COVERALLS_REPO_TOKEN}" ]; then npm run coveralls; else echo "No Coveralls token"; fi
-    displayName: submit coverage data to Coveralls
-    env:
-      COVERALLS_SERVICE_NAME: Azure Pipeline (MacOS)
-      COVERALLS_REPO_TOKEN: $(coveralls.repoToken)
-      COVERALLS_SERVICE_JOB_ID: $(Build.BuildNumber)
-      TRAVIS: true
-      TRAVIS_BRANCH: $(System.PullRequest.TargetBranch)
-      TRAVIS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
-    condition: succeededOrFailed()
-
-- job: Windows
-  pool:
-    vmImage: vs2015-win2012r2
-  strategy:
-    matrix:
-      dev:
-        atom_channel: dev
-        atom_directory: Atom Dev
-      beta:
-        atom_channel: beta
-        atom_directory: Atom Beta
-      stable:
-        atom_channel: stable
-        atom_directory: Atom
-  steps:
-  - template: script/azure-pipelines/windows-install.yml
-    parameters:
-      atom_channel: $(atom_channel)
-      atom_directory: $(atom_directory)
-  - powershell: |
-      Set-StrictMode -Version Latest
-      $script:ATOMROOT = "$env:AGENT_HOMEDIRECTORY/atom"
-      $script:ATOM_SCRIPT_PATH = "$script:ATOMROOT\$env:ATOM_DIRECTORY\resources\cli\atom.cmd"
-
-      # Normalize %TEMP% as a long (non 8.3) path.
-      $env:TEMP = (Get-Item -LiteralPath $env:TEMP).FullName
-
-      $env:ELECTRON_NO_ATTACH_CONSOLE = "true"
-      [Environment]::SetEnvironmentVariable("ELECTRON_NO_ATTACH_CONSOLE", "true", "User")
-      $env:ELECTRON_ENABLE_LOGGING = "YES"
-      [Environment]::SetEnvironmentVariable("ELECTRON_ENABLE_LOGGING", "YES", "User")
-
-      Write-Host "Running tests"
-      & "$script:ATOM_SCRIPT_PATH" --test test 2>&1 | %{ "$_" }
-
-      if ($LASTEXITCODE -ne 0) {
-        Write-Host "Specs Failed"
-        $host.SetShouldExit($LASTEXITCODE)
-        exit
-      }
-    displayName: run tests
-    env:
-      TEST_JUNIT_XML_PATH: $(Agent.HomeDirectory)/test-results.xml
-      ATOM_GITHUB_BABEL_ENV: coverage
-      ATOM_GITHUB_SKIP_SYMLINKS: 1
-      FORCE_COLOR: 0
-      MOCHA_TIMEOUT: 60000
-      UNTIL_TIMEOUT: 30000
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(Agent.HomeDirectory)/test-results.xml
-      testRunTitle: Windows $(atom_channel)
-    condition: succeededOrFailed()
-  - powershell: |
-      if ($env:COVERALLS_REPO_TOKEN -ne "") {
-        npm run coveralls
-      } else {
-        Write-Output "No Coveralls token"
-      }
-    displayName: submit coverage data to Coveralls
-    env:
-      COVERALLS_SERVICE_NAME: Azure Pipeline (Windows)
-      COVERALLS_REPO_TOKEN: $(coveralls.repoToken)
-      COVERALLS_SERVICE_JOB_ID: $(Build.BuildNumber)
-      TRAVIS: true
-      TRAVIS_BRANCH: $(System.PullRequest.TargetBranch)
-      TRAVIS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
-    condition: succeededOrFailed()
-
-- job: Lint
-  pool:
-    vmImage: ubuntu-16.04
-  variables:
-    display: ":99"
-    atom_channel: dev
-  steps:
-  - template: script/azure-pipelines/linux-install.yml
-    parameters:
-      atom_channel: $(atom_channel)
-      atom_name: atom-dev
-  - bash: /tmp/atom/usr/share/atom-dev/resources/app/apm/node_modules/.bin/npm run lint
-    displayName: run the linter
-
-- job: Snapshot
-  pool:
-    vmImage: ubuntu-16.04
-  variables:
-    display: ":99"
-    atom_channel: dev
-  steps:
-  - template: script/azure-pipelines/linux-install.yml
-    parameters:
-      atom_channel: $(atom_channel)
-      atom_name: atom-dev
-  - bash: /tmp/atom/usr/bin/atom-dev --test test/
-    displayName: run tests
-    env:
-      ATOM_GITHUB_TEST_SUITE: snapshot
-      TEST_JUNIT_XML_PATH: $(Agent.HomeDirectory)/test-results.xml
-      FORCE_COLOR: 0
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(Agent.HomeDirectory)/test-results.xml
-      testRunTitle: Snapshot
-    condition: succeededOrFailed()
+#
+# - job: MacOS
+#   pool:
+#     vmImage: macos-10.13
+#   strategy:
+#     matrix:
+#       dev:
+#         atom_channel: dev
+#         atom_app: Atom Dev.app
+#       beta:
+#         atom_channel: beta
+#         atom_app: Atom Beta.app
+#       stable:
+#         atom_channel: stable
+#         atom_app: Atom.app
+#   steps:
+#   - template: script/azure-pipelines/macos-install.yml
+#     parameters:
+#       atom_channel: $(atom_channel)
+#       atom_app: $(atom_app)
+#   - bash: |
+#       "/tmp/atom/${ATOM_APP}/Contents/Resources/app/atom.sh" --test test/
+#     displayName: run tests
+#     env:
+#       TEST_JUNIT_XML_PATH: $(Agent.HomeDirectory)/test-results.xml
+#       ATOM_GITHUB_BABEL_ENV: coverage
+#       FORCE_COLOR: 0
+#       MOCHA_TIMEOUT: 60000
+#       UNTIL_TIMEOUT: 30000
+#   - task: PublishTestResults@2
+#     inputs:
+#       testResultsFormat: JUnit
+#       testResultsFiles: $(Agent.HomeDirectory)/test-results.xml
+#       testRunTitle: MacOS $(atom_channel)
+#     condition: succeededOrFailed()
+#   - bash: |
+#       if [ -n "${COVERALLS_REPO_TOKEN}" ]; then npm run coveralls; else echo "No Coveralls token"; fi
+#     displayName: submit coverage data to Coveralls
+#     env:
+#       COVERALLS_SERVICE_NAME: Azure Pipeline (MacOS)
+#       COVERALLS_REPO_TOKEN: $(coveralls.repoToken)
+#       COVERALLS_SERVICE_JOB_ID: $(Build.BuildNumber)
+#       TRAVIS: true
+#       TRAVIS_BRANCH: $(System.PullRequest.TargetBranch)
+#       TRAVIS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
+#     condition: succeededOrFailed()
+#
+# - job: Windows
+#   pool:
+#     vmImage: vs2015-win2012r2
+#   strategy:
+#     matrix:
+#       dev:
+#         atom_channel: dev
+#         atom_directory: Atom Dev
+#       beta:
+#         atom_channel: beta
+#         atom_directory: Atom Beta
+#       stable:
+#         atom_channel: stable
+#         atom_directory: Atom
+#   steps:
+#   - template: script/azure-pipelines/windows-install.yml
+#     parameters:
+#       atom_channel: $(atom_channel)
+#       atom_directory: $(atom_directory)
+#   - powershell: |
+#       Set-StrictMode -Version Latest
+#       $script:ATOMROOT = "$env:AGENT_HOMEDIRECTORY/atom"
+#       $script:ATOM_SCRIPT_PATH = "$script:ATOMROOT\$env:ATOM_DIRECTORY\resources\cli\atom.cmd"
+#
+#       # Normalize %TEMP% as a long (non 8.3) path.
+#       $env:TEMP = (Get-Item -LiteralPath $env:TEMP).FullName
+#
+#       $env:ELECTRON_NO_ATTACH_CONSOLE = "true"
+#       [Environment]::SetEnvironmentVariable("ELECTRON_NO_ATTACH_CONSOLE", "true", "User")
+#       $env:ELECTRON_ENABLE_LOGGING = "YES"
+#       [Environment]::SetEnvironmentVariable("ELECTRON_ENABLE_LOGGING", "YES", "User")
+#
+#       Write-Host "Running tests"
+#       & "$script:ATOM_SCRIPT_PATH" --test test 2>&1 | %{ "$_" }
+#
+#       if ($LASTEXITCODE -ne 0) {
+#         Write-Host "Specs Failed"
+#         $host.SetShouldExit($LASTEXITCODE)
+#         exit
+#       }
+#     displayName: run tests
+#     env:
+#       TEST_JUNIT_XML_PATH: $(Agent.HomeDirectory)/test-results.xml
+#       ATOM_GITHUB_BABEL_ENV: coverage
+#       ATOM_GITHUB_SKIP_SYMLINKS: 1
+#       FORCE_COLOR: 0
+#       MOCHA_TIMEOUT: 60000
+#       UNTIL_TIMEOUT: 30000
+#   - task: PublishTestResults@2
+#     inputs:
+#       testResultsFormat: JUnit
+#       testResultsFiles: $(Agent.HomeDirectory)/test-results.xml
+#       testRunTitle: Windows $(atom_channel)
+#     condition: succeededOrFailed()
+#   - powershell: |
+#       if ($env:COVERALLS_REPO_TOKEN -ne "") {
+#         npm run coveralls
+#       } else {
+#         Write-Output "No Coveralls token"
+#       }
+#     displayName: submit coverage data to Coveralls
+#     env:
+#       COVERALLS_SERVICE_NAME: Azure Pipeline (Windows)
+#       COVERALLS_REPO_TOKEN: $(coveralls.repoToken)
+#       COVERALLS_SERVICE_JOB_ID: $(Build.BuildNumber)
+#       TRAVIS: true
+#       TRAVIS_BRANCH: $(System.PullRequest.TargetBranch)
+#       TRAVIS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
+#     condition: succeededOrFailed()
+#
+# - job: Lint
+#   pool:
+#     vmImage: ubuntu-16.04
+#   variables:
+#     display: ":99"
+#     atom_channel: dev
+#   steps:
+#   - template: script/azure-pipelines/linux-install.yml
+#     parameters:
+#       atom_channel: $(atom_channel)
+#       atom_name: atom-dev
+#   - bash: /tmp/atom/usr/share/atom-dev/resources/app/apm/node_modules/.bin/npm run lint
+#     displayName: run the linter
+#
+# - job: Snapshot
+#   pool:
+#     vmImage: ubuntu-16.04
+#   variables:
+#     display: ":99"
+#     atom_channel: dev
+#   steps:
+#   - template: script/azure-pipelines/linux-install.yml
+#     parameters:
+#       atom_channel: $(atom_channel)
+#       atom_name: atom-dev
+#   - bash: /tmp/atom/usr/bin/atom-dev --test test/
+#     displayName: run tests
+#     env:
+#       ATOM_GITHUB_TEST_SUITE: snapshot
+#       TEST_JUNIT_XML_PATH: $(Agent.HomeDirectory)/test-results.xml
+#       FORCE_COLOR: 0
+#   - task: PublishTestResults@2
+#     inputs:
+#       testResultsFormat: JUnit
+#       testResultsFiles: $(Agent.HomeDirectory)/test-results.xml
+#       testRunTitle: Snapshot
+#     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,12 +58,12 @@ jobs:
       if [ -n "${COVERALLS_REPO_TOKEN}" ]; then npm run coveralls; else echo "No Coveralls token"; fi
     displayName: submit coverage data to Coveralls
     env:
-      CI_NAME: Azure Pipeline (Linux)
-      CI_BUILD_NUMBER: $(Build.BuildNumber)
-      CI_BUILD_URL: https://dev.azure.com/atom-github/GitHub%20package%20for%20Atom/_build/results?buildId=$(Build.BuildId)&view=logs
-      CI_BRANCH: $(System.PullRequest.TargetBranch)
-      CI_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
+      COVERALLS_SERVICE_NAME: Azure Pipeline (Linux)
       COVERALLS_REPO_TOKEN: $(coveralls.repoToken)
+      COVERALLS_SERVICE_JOB_ID: $(Build.BuildNumber)
+      TRAVIS: true
+      TRAVIS_BRANCH: $(System.PullRequest.TargetBranch)
+      TRAVIS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
     condition: succeededOrFailed()
 
 - job: MacOS
@@ -104,12 +104,12 @@ jobs:
       if [ -n "${COVERALLS_REPO_TOKEN}" ]; then npm run coveralls; else echo "No Coveralls token"; fi
     displayName: submit coverage data to Coveralls
     env:
-      CI_NAME: Azure Pipeline (MacOS)
-      CI_BUILD_NUMBER: $(Build.BuildNumber)
-      CI_BUILD_URL: https://dev.azure.com/atom-github/GitHub%20package%20for%20Atom/_build/results?buildId=$(Build.BuildId)&view=logs
-      CI_BRANCH: $(System.PullRequest.TargetBranch)
-      CI_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
+      COVERALLS_SERVICE_NAME: Azure Pipeline (MacOS)
       COVERALLS_REPO_TOKEN: $(coveralls.repoToken)
+      COVERALLS_SERVICE_JOB_ID: $(Build.BuildNumber)
+      TRAVIS: true
+      TRAVIS_BRANCH: $(System.PullRequest.TargetBranch)
+      TRAVIS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
     condition: succeededOrFailed()
 
 - job: Windows
@@ -174,12 +174,12 @@ jobs:
       }
     displayName: submit coverage data to Coveralls
     env:
-      CI_NAME: Azure Pipeline (Windows)
-      CI_BUILD_NUMBER: $(Build.BuildNumber)
-      CI_BUILD_URL: https://dev.azure.com/atom-github/GitHub%20package%20for%20Atom/_build/results?buildId=$(Build.BuildId)&view=logs
-      CI_BRANCH: $(System.PullRequest.TargetBranch)
-      CI_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
+      COVERALLS_SERVICE_NAME: Azure Pipeline (Windows)
       COVERALLS_REPO_TOKEN: $(coveralls.repoToken)
+      COVERALLS_SERVICE_JOB_ID: $(Build.BuildNumber)
+      TRAVIS: true
+      TRAVIS_BRANCH: $(System.PullRequest.TargetBranch)
+      TRAVIS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
     condition: succeededOrFailed()
 
 - job: Lint

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:coverage:html": "nyc --reporter=html npm run test:coverage",
     "test:coverage:lcov": "npm run test:coverage",
     "test:snapshot": "cross-env-shell ATOM_GITHUB_TEST_SUITE=snapshot \"${ATOM_SCRIPT_PATH:-atom} --test test\"",
-    "coveralls": "nyc report --reporter=text-lcov | coveralls",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls --verbose",
     "lint": "eslint --max-warnings 0 test lib",
     "fetch-schema": "node script/fetch-schema",
     "relay": "relay-compiler --src ./lib --schema graphql/schema.graphql"


### PR DESCRIPTION
The coveralls setup I did in #1740 misconfigured Coveralls slightly. Our builds were being reported to Coveralls with the pull request _source_ branch, while before it was the pull request _target_ branch. This breaks the ability to compare coverage to the parent:

<img width="330" alt="coveralls-first-build" src="https://user-images.githubusercontent.com/17565/48318436-0df5be80-e5cf-11e8-8595-b203cb9d433a.PNG">
