### PR TITLE
Synchronize electron-link and electron-mksnapshot versions to Atom's

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2650,9 +2650,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -2691,9 +2691,9 @@
       }
     },
     "electron-mksnapshot": {
-      "version": "3.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/electron-mksnapshot/-/electron-mksnapshot-3.0.0-beta.1.tgz",
-      "integrity": "sha512-0Q4yV7jCnXiCFOAih8ZvmFBS492kPzQYtsIj30pVyWsytAEyxmyPQD5NbSAaAAJt5di2XocxfvbAEgcAhUXEqA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/electron-mksnapshot/-/electron-mksnapshot-2.0.0.tgz",
+      "integrity": "sha512-OoZwZJNKgHP+DwhCGVTJEuDSeb478hOzAbHeg7dKGCHDbKKmUWmjGc+pEjxGutpqQ3Mn8hCdLzdx2c/lAJcTLA==",
       "dev": true,
       "requires": {
         "electron-download": "^4.1.0",
@@ -6340,7 +6340,7 @@
     },
     "pretty-bytes": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
       "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
       "dev": true,
       "requires": {
@@ -7176,7 +7176,7 @@
       "dependencies": {
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -7898,7 +7898,7 @@
     },
     "through2": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+      "resolved": "http://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
       "dev": true,
       "requires": {
@@ -7926,7 +7926,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1643,9 +1643,9 @@
       }
     },
     "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
       "dev": true
     },
     "bl": {
@@ -2667,19 +2667,27 @@
       }
     },
     "electron-link": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/electron-link/-/electron-link-0.2.2.tgz",
-      "integrity": "sha1-uWvx/MrowwyAuiaTBq+UVOYtP2U=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/electron-link/-/electron-link-0.3.2.tgz",
+      "integrity": "sha512-V7QmtujzWgvrW5BI2CKmIRF+q+pkrFO5Lecd8TpibbBz+FfW5WQ4kCN0sZjNaUOMtGGroCib721OqIDEynjwgA==",
       "dev": true,
       "requires": {
         "ast-util": "^0.6.0",
         "encoding-down": "~5.0.0",
-        "indent-string": "^2.1.0",
+        "indent-string": "^3.2.0",
         "leveldown": "~4.0.0",
         "levelup": "~3.0.0",
         "recast": "^0.12.6",
         "resolve": "^1.5.0",
         "source-map": "^0.5.6"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        }
       }
     },
     "electron-mksnapshot": {
@@ -6968,12 +6976,12 @@
       }
     },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+      "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "cross-unzip": "0.2.1",
     "dedent-js": "1.0.1",
     "electron-devtools-installer": "2.2.4",
-    "electron-link": "0.2.2",
+    "electron-link": "0.3.2",
     "electron-mksnapshot": "3.0.0-beta.1",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.7.1",

--- a/package.json
+++ b/package.json
@@ -204,5 +204,11 @@
     "FilePatchControllerStub": "createFilePatchControllerStub",
     "CommitPreviewStub": "createCommitPreviewStub",
     "CommitDetailStub": "createCommitDetailStub"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "electron-link",
+      "electron-mksnapshot"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "dedent-js": "1.0.1",
     "electron-devtools-installer": "2.2.4",
     "electron-link": "0.3.2",
-    "electron-mksnapshot": "3.0.0-beta.1",
+    "electron-mksnapshot": "~2.0",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.7.1",
     "eslint": "5.0.1",


### PR DESCRIPTION
To ensure that the snapshot test is as accurate as possible, lock electron-link and electron-mksnapshot to the version ranges specified in [atom/atom's package.json](https://github.com/atom/atom/blob/master/script/package.json#L14-L15).

Closes #1861; closes #1834.