### PR TITLE
mentionable users fall back

### DIFF
--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -102,8 +102,12 @@ export default class UserStore {
 
     if (githubRemotes.length > 0) {
       await this.loadUsersFromGraphQL(githubRemotes);
+    } else {
+      this.addUsers(data.authors, source.GITLOG);
     }
 
+    // if for whatever reason, no committers can be added, fall back to
+    // using git log committers as the last resort
     if (this.allUsers.size === 0) {
       this.addUsers(data.authors, source.GITLOG);
     }

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -100,10 +100,12 @@ export default class UserStore {
     this.setCommitter(data.committer);
     const githubRemotes = Array.from(data.remotes).filter(remote => remote.isGithubRepo());
 
-    if (githubRemotes.length === 0) {
-      this.addUsers(data.authors, source.GITLOG);
-    } else {
+    if (githubRemotes.length > 0) {
       await this.loadUsersFromGraphQL(githubRemotes);
+    }
+
+    if (this.getUsers().length === 0) {
+      this.addUsers(data.authors, source.GITLOG);
     }
   }
 

--- a/lib/models/user-store.js
+++ b/lib/models/user-store.js
@@ -104,7 +104,7 @@ export default class UserStore {
       await this.loadUsersFromGraphQL(githubRemotes);
     }
 
-    if (this.getUsers().length === 0) {
+    if (this.allUsers.size === 0) {
       this.addUsers(data.authors, source.GITLOG);
     }
   }

--- a/test/models/user-store.test.js
+++ b/test/models/user-store.test.js
@@ -101,7 +101,7 @@ describe('UserStore', function() {
     const workdirPath = await cloneRepository('multiple-commits');
     const repository = await buildRepository(workdirPath);
 
-    store = new UserStore({repository, login, config});
+    store = new UserStore({repository, config});
     sinon.stub(store, 'loadMentionableUsers').returns(undefined);
 
     await store.loadUsers();

--- a/test/models/user-store.test.js
+++ b/test/models/user-store.test.js
@@ -238,12 +238,12 @@ describe('UserStore', function() {
     const workdirPath = await cloneRepository('multiple-commits');
     const repository = await buildRepository(workdirPath);
     store = new UserStore({repository, config});
-    await assert.async.lengthOf(store.getUsers(), 1);
-
     sinon.spy(store, 'addUsers');
+    await assert.async.lengthOf(store.getUsers(), 1);
+    await assert.async.equal(store.addUsers.callCount, 1);
+
     // make a commit with FAKE_USER as committer
     await repository.commit('made a new commit', {allowEmpty: true});
-    await assert.async.equal(store.addUsers.callCount, 1);
 
     // verify that FAKE_USER is in commit history
     const lastCommit = await repository.getLastCommit();

--- a/test/models/user-store.test.js
+++ b/test/models/user-store.test.js
@@ -97,6 +97,21 @@ describe('UserStore', function() {
     assert.deepEqual(store.committer, new Author(FAKE_USER.email, FAKE_USER.name));
   });
 
+  it('falls back to local git users and committers if laodMentionableUsers cannot load any user for whatever reason', async function() {
+    const workdirPath = await cloneRepository('multiple-commits');
+    const repository = await buildRepository(workdirPath);
+
+    store = new UserStore({repository, login, config});
+    sinon.stub(store, 'loadMentionableUsers').returns(undefined);
+
+    await store.loadUsers();
+    await nextUpdatePromise();
+
+    assert.deepEqual(store.getUsers(), [
+      new Author('kuychaco@github.com', 'Katrina Uychaco'),
+    ]);
+  });
+
   it('loads store with mentionable users from the GitHub API in a repo with a GitHub remote', async function() {
     await login.setToken('https://api.github.com', '1234');
 

--- a/test/models/user-store.test.js
+++ b/test/models/user-store.test.js
@@ -97,7 +97,7 @@ describe('UserStore', function() {
     assert.deepEqual(store.committer, new Author(FAKE_USER.email, FAKE_USER.name));
   });
 
-  it('falls back to local git users and committers if laodMentionableUsers cannot load any user for whatever reason', async function() {
+  it('falls back to local git users and committers if loadMentionableUsers cannot load any user for whatever reason', async function() {
     const workdirPath = await cloneRepository('multiple-commits');
     const repository = await buildRepository(workdirPath);
 


### PR DESCRIPTION
resolves #1872 

If `GithubLoginModel` cannot retrieve mentionable users for whatever reason, we fall back to fill `UserStore` from recent git commit authors, so the co-author dropdown isn't left empty.