### PR TITLE
Exclude Relay-generated GraphQL files from code coverage

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -8,6 +8,6 @@
     "lib/views/git-cache-view.js",
     "lib/views/git-timings-view.js",
     "lib/relay-network-layer-manager.js",
-    "*.graphql.js"
+    "**/__generated__/*.graphql.js"
   ]
 }

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -7,6 +7,7 @@
   "exclude": [
     "lib/views/git-cache-view.js",
     "lib/views/git-timings-view.js",
-    "lib/relay-network-layer-manager.js"
+    "lib/relay-network-layer-manager.js",
+    "*.graphql.js"
   ]
 }


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Exclude files generated by `relay-compiler` from collected code coverage.

### Alternate Designs

I don't think there really is one.

### Benefits

It'll make our code coverage go up :wink:

### Possible Drawbacks

We might accidentally add a file with a name matching `*.graphql.js` in a directory called `__generated__` and exclude it by mistake... ?

### Applicable Issues

Fixes #1886.

### Metrics

_N/A_

### Tests

_N/A_

### Documentation

_N/A_

### Release Notes

_N/A_

### User Experience Research (Optional)

_N/A_