### PR TITLE
Prevent broken patches when staging or unstaging lines rapidly

### DIFF
--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -37,7 +37,6 @@ export default class FilePatchController extends React.Component {
     );
 
     this.state = {
-      lastFilePatch: this.props.filePatch,
       selectionMode: 'hunk',
       selectedRows: new Set(),
     };

--- a/lib/controllers/file-patch-controller.js
+++ b/lib/controllers/file-patch-controller.js
@@ -44,13 +44,17 @@ export default class FilePatchController extends React.Component {
     this.mouseSelectionInProgress = false;
     this.stagingOperationInProgress = false;
 
+    this.lastPatchString = null;
     this.patchChangePromise = new Promise(resolve => {
       this.resolvePatchChangePromise = resolve;
     });
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.filePatch !== this.props.filePatch) {
+    if (
+      this.lastPatchString !== null &&
+      this.lastPatchString !== this.props.filePatch.toString()
+    ) {
       this.resolvePatchChangePromise();
       this.patchChangePromise = new Promise(resolve => {
         this.resolvePatchChangePromise = resolve;
@@ -219,11 +223,18 @@ export default class FilePatchController extends React.Component {
     if (this.stagingOperationInProgress) {
       return null;
     }
-    this.stagingOperationInProgress = true;
-    this.patchChangePromise.then(() => {
-      this.stagingOperationInProgress = false;
-    });
 
-    return fn();
+    this.stagingOperationInProgress = true;
+    this.lastPatchString = this.props.filePatch.toString();
+    const operationPromise = fn();
+
+    operationPromise
+      .then(() => this.patchChangePromise)
+      .then(() => {
+        this.stagingOperationInProgress = false;
+        this.lastPatchString = null;
+      });
+
+    return operationPromise;
   }
 }

--- a/test/controllers/file-patch-controller.test.js
+++ b/test/controllers/file-patch-controller.test.js
@@ -4,6 +4,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import FilePatchController from '../../lib/controllers/file-patch-controller';
+import FilePatch from '../../lib/models/patch/file-patch';
 import * as reporterProxy from '../../lib/reporter-proxy';
 import {cloneRepository, buildRepository} from '../helpers';
 
@@ -151,14 +152,22 @@ describe('FilePatchController', function() {
       const wrapper = shallow(buildApp({relPath: 'a.txt', stagingStatus: 'unstaged'}));
       assert.strictEqual(await wrapper.find('FilePatchView').prop('toggleFile')(), 'staged');
 
-      wrapper.setProps({stagingStatus: 'staged'});
+      // No-op
       assert.isNull(await wrapper.find('FilePatchView').prop('toggleFile')());
 
-      const promise = wrapper.instance().patchChangePromise;
+      // Simulate an identical patch arriving too soon
       wrapper.setProps({filePatch: filePatch.clone()});
+
+      // Still a no-op
+      assert.isNull(await wrapper.find('FilePatchView').prop('toggleFile')());
+
+      // Simulate updated patch arrival
+      const promise = wrapper.instance().patchChangePromise;
+      wrapper.setProps({filePatch: FilePatch.createNull()});
       await promise;
 
-      assert.strictEqual(await wrapper.find('FilePatchView').prop('toggleFile')(), 'unstaged');
+      // Performs an operation again
+      assert.strictEqual(await wrapper.find('FilePatchView').prop('toggleFile')(), 'staged');
     });
   });
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

To prevent the generation of broken patches, the `FilePatchController` (soon to be `MultiFilePatchController`) pauses staging operations while it waits on a Promise that is _intended_ to be resolved when the `FilePatch` containing the result of the operation arrives as a component prop. However, staging operations were being resumed too soon for two reasons:

* If a new `FilePatch` is already being generated before a staging operation is begun -- triggered by an unrelated filesystem event, for example -- and arrives before the staging operation is complete, the "next patch" promise will resolve too early.

I've addressed this somewhat by waiting for the staging operation promise to resolve first before waiting for the "next patch" promise to resolve.

* Our `FilePatch` comparison noticed any difference in referential equality between old and new patches. This isn't good enough: it's very possible for the component to be re-rendered with a different `FilePatch` object that contains an identical patch.

This one I fixed by comparing the actual `toString()` serialization of the old and new `FilePatches` to determine when to resolve the "next patch" promise. I am still doing a referential equality check first so we'll stay nice and quick in the common case of a re-render with the same patch, and not doing a check at all in the common case of not having a pending staging operation underway.

### Alternate Designs

I thought about introducing a first-class way to sequence the operations performed within a `Repository` so we could explicitly express our constraint of "wait for the next FilePatch to be generated _after_ the staging operation has completed." We could do this by tracking a counter in the `Present` state that we increment each time an operation is started, and finding some way to compare its value among two different result objects. It felt pretty invasive to implement once I started looking at it, though, so I took the simpler tack.

### Benefits

Rapidly staging and unstaging lines will no longer create bad patches.

### Possible Drawbacks

Well, it might cause some merge conflicts in #1767.

### Applicable Issues

Fixes #1796.

### Metrics

_N/A_

### Tests

I've tested this by manually reproducing the bug in dev mode, making the change, and verifying that it no longer appears.

We already do have unit tests that are intended to capture this sort of situation. It turns out that writing unit tests to catch asynchronous race conditions is tricky. Who knew!

### Documentation

_N/A_

### User Experience Research

- [ ] @vanessayuenn should be unable to reproduce the problem when using this branch

