### PR TITLE
Collapse and expand files within a multi file patch view.

### DIFF
--- a/lib/views/file-patch-header-view.js
+++ b/lib/views/file-patch-header-view.js
@@ -4,6 +4,7 @@ import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
+import Octicon from '../atom/octicon';
 import RefHolder from '../models/ref-holder';
 import IssueishDetailItem from '../items/issueish-detail-item';
 import ChangedFileItem from '../items/changed-file-item';
@@ -25,7 +26,10 @@ export default class FilePatchHeaderView extends React.Component {
     undoLastDiscard: PropTypes.func.isRequired,
     diveIntoMirrorPatch: PropTypes.func.isRequired,
     openFile: PropTypes.func.isRequired,
+    // should probably change 'toggleFile' to 'toggleFileStagingStatus'
+    // because the addition of another toggling function makes the old name confusing.
     toggleFile: PropTypes.func.isRequired,
+    toggleFileCollapse: PropTypes.func,
 
     itemType: ItemTypePropType.isRequired,
   };
@@ -42,9 +46,20 @@ export default class FilePatchHeaderView extends React.Component {
       <header className="github-FilePatchView-header">
         <span className="github-FilePatchView-title">
           {this.renderTitle()}
+          {this.renderCollapseButton()}
         </span>
         {this.renderButtonGroup()}
       </header>
+    );
+  }
+
+  renderCollapseButton() {
+    return (
+      <button
+        className="github-FilePatchView-collapseButton"
+        onClick={this.props.toggleFileCollapse}>
+        <Octicon className="github-FilePatchView-collapseButtonIcon" icon="chevron-down" />
+      </button>
     );
   }
 

--- a/lib/views/file-patch-header-view.js
+++ b/lib/views/file-patch-header-view.js
@@ -46,14 +46,14 @@ export default class FilePatchHeaderView extends React.Component {
       <header className="github-FilePatchView-header">
         <span className="github-FilePatchView-title">
           {this.renderTitle()}
-          {this.renderCollapseButton()}
+          {this.renderToggleCollapseButton()}
         </span>
         {this.renderButtonGroup()}
       </header>
     );
   }
 
