### PR TITLE
UserStore handles GitHub remotes that no longer exist

### DIFF
--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -175,7 +175,7 @@ export default class UserStore {
         console.error(`Error fetching mentionable users:\n${response.errors.map(e => e.message).join('\n')}`);
       }
 
-      if (!response.data) {
+      if (!response.data || !response.data.repository) {
         break;
       }
 


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Break from the user accumulation loop in `UserStore` when the GraphQL response includes a null Repository.

### Alternate Designs

When you have no GitHub remotes at all, we currently fall back to your local git history to populate the UserStore. Given that we now have the possibility that your GitHub remote could no longer exist, it may make sense to fall back to that in the instance that no _valid_ GitHub remotes are found any more. I opted not to go that route in this take to keep the change small and minimize risk.

### Benefits

A stacktrace on package activation no longer occurs.

### Possible Drawbacks

If you delete all GitHub repositories referenced by your git remotes - or add a bunch of fake ones - your UserStore will stay empty.

### Applicable Issues

Fixes #1867.

### Metrics

_N/A_

### Tests

I've added a unit test to capture the null-Repository case to verify the fix.

### Documentation

_N/A_

### Release Notes

* The GitHub package no longer logs an exception when a remote has been deleted on github.com.

### User Experience Research (Optional)

_N/A_

