### PR TITLE
Fix bug where pull request cannot be viewed if pullRequest.headRepository is null.

### DIFF
--- a/lib/controllers/issueish-detail-controller.js
+++ b/lib/controllers/issueish-detail-controller.js
@@ -153,6 +153,12 @@ export class BareIssueishDetailController extends React.Component {
       return this.checkoutOp.disable(checkoutStates.DISABLED, 'Checking out...');
     }
 
+    // determine if pullRequest.headRepository is null
+    // this can happen if a repository has been deleted.
+    if (!pullRequest.headRepository) {
+      return this.checkoutOp.disable(checkoutStates.DISABLED, 'Pull request head repository does not exist');
+    }
+
     // Determine if we already have this PR checked out.
 
     const headPush = this.props.branches.getHeadBranch().getPush();

--- a/test/controllers/issueish-detail-controller.test.js
+++ b/test/controllers/issueish-detail-controller.test.js
@@ -109,6 +109,15 @@ describe('IssueishDetailController', function() {
       assert.isFalse(op1.isEnabled());
       assert.strictEqual(op1.getMessage(), 'Rebase in progress');
     });
+    it('is disabled if pullRequest.headRepository is null', function() {
+      const props = issueishDetailControllerProps({}, {});
+      props.repository.pullRequest.headRepository = null;
+      const wrapper = shallow(buildApp({}, {...props}));
+      const op = wrapper.find('Relay(BarePullRequestDetailView)').prop('checkoutOp');
+      assert.isFalse(op.isEnabled());
+      assert.strictEqual(op.getMessage(), 'Pull request head repository does not exist');
+    });
+
 
     it('is disabled if the current branch already corresponds to the pull request', function() {
       const upstream = Branch.createRemoteTracking('remotes/origin/feature', 'origin', 'refs/heads/feature');


### PR DESCRIPTION
### Description of the Change

If `pullRequest.headRepository` is null, (which might be the case if, for example, a user deletes the repository), currently we throw an error and the pull request cannot be viewed.

This pull request adds a check for this condition, so we can avoid the code that's checking for a non existent property.

### Alternate Designs

This approach allows a user to view a pull request where a head repository is null, but they cannot check it out.  While it would be possible to fall back to refs/pull/${PR}/head to check out the pull request from dotcom, it seems not worth the added complexity.  My assumption is, it's relatively rare for a user to open a cross repository pull request and then delete their fork. 

If I'm wrong, and it's more common than I think, I'd be open to revisiting this decision and supporting checkout in this edge case.

### Benefits

Users can view pull requests again.

### Possible Drawbacks

I can't think of anything, other than writing code always introduces the possibility of more bugs.

### Applicable Issues

https://github.com/atom/github/issues/1776

### Metrics

n/a

### Tests

- Wrote a unit test to validate that the checkout opportunity is disabled if `pullRequest.headRepository` is null.
- Manually testing viewing a pull request within Atom where the head repository has been deleted.

### Documentation

N/A

### Release Notes

It's not a notable change, dawg.  Nothing to see here.

