### PR TITLE
Cache token scope check failures

### DIFF
--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -10,6 +10,9 @@ export default class GithubLoginModel {
   // give everyone a really frustrating experience ;-)
   static REQUIRED_SCOPES = ['repo', 'read:org', 'user:email']
 
+  // Returned from getScopes if the HEAD request fails with a 401
+  static UNAUTHORIZED = Symbol('unauthorized')
+
   static get() {
     if (!instance) {
       instance = new GithubLoginModel();
@@ -21,7 +24,7 @@ export default class GithubLoginModel {
     this._Strategy = Strategy;
     this._strategy = null;
     this.emitter = new Emitter();
-    this.checked = new Set();
+    this.checked = new Map();
   }
 
   async getStrategy() {
@@ -53,21 +56,33 @@ export default class GithubLoginModel {
       hash.update(password);
       const fingerprint = hash.digest('base64');
 
-      if (!this.checked.has(fingerprint)) {
+      const outcome = this.checked.get(fingerprint);
+      if (outcome === UNAUTHENTICATED || outcome === INSUFFICIENT) {
+        // Cached failure
+        return outcome;
+      } else if (!outcome) {
+        // No cached outcome. Query for scopes.
         try {
-          const scopes = new Set(await this.getScopes(account, password));
+          const scopes = await this.getScopes(account, password);
+          if (scopes === this.constructor.UNAUTHORIZED) {
+            // password is incorrect
+            this.checked.set(fingerprint, UNAUTHENTICATED);
+            return UNAUTHENTICATED;
+          }
+          const scopeSet = new Set(scopes);
 
           for (const scope of this.constructor.REQUIRED_SCOPES) {
-            if (!scopes.has(scope)) {
+            if (!scopeSet.has(scope)) {
               // Token doesn't have enough OAuth scopes, need to reauthenticate
+              this.checked.set(fingerprint, INSUFFICIENT);
               return INSUFFICIENT;
             }
           }
 
-          // We're good
-          this.checked.add(fingerprint);
+          // Successfully authenticated and had all required scopes.
+          this.checked.set(fingerprint, true);
         } catch (e) {
-          // Bad credential most likely
+          // Most likely a network error. Do not cache the failure.
           // eslint-disable-next-line no-console
           console.error(`Unable to validate token scopes against ${account}`, e);
           return UNAUTHENTICATED;
@@ -103,6 +118,11 @@ export default class GithubLoginModel {
       method: 'HEAD',
       headers: {Authorization: `bearer ${token}`},
     });
+
+    if (response.status === 401) {
+      // Unauthorized
+      return this.constructor.UNAUTHORIZED;
+    }
 
     if (response.status !== 200) {
       throw new Error(`Unable to check token for OAuth scopes against ${host}: ${await response.text()}`);

--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -105,6 +105,7 @@ export default class GithubLoginModel {
     this.didUpdate();
   }
 
+  /* istanbul ignore next */
   async getScopes(host, token) {
     if (atom.inSpecMode()) {
       if (token === 'good-token') {

--- a/lib/models/github-login-model.js
+++ b/lib/models/github-login-model.js
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import {Emitter} from 'event-kit';
 
-import {UNAUTHENTICATED, INSUFFICIENT, createStrategy} from '../shared/keytar-strategy';
+import {UNAUTHENTICATED, INSUFFICIENT, UNAUTHORIZED, createStrategy} from '../shared/keytar-strategy';
 
 let instance = null;
 
@@ -9,9 +9,6 @@ export default class GithubLoginModel {
   // Be sure that we're requesting at least this many scopes on the token we grant through github.atom.io or we'll
   // give everyone a really frustrating experience ;-)
   static REQUIRED_SCOPES = ['repo', 'read:org', 'user:email']
-
-  // Returned from getScopes if the HEAD request fails with a 401
-  static UNAUTHORIZED = Symbol('unauthorized')
 
   static get() {
     if (!instance) {
@@ -64,8 +61,8 @@ export default class GithubLoginModel {
         // No cached outcome. Query for scopes.
         try {
           const scopes = await this.getScopes(account, password);
-          if (scopes === this.constructor.UNAUTHORIZED) {
-            // password is incorrect
+          if (scopes === UNAUTHORIZED) {
+            // Password is incorrect. Treat it as though you aren't authenticated at all.
             this.checked.set(fingerprint, UNAUTHENTICATED);
             return UNAUTHENTICATED;
           }
@@ -121,8 +118,7 @@ export default class GithubLoginModel {
     });
 
     if (response.status === 401) {
-      // Unauthorized
-      return this.constructor.UNAUTHORIZED;
+      return UNAUTHORIZED;
     }
 
     if (response.status !== 200) {

--- a/lib/shared/keytar-strategy.js
+++ b/lib/shared/keytar-strategy.js
@@ -16,9 +16,14 @@ if (typeof atom === 'undefined') {
   };
 }
 
+// No token available in your OS keychain.
 const UNAUTHENTICATED = Symbol('UNAUTHENTICATED');
 
+// The token in your keychain isn't granted all of the required OAuth scopes.
 const INSUFFICIENT = Symbol('INSUFFICIENT');
+
+// The token in your keychain is not accepted by GitHub.
+const UNAUTHORIZED = Symbol('UNAUTHORIZED');
 
 class KeytarStrategy {
   static get keytar() {
@@ -248,6 +253,7 @@ async function createStrategy() {
 module.exports = {
   UNAUTHENTICATED,
   INSUFFICIENT,
+  UNAUTHORIZED,
   KeytarStrategy,
   SecurityBinaryStrategy,
   InMemoryStrategy,

--- a/test/models/github-login-model.test.js
+++ b/test/models/github-login-model.test.js
@@ -5,6 +5,7 @@ import {
   InMemoryStrategy,
   UNAUTHENTICATED,
   INSUFFICIENT,
+  UNAUTHORIZED,
 } from '../../lib/shared/keytar-strategy';
 
 describe('GithubLoginModel', function() {
@@ -69,7 +70,7 @@ describe('GithubLoginModel', function() {
     });
 
     it('caches tokens that failed to authenticate correctly', async function() {
-      sinon.stub(loginModel, 'getScopes').resolves(GithubLoginModel.UNAUTHORIZED);
+      sinon.stub(loginModel, 'getScopes').resolves(UNAUTHORIZED);
 
       assert.strictEqual(await loginModel.getToken('https://api.github.com'), UNAUTHENTICATED);
       assert.strictEqual(loginModel.getScopes.callCount, 1);

--- a/test/models/github-login-model.test.js
+++ b/test/models/github-login-model.test.js
@@ -47,19 +47,19 @@ describe('GithubLoginModel', function() {
     });
 
     it('returns INSUFFICIENT if scopes are present', async function() {
-      sinon.stub(loginModel, 'getScopes').returns(Promise.resolve(['repo', 'read:org']));
+      sinon.stub(loginModel, 'getScopes').resolves(['repo', 'read:org']);
 
       assert.strictEqual(await loginModel.getToken('https://api.github.com'), INSUFFICIENT);
     });
 
     it('returns the token if at least the required scopes are present', async function() {
-      sinon.stub(loginModel, 'getScopes').returns(Promise.resolve(['repo', 'read:org', 'user:email', 'extra']));
+      sinon.stub(loginModel, 'getScopes').resolves(['repo', 'read:org', 'user:email', 'extra']);
 
       assert.strictEqual(await loginModel.getToken('https://api.github.com'), '1234');
     });
 
     it('caches checked tokens', async function() {
-      sinon.stub(loginModel, 'getScopes').returns(Promise.resolve(['repo', 'read:org', 'user:email']));
+      sinon.stub(loginModel, 'getScopes').resolves(['repo', 'read:org', 'user:email']);
 
       assert.strictEqual(await loginModel.getToken('https://api.github.com'), '1234');
       assert.strictEqual(loginModel.getScopes.callCount, 1);


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

I've changed `GithubLoginModel` to cache not just the set of successfully authenticated tokens, but also tokens that have resulted in authentication failures or those that don't have sufficient OAuth scopes to be used.

I did _not_ cache tokens that fail the scope-check because the `fetch` call raised an error, to prevent us from remembering the failure from a transient network error (or a GitHub outage).

### Alternate Designs

We may also be able to address this with careful handling of how `GithubLoginModel::getToken()` is called, ensuring that it's only ever retried when the token has actually changed. Fixing it within `getToken()` feels more robust.

### Benefits

We will no longer lock users out with rate-limit errors when the token stored in your OS keychain is revoked or older than the last time that we've changed the required OAuth scopes.

### Possible Drawbacks

The Map of checked tokens could, theoretically, grow without bound. For it to be an issue you'd need to revoke and regenerate tokens millions of times. I'm guessing that the GitHub API would become unhappy with you long before your RAM started to noticeably bloat.

### Applicable Issues

Fixes #1868.

### Metrics

_N/A_

### Tests

I've added unit tests to `GithubLoginModel` to test the caching of various kinds of failures.

To test it manually, I'll:

1. Add a `console.log` to trace each time we're doing the scope check.
2. Generate a personal access token without the OAuth scopes that we need.
3. Log out of the GitHub package.
4. Log back in with the PAT.
5. Verify that the "insufficient scopes" message shows up in the GitHub tab, but that the scope check only happens _once_.
6. Revoke the PAT.
7. Reload Atom.
8. Verify that the "log in" message shows up in the GitHub tab, but that the scope check only happens _once_.

### Documentation

_N/A_

### Release Notes

* Fixed an issue where the GitHub package would check your OAuth token scopes repeatedly if the token was invalid or had insufficient scopes.

### User Experience Research (Optional)

_N/A_