### PR TITLE
Disable the "changes" status from CodeCov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,3 @@ coverage:
     patch:
       default:
         threshold: 2
-
-    changes:
-      default:
-        threshold: 2


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Disable the "changes" status reported by CodeCov.

### Alternate Designs

I'd originally tried to build us some slack by configuring it with a `threshold` key, but that doesn't appear to work. In retrospect, that makes sense - the changes status is reported as a total number of files, not by coverage percentage like the others are - and the [commit status docs](https://docs.codecov.io/docs/commit-status) kind of support this.

### Benefit

It'll unblock pull requests like #1822 that currently have a red "changes" check that we can't do anything about from merging.

It'll also prevent our CI-watching chatops from spamming the #atom channel on every merge to master.

### Possible Drawbacks

There are some situations where we'll be able to incidentally decrease coverage and still get passing statuses from CodeCov. Deleting tests is one example.

### Applicable Issues

_n/a_

### Metrics

_n/a_

### Tests

I'm going to see if this pull request doesn't have the "changes" status reported from CodeCov. 🙃 

### Documentation

_n/a_

### Release Notes

_n/a_

### User Experience Research (Optional)

_n/a_