### PR TITLE
Fix: handle renames on file changed tab

### DIFF
--- a/lib/views/file-patch-header-view.js
+++ b/lib/views/file-patch-header-view.js
@@ -13,6 +13,7 @@ import {ItemTypePropType} from '../prop-types';
 export default class FilePatchHeaderView extends React.Component {
   static propTypes = {
     relPath: PropTypes.string.isRequired,
+    newPath: PropTypes.string,
     stagingStatus: PropTypes.oneOf(['staged', 'unstaged']),
     isPartiallyStaged: PropTypes.bool,
     hasHunks: PropTypes.bool.isRequired,
@@ -51,16 +52,26 @@ export default class FilePatchHeaderView extends React.Component {
     if (this.props.itemType === ChangedFileItem) {
       const status = this.props.stagingStatus;
       return (
-        <span>{status[0].toUpperCase()}{status.slice(1)} Changes for {this.renderPath()}</span>
+        <span>{status[0].toUpperCase()}{status.slice(1)} Changes for {this.renderDisplayPath()}</span>
       );
     } else {
-      return this.renderPath();
+      return this.renderDisplayPath();
     }
   }
 
-  renderPath() {
-    const dirname = path.dirname(this.props.relPath);
-    const basename = path.basename(this.props.relPath);
+  renderDisplayPath() {
+    if (this.props.newPath && this.props.newPath !== this.props.relPath) {
+      const oldPath = this.renderPath(this.props.relPath);
+      const newPath = this.renderPath(this.props.newPath);
+      return <span>{oldPath} <span>→</span> {newPath}</span>;
+    } else {
+      return this.renderPath(this.props.relPath);
+    }
+  }
+
+  renderPath(filePath) {
+    const dirname = path.dirname(filePath);
+    const basename = path.basename(filePath);
 
     if (dirname === '.') {
       return <span className="gitub-FilePatchHeaderView-basename">{basename}</span>;

--- a/lib/views/multi-file-patch-view.js
+++ b/lib/views/multi-file-patch-view.js
@@ -316,6 +316,7 @@ export default class MultiFilePatchView extends React.Component {
             <FilePatchHeaderView
               itemType={this.props.itemType}
               relPath={filePatch.getPath()}
+              newPath={filePatch.getStatus() === 'renamed' ? filePatch.getNewPath() : null}
               stagingStatus={this.props.stagingStatus}
               isPartiallyStaged={this.props.isPartiallyStaged}
               hasHunks={filePatch.getHunks().length > 0}

--- a/test/views/file-patch-header-view.test.js
+++ b/test/views/file-patch-header-view.test.js
@@ -60,6 +60,13 @@ describe('FilePatchHeaderView', function() {
         assert.strictEqual(wrapper.find('.github-FilePatchView-title').text(), `Staged Changes for ${relPath}`);
       });
     });
+
+    it('renders title for a renamed file as oldPath → newPath', function() {
+      const oldPath = path.join('dir', 'a.txt');
+      const newPath = path.join('dir', 'b.txt');
+      const wrapper = shallow(buildApp({relPath: oldPath, newPath}));
+      assert.strictEqual(wrapper.find('.github-FilePatchView-title').text(), `${oldPath} → ${newPath}`);
+    });
   });
 
   describe('the button group', function() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6842965/50219725-653a3c00-0390-11e9-9e83-2d854d80d853.png)

Now that renaming files is properly handled in [the upstream library](https://github.com/kuychaco/what-the-diff/pull/12), we should add support for that on files changed tab too. Now the title for a renamed file is rendered as `$oldPath → $newPath`. Fixes #1852.