### PR TITLE
Build PRs that only change documentation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,19 +3,11 @@ trigger:
     include:
     - master
     - releases/*
-  paths:
-    exclude:
-    - README.md
-    - docs/*
 
 pr:
   branches:
     include:
     - "*"
-  paths:
-    exclude:
-    - README.md
-    - docs/*
 
 jobs:
 - job: Linux


### PR DESCRIPTION
When I was first setting up Azure DevOps, I was trying to be all clever and kept builds from triggering on docs-only changes. Unfortunately, our expected status checks don't account for this, so docs-only PRs will never be marked mergeable; see #1842.