### PR TITLE
Backportable keymap changes

### DIFF
--- a/keymaps/git.cson
+++ b/keymaps/git.cson
@@ -55,9 +55,13 @@
   'ctrl-enter': 'github:commit'
 
 '.github-CommitView-commitPreview':
-  'cmd-left': 'github:dive'
-  'ctrl-left': 'github:dive'
   'enter': 'native!'
+'.platform-darwin .github-CommitView-commitPreview':
+  'cmd-left': 'github:dive'
+'.platform-win32 .github-CommitView-commitPreview':
+  'ctrl-left': 'github:dive'
+'.platform-linux .github-CommitView-commitPreview':
+  'ctrl-left': 'github:dive'
 
 '.github-RecentCommits':
   'left': 'github:dive'

--- a/keymaps/git.cson
+++ b/keymaps/git.cson
@@ -26,21 +26,33 @@
   'shift-tab': 'core:focus-previous'
   'o': 'github:jump-to-file'
   'left': 'core:move-left'
+'.platform-darwin .github-StagingView':
   'cmd-left': 'core:move-left'
+'.platform-linux .github-StagingView, .platform-win32 .github-StagingView':
+  'ctrl-left': 'core-move-left'
 
 '.github-CommitView button':
   'tab': 'core:focus-next'
   'shift-tab': 'core:focus-previous'
 
-'.github-StagingView.unstaged-changes-focused':
+'.platform-darwin .github-StagingView.unstaged-changes-focused':
   'cmd-backspace': 'github:discard-changes-in-selected-files'
+'.platform-linux .github-StagingView.unstaged-changes-focused':
+  'ctrl-backspace': 'github:discard-changes-in-selected-files'
+'.platform-win32 .github-StagingView.unstaged-changes-focused':
+  # Repeated to avoid line length
   'ctrl-backspace': 'github:discard-changes-in-selected-files'
 
 '.github-CommitView-editor atom-text-editor:not([mini])':
-  'cmd-enter': 'github:commit'
-  'ctrl-enter': 'github:commit'
   'tab': 'core:focus-next'
   'shift-tab': 'core:focus-previous'
+'.platform-darwin .github-CommitView-editor atom-text-editor:not([mini])':
+  'cmd-enter': 'github:commit'
+'.platform-win32 .github-CommitView-editor atom-text-editor:not([mini])':
+  'ctrl-enter': 'github:commit'
+'.platform-linux .github-CommitView-editor atom-text-editor:not([mini])':
+  # Repeated to avoid line length
+  'ctrl-enter': 'github:commit'
 
 '.github-CommitView-commitPreview':
   'cmd-left': 'github:dive'
@@ -49,25 +61,38 @@
 
 '.github-RecentCommits':
   'enter': 'github:dive'
-  'cmd-left': 'github:dive'
-  'ctrl-left': 'github:dive'
   'tab': 'core:focus-next'
   'shift-tab': 'core:focus-previous'
+'.platform-darwin .github-RecentCommits':
+  'cmd-left': 'github:dive'
+'.platform-win32 .github-RecentCommits, .platform-linux .github-RecentCommits':
+  'ctrl-left': 'github:dive'
 
-'.github-CommitDetailView':
+'.platform-darwin .github-CommitDetailView':
   'cmd-right': 'github:surface'
+'.platform-win32 .github-CommitDetailView':
+  'ctrl-right': 'github:surface'
+'.platform-linux .github-CommitDetailView':
   'ctrl-right': 'github:surface'
 
 '.github-FilePatchView atom-text-editor:not([mini])':
+'.platform-darwin .github-FilePatchView atom-text-editor:not([mini])':
   'cmd-/': 'github:toggle-patch-selection-mode'
-  'ctrl-/': 'github:toggle-patch-selection-mode'
   'cmd-backspace': 'github:discard-selected-lines'
-  'ctrl-backspace': 'github:discard-selected-lines'
-  'ctrl-enter': 'core:confirm'
   'cmd-enter': 'core:confirm'
   'cmd-right': 'github:surface'
-  'ctrl-right': 'github:surface'
   'cmd-o': 'github:jump-to-file'
+'.platform-win32 .github-FilePatchView atom-text-editor:not([mini])':
+  'ctrl-/': 'github:toggle-patch-selection-mode'
+  'ctrl-backspace': 'github:discard-selected-lines'
+  'ctrl-enter': 'core:confirm'
+  'ctrl-right': 'github:surface'
+  'ctrl-o': 'github:jump-to-file'
+'.platform-linux .github-FilePatchView atom-text-editor:not([mini])':
+  'ctrl-/': 'github:toggle-patch-selection-mode'
+  'ctrl-backspace': 'github:discard-selected-lines'
+  'ctrl-enter': 'core:confirm'
+  'ctrl-right': 'github:surface'
   'ctrl-o': 'github:jump-to-file'
 
 '.github-FilePatchView--hunkMode atom-text-editor:not([mini])':

--- a/keymaps/git.cson
+++ b/keymaps/git.cson
@@ -17,8 +17,9 @@
   'alt-m enter': 'github:resolve-as-current'
   'alt-m r': 'github:revert-current'
 
