### PR TITLE
Adjustable diff font size

### DIFF
--- a/styles/file-patch-view.less
+++ b/styles/file-patch-view.less
@@ -41,7 +41,7 @@
     padding-left: @component-padding;
     border: 1px solid @base-border-color;
     border-radius: @component-border-radius;
-    font-family: system-ui;
+    font-family: @font-family;
     font-size: @font-size;
     background-color: @header-bg-color;
     cursor: default;

--- a/styles/file-patch-view.less
+++ b/styles/file-patch-view.less
@@ -42,6 +42,7 @@
     border: 1px solid @base-border-color;
     border-radius: @component-border-radius;
     font-family: system-ui;
+    font-size: @font-size;
     background-color: @header-bg-color;
     cursor: default;
 
@@ -248,7 +249,6 @@
   // Readonly editor
 
   atom-text-editor[readonly] {
-    font-size: @font-size; // Use font-size form UI themes and not the editor config
     .cursors {
       display: none;
     }

--- a/styles/hunk-header-view.less
+++ b/styles/hunk-header-view.less
@@ -10,7 +10,7 @@
 
   display: flex;
   align-items: stretch;
-  font-size: .9em;
+  font-size: @font-size;
   border: 1px solid @base-border-color;
   border-radius: @component-border-radius;
   background-color: @hunk-bg-color;

--- a/styles/hunk-header-view.less
+++ b/styles/hunk-header-view.less
@@ -6,8 +6,6 @@
 @hunk-bg-color-active: mix(@syntax-text-color, @syntax-background-color, 2%);
 
 .github-HunkHeaderView {
-  font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-
   display: flex;
   align-items: stretch;
   font-size: @font-size;


### PR DESCRIPTION
### Description of the Change

This PR makes the font size of diffs adjustable based on Atom's editor config. The header font size is set by the UI themes.

![screen shot 2018-12-21 at 10 47 28 am](https://user-images.githubusercontent.com/378023/50320077-11edf800-050e-11e9-9a58-185e13e48b7e.png)

Bonus:

- File headers now use the font family from UI themes. Before it was hard-coded.
- Hunk headers now use the font family from the config. Before it was hard-coded.

### Alternate Designs

N/A

### Benefits

Users can change the font size of diffs in Atom's settings. 

### Possible Drawbacks

Some might have a different preference.

### Applicable Issues

Fixes https://github.com/atom/github/issues/1858

### Metrics

N/A

### Tests

1. Open a diff
2. Press `cmd -` or `cmd +`
3. Observe how the code changes the font size, but the file and hunk header stay the same.

![resize](https://user-images.githubusercontent.com/378023/50331592-8b9fd900-0542-11e9-94f1-c907f7b3f763.gif)

### Documentation

N/A

### Release Notes

N/A

### User Experience Research (Optional)

N/A

