### PR TITLE
add tooltips to git && GitHub status bar icons

### DIFF
--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -97,6 +97,7 @@ export default class StatusBarTileController extends React.Component {
           didClick={this.props.toggleGitTab}
           changedFilesCount={repoProps.changedFilesCount}
           mergeConflictsPresent={repoProps.mergeConflictsPresent}
+          tooltips={this.props.tooltips}
         />
       </Fragment>
     );

--- a/lib/controllers/status-bar-tile-controller.js
+++ b/lib/controllers/status-bar-tile-controller.js
@@ -89,7 +89,10 @@ export default class StatusBarTileController extends React.Component {
     return (
       <Fragment>
         {this.renderTiles(repoProps)}
-        <GithubTileView didClick={this.props.toggleGithubTab} />
+        <GithubTileView
+          didClick={this.props.toggleGithubTab}
+          tooltips={this.props.tooltips}
+        />
         <ChangedFilesCountView
           didClick={this.props.toggleGitTab}
           changedFilesCount={repoProps.changedFilesCount}

--- a/lib/views/changed-files-count-view.js
+++ b/lib/views/changed-files-count-view.js
@@ -21,6 +21,7 @@ export default class ChangedFilesCountView extends React.Component {
   static defaultProps = {
     changedFilesCount: 0,
     mergeConflictsPresent: false,
+    tooltips: {},
     didClick: () => {},
   }
 

--- a/lib/views/changed-files-count-view.js
+++ b/lib/views/changed-files-count-view.js
@@ -7,7 +7,6 @@ import Tooltip from '../atom/tooltip';
 import RefHolder from '../models/ref-holder';
 
 import {addEvent} from '../reporter-proxy';
-import {autobind} from '../helpers';
 
 export const tooltipMessage = 'Click to open the Git pane and commit your changes';
 
@@ -27,11 +26,10 @@ export default class ChangedFilesCountView extends React.Component {
 
   constructor(props) {
     super(props);
-    autobind(this, 'handleClick');
     this.refTileNode = new RefHolder();
   }
 
-  handleClick() {
+  handleClick = () => {
     addEvent('click', {package: 'github', component: 'ChangedFileCountView'});
     this.props.didClick();
   }

--- a/lib/views/changed-files-count-view.js
+++ b/lib/views/changed-files-count-view.js
@@ -1,14 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import Octicon from '../atom/octicon';
+import Tooltip from '../atom/tooltip';
+
+import RefHolder from '../models/ref-holder';
+
 import {addEvent} from '../reporter-proxy';
 import {autobind} from '../helpers';
+
+export const tooltipMessage = 'Click to open the Git pane and commit your changes';
 
 export default class ChangedFilesCountView extends React.Component {
   static propTypes = {
     changedFilesCount: PropTypes.number.isRequired,
     didClick: PropTypes.func.isRequired,
     mergeConflictsPresent: PropTypes.bool,
+    tooltips: PropTypes.object.isRequired,
   }
 
   static defaultProps = {
@@ -20,6 +28,7 @@ export default class ChangedFilesCountView extends React.Component {
   constructor(props) {
     super(props);
     autobind(this, 'handleClick');
+    this.refTileNode = new RefHolder();
   }
 
   handleClick() {
@@ -29,14 +38,24 @@ export default class ChangedFilesCountView extends React.Component {
 
   render() {
     return (
-      <button
-        ref="changedFiles"
-        className="github-ChangedFilesCount inline-block"
-        onClick={this.handleClick}>
-        <Octicon icon="git-commit" />
-        {`Git (${this.props.changedFilesCount})`}
-        {this.props.mergeConflictsPresent && <Octicon icon="alert" />}
-      </button>
+      <span ref={this.refTileNode.setter}>
+        <button
+          ref="changedFiles"
+          className="github-ChangedFilesCount inline-block"
+          onClick={this.handleClick}>
+          <Octicon icon="git-commit" />
+          {`Git (${this.props.changedFilesCount})`}
+          {this.props.mergeConflictsPresent && <Octicon icon="alert" />}
+        </button>
+        <Tooltip
+          key="tooltip"
+          manager={this.props.tooltips}
+          target={this.refTileNode}
+          title={`<div style="text-align: left; line-height: 1.2em;">${tooltipMessage}</div>`}
+          showDelay={atom.tooltips.hoverDefaults.delay.show}
+          hideDelay={atom.tooltips.hoverDefaults.delay.hide}
+        />
+      </span>
     );
   }
 }

--- a/lib/views/github-tile-view.js
+++ b/lib/views/github-tile-view.js
@@ -2,17 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Octicon from '../atom/octicon';
 
+import RefHolder from '../models/ref-holder';
+import Tooltip from '../atom/tooltip';
 import {addEvent} from '../reporter-proxy';
 import {autobind} from '../helpers';
 
 export default class GithubTileView extends React.Component {
   static propTypes = {
     didClick: PropTypes.func.isRequired,
+    tooltips: PropTypes.object.isRequired
   }
 
   constructor(props) {
     super(props);
     autobind(this, 'handleClick');
+    this.refTileNode = new RefHolder();
   }
 
   handleClick() {
@@ -22,12 +26,22 @@ export default class GithubTileView extends React.Component {
 
   render() {
     return (
-      <button
-        className="github-StatusBarTile inline-block"
-        onClick={this.handleClick}>
-        <Octicon icon="mark-github" />
-        GitHub
-      </button>
+      <span ref={this.refTileNode.setter}>
+        <button
+          className="github-StatusBarTile inline-block"
+          onClick={this.handleClick}>
+          <Octicon icon="mark-github" />
+          GitHub
+        </button>
+        <Tooltip
+          key="tooltip"
+          manager={this.props.tooltips}
+          target={this.refTileNode}
+          title={`<div style="text-align: left; line-height: 1.2em;">${'hi'}</div>`}
+          showDelay={atom.tooltips.hoverDefaults.delay.show}
+          hideDelay={atom.tooltips.hoverDefaults.delay.hide}
+        />
+      </span>
     );
   }
 }

--- a/lib/views/github-tile-view.js
+++ b/lib/views/github-tile-view.js
@@ -7,7 +7,7 @@ import Tooltip from '../atom/tooltip';
 import {addEvent} from '../reporter-proxy';
 import {autobind} from '../helpers';
 
-const toolTipMessage = 'Click to view open GitHub pull requests';
+export const toolTipMessage = 'Click to view open GitHub pull requests';
 
 export default class GithubTileView extends React.Component {
   static propTypes = {

--- a/lib/views/github-tile-view.js
+++ b/lib/views/github-tile-view.js
@@ -12,7 +12,7 @@ export const toolTipMessage = 'Click to view open GitHub pull requests';
 export default class GithubTileView extends React.Component {
   static propTypes = {
     didClick: PropTypes.func.isRequired,
-    tooltips: PropTypes.object.isRequired
+    tooltips: PropTypes.object.isRequired,
   }
 
   constructor(props) {

--- a/lib/views/github-tile-view.js
+++ b/lib/views/github-tile-view.js
@@ -7,6 +7,8 @@ import Tooltip from '../atom/tooltip';
 import {addEvent} from '../reporter-proxy';
 import {autobind} from '../helpers';
 
+const toolTipMessage = 'Click to view open GitHub pull requests';
+
 export default class GithubTileView extends React.Component {
   static propTypes = {
     didClick: PropTypes.func.isRequired,
@@ -37,7 +39,7 @@ export default class GithubTileView extends React.Component {
           key="tooltip"
           manager={this.props.tooltips}
           target={this.refTileNode}
-          title={`<div style="text-align: left; line-height: 1.2em;">${'hi'}</div>`}
+          title={`<div style="text-align: left; line-height: 1.2em;">${toolTipMessage}</div>`}
           showDelay={atom.tooltips.hoverDefaults.delay.show}
           hideDelay={atom.tooltips.hoverDefaults.delay.hide}
         />

--- a/lib/views/github-tile-view.js
+++ b/lib/views/github-tile-view.js
@@ -5,7 +5,6 @@ import Octicon from '../atom/octicon';
 import RefHolder from '../models/ref-holder';
 import Tooltip from '../atom/tooltip';
 import {addEvent} from '../reporter-proxy';
-import {autobind} from '../helpers';
 
 export const toolTipMessage = 'Click to view open GitHub pull requests';
 
@@ -17,11 +16,10 @@ export default class GithubTileView extends React.Component {
 
   constructor(props) {
     super(props);
-    autobind(this, 'handleClick');
     this.refTileNode = new RefHolder();
   }
 
-  handleClick() {
+  handleClick = () => {
     addEvent('click', {package: 'github', component: 'GithubTileView'});
     this.props.didClick();
   }

--- a/lib/views/github-tile-view.js
+++ b/lib/views/github-tile-view.js
@@ -6,7 +6,7 @@ import RefHolder from '../models/ref-holder';
 import Tooltip from '../atom/tooltip';
 import {addEvent} from '../reporter-proxy';
 
-export const toolTipMessage = 'Click to view open GitHub pull requests';
+export const tooltipMessage = 'Click to view open GitHub pull requests';
 
 export default class GithubTileView extends React.Component {
   static propTypes = {
@@ -37,7 +37,7 @@ export default class GithubTileView extends React.Component {
           key="tooltip"
           manager={this.props.tooltips}
           target={this.refTileNode}
-          title={`<div style="text-align: left; line-height: 1.2em;">${toolTipMessage}</div>`}
+          title={`<div style="text-align: left; line-height: 1.2em;">${tooltipMessage}</div>`}
           showDelay={atom.tooltips.hoverDefaults.delay.show}
           hideDelay={atom.tooltips.hoverDefaults.delay.hide}
         />

--- a/styles/github-status-bar-tile.less
+++ b/styles/github-status-bar-tile.less
@@ -1,6 +1,7 @@
 .github-StatusBarTile {
   background-color: inherit;
   border: none;
+  cursor: default;
 
   &.icon-mark-github::before {
     margin-right: .2em;

--- a/test/controllers/status-bar-tile-controller.test.js
+++ b/test/controllers/status-bar-tile-controller.test.js
@@ -10,8 +10,6 @@ import {getTempDir} from '../../lib/helpers';
 import Repository from '../../lib/models/repository';
 import StatusBarTileController from '../../lib/controllers/status-bar-tile-controller';
 import BranchView from '../../lib/views/branch-view';
-import ChangedFilesCountView from '../../lib/views/changed-files-count-view';
-import GithubTileView from '../../lib/views/github-tile-view';
 
 describe('StatusBarTileController', function() {
   let atomEnvironment;
@@ -707,7 +705,7 @@ describe('StatusBarTileController', function() {
 
       const wrapper = await mountAndLoad(buildApp({repository, toggleGithubTab}));
 
-      wrapper.find(GithubTileView).simulate('click');
+      wrapper.find('.github-StatusBarTile').simulate('click');
       assert(toggleGithubTab.calledOnce);
     });
   });
@@ -722,7 +720,7 @@ describe('StatusBarTileController', function() {
 
       const wrapper = await mountAndLoad(buildApp({repository, toggleGitTab}));
 
-      wrapper.find(ChangedFilesCountView).simulate('click');
+      wrapper.find('.github-ChangedFilesCount').simulate('click');
       assert(toggleGitTab.calledOnce);
     });
   });

--- a/test/views/changed-files-count-view.test.js
+++ b/test/views/changed-files-count-view.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import ChangedFilesCountView from '../../lib/views/changed-files-count-view';
+import ChangedFilesCountView, {tooltipMessage} from '../../lib/views/changed-files-count-view';
 import * as reporterProxy from '../../lib/reporter-proxy';
 
 describe('ChangedFilesCountView', function() {
@@ -27,10 +27,17 @@ describe('ChangedFilesCountView', function() {
     assert.isTrue(wrapper.text().includes('Git (2)'));
   });
 
+  it('renders tooltip', function() {
+    wrapper = shallow(<ChangedFilesCountView />);
+    const tooltip = wrapper.find('Tooltip');
+    assert.isTrue(tooltip.props().title.includes(tooltipMessage));
+  });
+
+
   it('records an event on click', function() {
     sinon.stub(reporterProxy, 'addEvent');
     wrapper = shallow(<ChangedFilesCountView />);
-    wrapper.simulate('click');
+    wrapper.find('button').simulate('click');
     assert.isTrue(reporterProxy.addEvent.calledWith('click', {package: 'github', component: 'ChangedFileCountView'}));
   });
 });

--- a/test/views/github-tile-view.test.js
+++ b/test/views/github-tile-view.test.js
@@ -1,20 +1,28 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import GithubTileView from '../../lib/views/github-tile-view';
+import GithubTileView, {toolTipMessage} from '../../lib/views/github-tile-view';
 import * as reporterProxy from '../../lib/reporter-proxy';
 
 describe('GithubTileView', function() {
   let wrapper, clickSpy;
   beforeEach(function() {
     clickSpy = sinon.spy();
-    wrapper = shallow(<GithubTileView didClick={clickSpy} />);
+    wrapper = shallow(<GithubTileView didClick={clickSpy}
+      tooltips={{}}
+    />);
   });
 
   it('renders github icon and text', function() {
     assert.isTrue(wrapper.html().includes('mark-github'));
     assert.isTrue(wrapper.text().includes('GitHub'));
   });
+
+  it('renders tooltip', function() {
+    const tooltip = wrapper.find('Tooltip');
+    assert.isTrue(tooltip.props().title.includes(toolTipMessage));
+  });
+
 
   it('calls props.didClick when clicked', function() {
     wrapper.find('button').simulate('click');

--- a/test/views/github-tile-view.test.js
+++ b/test/views/github-tile-view.test.js
@@ -17,13 +17,13 @@ describe('GithubTileView', function() {
   });
 
   it('calls props.didClick when clicked', function() {
-    wrapper.simulate('click');
+    wrapper.find('button').simulate('click');
     assert.isTrue(clickSpy.calledOnce);
   });
 
   it('records an event on click', function() {
     sinon.stub(reporterProxy, 'addEvent');
-    wrapper.simulate('click');
+    wrapper.find('button').simulate('click');
     assert.isTrue(reporterProxy.addEvent.calledWith('click', {package: 'github', component: 'GithubTileView'}));
   });
 });

--- a/test/views/github-tile-view.test.js
+++ b/test/views/github-tile-view.test.js
@@ -8,9 +8,12 @@ describe('GithubTileView', function() {
   let wrapper, clickSpy;
   beforeEach(function() {
     clickSpy = sinon.spy();
-    wrapper = shallow(<GithubTileView didClick={clickSpy}
-      tooltips={{}}
-    />);
+    wrapper = shallow(
+      <GithubTileView
+        didClick={clickSpy}
+        tooltips={{}}
+      />,
+    );
   });
 
   it('renders github icon and text', function() {

--- a/test/views/github-tile-view.test.js
+++ b/test/views/github-tile-view.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 
-import GithubTileView, {toolTipMessage} from '../../lib/views/github-tile-view';
+import GithubTileView, {tooltipMessage} from '../../lib/views/github-tile-view';
 import * as reporterProxy from '../../lib/reporter-proxy';
 
 describe('GithubTileView', function() {
@@ -23,7 +23,7 @@ describe('GithubTileView', function() {
 
   it('renders tooltip', function() {
     const tooltip = wrapper.find('Tooltip');
-    assert.isTrue(tooltip.props().title.includes(toolTipMessage));
+    assert.isTrue(tooltip.props().title.includes(tooltipMessage));
   });
 
 


### PR DESCRIPTION
### Description of the Change

During usability testing, some users tried to hover over the git and GitHub icons in the status bar.  I noticed that these buttons don't have tooltips, but the rest of the status bar icons do.

This pull request adds tooltips to these status bar icons that show up on hover.

### Alternate Designs

- We thought about just saying "Click to open the git || GitHub pane."  However, @mofo37 and myself thought telling users what they can accomplish by doing so would be more informative.

### Benefits

- Making our UI more consistent (all the other status bar things have tooltips)
- Possibly improving discoverability of the git and GitHub panes
- Cleaned up a few `autobind` calls while I was at it. 

### Possible Drawbacks

Users who already know what the buttons do might be annoyed by the real estate taken up by the tooltips.  However, the tooltip delay is relatively long.  We can always increase it if there's a problem.

### Applicable Issues

https://github.com/atom/github/issues/1774

### Metrics

It might be beneficial to collect metrics about when tooltips are shown.  However, actually showing the tooltip is handled by some Atom core apis, so it's a bit out of scope for us to track that here.

We do already have metrics showing how many times the icons are clicked, so if there's a jump in that, we'll know this change was beneficial for discoverability.  That said, I'm not expecting a massive increase.

### Tests

- Manually tested that tooltips show up as expected, and the buttons still open the panes.
- Unit tests for both components verifying that tooltip shows up and contains the expected message.

### Documentation
N/A

### Release Notes

Added tooltips to the git and GitHub status bar icons that are shown on hover.

### User Experience Research (Optional)

This change was a result of research we've already done.  woo!