-  renderCollapseButton() {
+  renderToggleCollapseButton() {
     const iconType = this.props.isCollapsed ? 'chevron-up' : 'chevron-down';
     return (
       <button

--- a/lib/views/file-patch-header-view.js
+++ b/lib/views/file-patch-header-view.js
@@ -54,11 +54,12 @@ export default class FilePatchHeaderView extends React.Component {
   }
 
   renderCollapseButton() {
+    const iconType = this.props.isCollapsed ? 'chevron-up' : 'chevron-down';
     return (
       <button
         className="github-FilePatchView-collapseButton"
         onClick={this.props.toggleFileCollapse}>
-        <Octicon className="github-FilePatchView-collapseButtonIcon" icon="chevron-down" />
+        <Octicon className="github-FilePatchView-collapseButtonIcon" icon={iconType} />
       </button>
     );
   }

--- a/lib/views/file-patch-header-view.js
+++ b/lib/views/file-patch-header-view.js
@@ -45,8 +45,8 @@ export default class FilePatchHeaderView extends React.Component {
     return (
       <header className="github-FilePatchView-header">
         <span className="github-FilePatchView-title">
-          {this.renderTitle()}
           {this.renderToggleCollapseButton()}
+          {this.renderTitle()}
         </span>
         {this.renderButtonGroup()}
       </header>
@@ -54,7 +54,7 @@ export default class FilePatchHeaderView extends React.Component {
   }
 
   renderToggleCollapseButton() {
-    const iconType = this.props.isCollapsed ? 'chevron-up' : 'chevron-down';
+    const iconType = this.props.isCollapsed ? 'chevron-right' : 'chevron-down';
     return (
       <button
         className="github-FilePatchView-collapseButton"

--- a/lib/views/multi-file-patch-view.js
+++ b/lib/views/multi-file-patch-view.js
@@ -80,6 +80,10 @@ export default class MultiFilePatchView extends React.Component {
     this.refEditor = new RefHolder();
     this.refEditorElement = new RefHolder();
 
+    const initialPatchExpansionState = {};
+    this.props.multiFilePatch.getFilePatches().forEach(fp => initialPatchExpansionState[fp.getPath()] = 'expanded');
+    this.state = {...initialPatchExpansionState};
+
     this.subs = new CompositeDisposable();
 
     this.subs.add(
@@ -164,6 +168,11 @@ export default class MultiFilePatchView extends React.Component {
   componentWillUnmount() {
     window.removeEventListener('mouseup', this.didMouseUp);
     this.subs.dispose();
+  }
+
+  toggleFileCollapse = filePatch => {
+    console.log(this.props.multiFilePatch);
+    // this.setState({filePatch.getPath(): })
   }
 
   render() {
@@ -329,6 +338,7 @@ export default class MultiFilePatchView extends React.Component {
               diveIntoMirrorPatch={() => this.props.diveIntoMirrorPatch(filePatch)}
               openFile={() => this.didOpenFile({selectedFilePatch: filePatch})}
               toggleFile={() => this.props.toggleFile(filePatch)}
+              toggleFileCollapse={() => this.toggleFileCollapse(filePatch)}
             />
             {this.renderSymlinkChangeMeta(filePatch)}
             {this.renderExecutableModeChangeMeta(filePatch)}

--- a/lib/views/multi-file-patch-view.js
+++ b/lib/views/multi-file-patch-view.js
@@ -172,8 +172,13 @@ export default class MultiFilePatchView extends React.Component {
 
   toggleFileCollapse = filePatch => {
     const path = filePatch.getPath();
-    const currentState = this.state[path];
-    this.setState({path: currentState === 'collapsed' ? 'expanded': 'collapsed'});
+    if (this.state[path] === 'collapsed') {
+      this.expand(filePatch);
+      this.setState({[path]: 'expanded'})
+    } else {
+      this.collapse(filePatch);
+      this.setState({[path]: 'collapsed'})
+    }
   }
 
   render() {
@@ -239,10 +244,14 @@ export default class MultiFilePatchView extends React.Component {
     );
   }
 
-  fold() {
-    // 1. get the range of rows that need to be collapsed
-    // 2. foldBufferRange
-    // question: does FoldBufferRange also unfold it? Is it symmetrical?
+  expand(filePatch) {
+    const startRow = filePatch.getMarker().getRange().start.row;
+    this.refEditor.map(editor => editor.unfoldBufferRow(startRow));
+  }
+
+  collapse(filePatch) {
+    const range = filePatch.getMarker().getRange();
+    this.refEditor.map(editor => editor.foldBufferRange(range));
   }
 
   renderEmptyPatch() {

--- a/lib/views/multi-file-patch-view.js
+++ b/lib/views/multi-file-patch-view.js
@@ -355,6 +355,7 @@ export default class MultiFilePatchView extends React.Component {
               openFile={() => this.didOpenFile({selectedFilePatch: filePatch})}
               toggleFile={() => this.props.toggleFile(filePatch)}
               toggleFileCollapse={() => this.toggleFileCollapse(filePatch)}
+              isCollapsed={this.state[filePatch.getPath()] === 'collapsed'}
             />
             {this.renderSymlinkChangeMeta(filePatch)}
             {this.renderExecutableModeChangeMeta(filePatch)}

--- a/lib/views/multi-file-patch-view.js
+++ b/lib/views/multi-file-patch-view.js
@@ -171,8 +171,9 @@ export default class MultiFilePatchView extends React.Component {
   }
 
   toggleFileCollapse = filePatch => {
-    console.log(this.props.multiFilePatch);
-    // this.setState({filePatch.getPath(): })
+    const path = filePatch.getPath();
+    const currentState = this.state[path];
+    this.setState({path: currentState === 'collapsed' ? 'expanded': 'collapsed'});
   }
 
   render() {
@@ -236,6 +237,12 @@ export default class MultiFilePatchView extends React.Component {
         {stageSymlinkCommand}
       </Commands>
     );
+  }
+
+  fold() {
+    // 1. get the range of rows that need to be collapsed
+    // 2. foldBufferRange
+    // question: does FoldBufferRange also unfold it? Is it symmetrical?
   }
 
   renderEmptyPatch() {

--- a/styles/file-patch-view.less
+++ b/styles/file-patch-view.less
@@ -64,6 +64,17 @@
     margin-right: @component-padding;
   }
 
+  &-collapseButton {
+    background: transparent;
+    border: none;
+    // dont' judge me.  flexbox seemed like overkill, ok?
+    float: right;
+  }
+
+  &-collapseButtonIcon {
+    position: absolute;
+  }
+
   &-container {
     flex: 1;
     display: flex;

--- a/styles/file-patch-view.less
+++ b/styles/file-patch-view.less
@@ -36,9 +36,8 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding-top: @component-padding*2;
     padding: @component-padding/2;
-    padding-left: @component-padding;
+    padding-left: 0;
     border: 1px solid @base-border-color;
     border-radius: @component-border-radius;
     font-family: @font-family;
@@ -65,14 +64,16 @@
   }
 
   &-collapseButton {
+    padding: 0 @component-padding/2;
     background: transparent;
     border: none;
-    // dont' judge me.  flexbox seemed like overkill, ok?
-    float: right;
   }
 
   &-collapseButtonIcon {
-    position: absolute;
+    &:before {
+      text-align: center;
+      margin-right: 0;
+    }
   }
 
   &-container {


### PR DESCRIPTION
### Description of the Change

This change adds the ability to collapse and expand individual files in the `MultiFilePatchView`.

### Alternate Designs

The collapse buttons could be on the right:

![screen shot 2019-01-02 at 12 38 56 pm](https://user-images.githubusercontent.com/378023/50581808-7e6ade80-0ea0-11e9-9f78-10070e30c731.png)

### Benefits

- Improves the experience of viewing multi file patches by allowing users to reduce visual clutter.

### Possible Drawbacks

TBD

### Applicable Issues

https://github.com/atom/github/issues/1860

### Metrics

- We could measure the count of file patches that are expanded / collapsed.

### Tests

TBD

### Documentation

TBD

### Release Notes

The GitHub package now supports collapsing and expanding files in the pull request, commit preview, and commit pane views.

