### PR TITLE
Revert "Exclude Relay-generated GraphQL files from code coverage"

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -7,7 +7,6 @@
   "exclude": [
     "lib/views/git-cache-view.js",
     "lib/views/git-timings-view.js",
-    "lib/relay-network-layer-manager.js",
-    "**/__generated__/*.graphql.js"
+    "lib/relay-network-layer-manager.js"
   ]
 }


### PR DESCRIPTION
It looks like this broke CodeCov somehow. Let's revert until we can figure out why.

Reverts atom/github#1889.