-'.github-Git':
+'.platform-darwin .github-Git':
   'cmd-enter': 'github:commit'
+'.platform-win32 .github-Git, .platform-linux .github-Git':
   'ctrl-enter': 'github:commit'
 
 '.github-StagingView':

--- a/keymaps/git.cson
+++ b/keymaps/git.cson
@@ -55,6 +55,7 @@
   'ctrl-enter': 'github:commit'
 
 '.github-CommitView-commitPreview':
+  'left': 'github-dive'
   'enter': 'native!'
 '.platform-darwin .github-CommitView-commitPreview':
   'cmd-left': 'github:dive'

--- a/keymaps/git.cson
+++ b/keymaps/git.cson
@@ -27,7 +27,6 @@
   'shift-tab': 'core:focus-previous'
   'o': 'github:jump-to-file'
   'left': 'core:move-left'
-  'enter': 'core:move-left'
 '.platform-darwin .github-StagingView':
   'cmd-left': 'core:move-left'
 '.platform-linux .github-StagingView, .platform-win32 .github-StagingView':

--- a/keymaps/git.cson
+++ b/keymaps/git.cson
@@ -26,6 +26,7 @@
   'shift-tab': 'core:focus-previous'
   'o': 'github:jump-to-file'
   'left': 'core:move-left'
+  'enter': 'core:move-left'
 '.platform-darwin .github-StagingView':
   'cmd-left': 'core:move-left'
 '.platform-linux .github-StagingView, .platform-win32 .github-StagingView':

--- a/keymaps/git.cson
+++ b/keymaps/git.cson
@@ -76,6 +76,13 @@
   'ctrl-right': 'github:surface'
 
 '.github-FilePatchView atom-text-editor:not([mini])':
+  # Only support unprefixed file patch keybindings until MultiFilePatch is
+  # editable
+  '/': 'github:toggle-patch-selection-mode'
+  'backspace': 'github:discard-selected-lines'
+  'enter': 'core:confirm'
+  'right': 'github:surface'
+  'o': 'github:jump-to-file'
 '.platform-darwin .github-FilePatchView atom-text-editor:not([mini])':
   'cmd-/': 'github:toggle-patch-selection-mode'
   'cmd-backspace': 'github:discard-selected-lines'

--- a/keymaps/git.cson
+++ b/keymaps/git.cson
@@ -68,13 +68,6 @@
 '.platform-win32 .github-RecentCommits, .platform-linux .github-RecentCommits':
   'ctrl-left': 'github:dive'
 
-'.platform-darwin .github-CommitDetailView':
-  'cmd-right': 'github:surface'
-'.platform-win32 .github-CommitDetailView':
-  'ctrl-right': 'github:surface'
-'.platform-linux .github-CommitDetailView':
-  'ctrl-right': 'github:surface'
-
 '.github-FilePatchView atom-text-editor:not([mini])':
   # Only support unprefixed file patch keybindings until MultiFilePatch is
   # editable

--- a/keymaps/git.cson
+++ b/keymaps/git.cson
@@ -60,6 +60,7 @@
   'enter': 'native!'
 
 '.github-RecentCommits':
+  'left': 'github:dive'
   'enter': 'github:dive'
   'tab': 'core:focus-next'
   'shift-tab': 'core:focus-previous'


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Restore MultiFilePatch navigation keybindings unadorned by `cmd` or `ctrl` that were removed by #1512. Specifically:

* `right` and `cmd-right` or `ctrl-right` surface focus to the Git tab
* `backspace` discards the selection
* `enter` stages or unstages the selection
* `o` jumps to file
* `/` toggles between line and hunk selection mode

I've also separated the `cmd` and `ctrl` keybindings throughout the keymap by platform, guarding `cmd` bindings with `.platform-darwin` and `ctrl` alternatives with `.platform-linux, .platform-win32`. This opens up the `ctrl-` bindings on macOS in the future and prevents ambiguities in the binding that we render on buttons and tooltips.

### Alternate Designs

Another alternative that we talked about was showing a notification the first time that you try to use one of the deprecated keystrokes (and letting the keystroke go through to the editor normally). I think we should do that as part of the diff editability work, personally.

### Benefits

This keeps our keybinding changes from breaking users' muscle memory for another few releases.

### Possible Drawbacks

If anyone on macOS learned the ctrl- keystrokes for some reason, those will be broken by this.

It also gives us a lot of redundancy in our keymap, which hurts maintainability. Hopefully this is just a temporary thing.

### Applicable Issues

Related to #1820.

### Metrics

Out of scope for the moment.

### Tests

Our existing test suite should catch any regressions here.

### Documentation

The flight manual [already references unadorned keystrokes](https://flight-manual.atom.io/using-atom/sections/github-package/#stage), which is a good reason to backport this. I've also already filed atom/flight-manual.atom.io#504 to update it to use the `cmd` or `ctrl` prefixes where appropriate, which we can merge while _both_ work, so that new users learn the prefixed commands instead.

### Release Notes

* Restored unprefixed keyboard navigation commands to file patches in the GitHub package.

### User Experience Research (Optional)

_n/a_