### PR TITLE
Remove status section from feature proposal template

### DIFF
--- a/docs/feature-requests/000-template.md
+++ b/docs/feature-requests/000-template.md
@@ -6,10 +6,6 @@ For community contributors -- Please fill out Part 1 of the following template. 
 
 # Feature title
 
-## :tipping_hand_woman: Status
-
-Proposed
-
 ## :memo: Summary
 
 One paragraph explanation of the feature.


### PR DESCRIPTION
I notice we have been inconsistent at remembering to change the status of feature requests from `proposed` to `accepted` when we merge the feature, and I don't think the status conveys much important information.

-----
[View rendered docs/feature-requests/000-template.md](https://github.com/atom/github/blob/vanessayuenn-patch-1/docs/feature-requests/000-template.md)