### PR TITLE
Give the "show more" button a left margin

### DIFF
--- a/styles/pr-commit-view.less
+++ b/styles/pr-commit-view.less
@@ -3,14 +3,6 @@
 @default-padding: @component-padding;
 @avatar-dimensions: 16px;
 
-.github-PrCommitsView {
-
-  &-load-more-button {
-    display: block;
-    margin: 20px auto 0;
-  }
-}
-
 .github-PrCommitView {
 
   &-container {
@@ -72,7 +64,7 @@
   }
 
   &-moreButton {
-    border: none;
+    margin: 0 auto 0 @default-padding;
     padding: 0em .2em;
     color: @text-color-subtle;
     font-style: italic;


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Give the "show more" button a left margin so that it doesn't look smooshed against the commit message:

![before](https://user-images.githubusercontent.com/3058150/50634065-ba0fb200-0f4d-11e9-83b4-72864238cc76.png)

### Alternate Designs

_N/A_

### Benefits

<img width="351" alt="after" src="https://user-images.githubusercontent.com/17565/50643662-b889be00-0f3c-11e9-92ec-2abd2bcf1ab2.png">

### Possible Drawbacks

_N/A_

### Applicable Issues

Fixes #1874.

### Metrics

_N/A_

### Tests

_N/A_

### Documentation

_N/A_

### Release Notes

_N/A_

### User Experience Research (Optional)

_N/A_