### PR TITLE
Add button to show/hide password in credentials dialog

### DIFF
--- a/lib/views/credential-dialog.js
+++ b/lib/views/credential-dialog.js
@@ -23,12 +23,14 @@ export default class CredentialDialog extends React.Component {
 
   constructor(props, context) {
     super(props, context);
-    autobind(this, 'confirm', 'cancel', 'onUsernameChange', 'onPasswordChange', 'onRememberChange', 'focusFirstInput');
+    autobind(this, 'confirm', 'cancel', 'onUsernameChange', 'onPasswordChange', 'onRememberChange',
+      'focusFirstInput', 'toggleShowPassword');
 
     this.state = {
       username: '',
       password: '',
       remember: false,
+      showPassword: false,
     };
   }
 
@@ -61,13 +63,16 @@ export default class CredentialDialog extends React.Component {
           <label className="github-DialogLabel">
             Password:
             <input
-              type="password"
+              type={this.state.showPassword ? 'text' : 'password'}
               ref={e => (this.passwordInput = e)}
               className="input-text github-CredentialDialog-Password"
               value={this.state.password}
               onChange={this.onPasswordChange}
               tabIndex="2"
             />
+            <button className="github-DialogLabelButton" onClick={this.toggleShowPassword}>
+              {this.state.showPassword ? 'Hide' : 'Show'}
+            </button>
           </label>
         </main>
         <footer className="github-DialogButtons">
@@ -121,5 +126,9 @@ export default class CredentialDialog extends React.Component {
 
   focusFirstInput() {
     (this.usernameInput || this.passwordInput).focus();
+  }
+
+  toggleShowPassword() {
+    this.setState({showPassword: !this.state.showPassword});
   }
 }

--- a/styles/dialog.less
+++ b/styles/dialog.less
@@ -19,7 +19,22 @@
   &Label {
     flex: 1;
     margin: @github-dialog-spacing;
+    position: relative;
     line-height: 2;
+
+    &Button {
+      position: absolute;
+      background: transparent;
+      right: .2em;
+      bottom: 0;
+      border: none;
+      color: #000;
+      cursor: pointer;
+
+      &:hover {
+        color: #888;
+      }
+    }
   }
 
   &Buttons {

--- a/styles/dialog.less
+++ b/styles/dialog.less
@@ -25,14 +25,14 @@
     &Button {
       position: absolute;
       background: transparent;
-      right: .2em;
+      right: .3em;
       bottom: 0;
       border: none;
-      color: #000;
+      color: @text-color-subtle;
       cursor: pointer;
 
       &:hover {
-        color: #888;
+        color: @text-color-highlight;
       }
     }
   }

--- a/test/views/credential-dialog.test.js
+++ b/test/views/credential-dialog.test.js
@@ -85,4 +85,24 @@ describe('CredentialDialog', function() {
       assert.isFalse(wrapper.find('.github-CredentialDialog-remember').exists());
     });
   });
+
+  describe('show password', function() {
+    it('sets the passwords input type to "text" on the first click', function() {
+      wrapper = mount(app);
+
+      wrapper.find('.github-DialogLabelButton').simulate('click');
+
+      const passwordInput = wrapper.find('.github-CredentialDialog-Password');
+      assert.equal(passwordInput.prop('type'), 'text');
+    });
+
+    it('sets the passwords input type back to "password" on the second click', function() {
+      wrapper = mount(app);
+
+      wrapper.find('.github-DialogLabelButton').simulate('click').simulate('click');
+
+      const passwordInput = wrapper.find('.github-CredentialDialog-Password');
+      assert.equal(passwordInput.prop('type'), 'password');
+    });
+  });
 });


### PR DESCRIPTION
<!--
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.
-->

### Description of the Change

Added a button to the credentials dialog to toggle the input type of the password between `"password"` and `"text"` so the user can see which credentials they entered, you can find a preview below.

I did this by adding a state variable named `showPassword` to the `CredentialDialog` component that keeps track of the current state (showing or hiding the password), and a button that manipulates this value.

- If `true` the `<input>` type is set to `"text"` and the `<button>` text to `"Hide"`. 
- If `false` the `<input>` type is set to `"password"` and the `<button>` text to `"Show"`

The button has an `onClick` listener which is the new method `toggleShowPassword`, which simply sets the value of the state variable `showPassword` to `!showPassword`.

As far as I can tell this is the only place in Atom (core) where a `<button>` is overlayed on an `<input>`, hence I added a new class named `.github-DialogLabelButton` which positions the `<button>` over the `<input>` and uses theme-based colors.

![preview](https://user-images.githubusercontent.com/3742559/48980192-9f385b00-f0ce-11e8-8fa2-dbae656df87a.gif)
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->

### Alternate Designs

The implementation of the `<button>` in HTML (JSX) and CSS is somewhat arbitrary and I'm open to changing it. Note however that I placed it inside the `<label>` so it can be positioned relative to that.

Currently the button is text-based, alternatively it could be icon-based. However, I did not implement this as the relevant icons are not present/incorrect, see:

![eye_icons_preview](https://user-images.githubusercontent.com/3742559/48980197-bb3bfc80-f0ce-11e8-9021-717eab87ea73.JPG)
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Better user experience for users that make typos when entering their credentials, i.e. everyone 😛 
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

No real drawbacks, arguably [Shoulder Surfing](https://en.wikipedia.org/wiki/Shoulder_surfing_(computer_security)) but as the default still hides the credentials I don't consider this a problem.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

#1736
<!-- Enter any applicable Issues here -->

### Metrics

N/A
<!-- What metrics are associated with this code change and what questions can they help us answer? Write "N/A" if not applicable. -->

### Tests

I tested the feature using two tests:

1. Verify the input type is `"text"` when the toggle button is pressed once.
1. Verify the input type is `"password"` when the toggle button is pressed twice.

Arguably another test verifying the input type when the button was not pressed can be added, I omitted this as the combination of the two tests above imply that assertion.
<!-- 

How did you verify that your change has the desired effects?
- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

What unit or integration tests were (or will be) added to help protect against future regressions? 
For manual testing, be sure to describe in detail the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and the results you observed.
If you chose not to include a specific test, please explain why. 

Write "N/A" if not applicable. 

-->

### Documentation

N/A
<!-- Describe the documentation added or improved. Write "N/A" if not applicable. -->

### Release Notes

_The GitHub package now provides a button to show/hide the input values of passwords._
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where the merge message did not show up in the commit message box.
- Increased the performance of rendering diffs.

-->

### User Experience Research (Optional)

No field research was done for this feature, however there is research supporting the addition of this feature. For example NIST specifies that "... [verifiers] SHOULD offer an option to display the secret..." [[1]](https://pages.nist.gov/800-63-3/sp800-63b.html#-5112-memorized-secret-verifiers) (where secret refers to the password in this situation).

If desired I can try to find more supporting research.

<!-- If this change would benefit from UXR, please state assumptions or hypotheses and specify if they are to be validated before or after releasing. Examples include investigating discoverability, verifying performance improvements, tracking metrics, etc. -->

