### PR TITLE
Add screenshot/gif section to PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ We must be able to understand the design of your change from this description. I
 
 ### Screenshot/Gif
 
-<!-- If the changes are visual add a screenshot or record a Gif. This doesn't have to be updated during implementation, but after a PR is merged, a final screenshot/gif should be added. It might get used for blog posts, documentation etc. Write "N/A" if not applicable. -->
+<!-- If the changes are visual, add a screenshot or record a Gif. This doesn't have to be updated during implementation, but after a PR is merged, a final screenshot/gif should be added. It might get used for blog posts, documentation etc. Write "N/A" if not applicable. -->
 
 ### Alternate Designs
 


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

This adds a screenshot or gif section to the PR template.

### Alternate Designs

N/A

### Benefits

1. Makes it easy to see what the PR is about (if the changes are visual)
2. The screenshot/gif can get used later for blog posts, documentation, twitter etc.
3. Makes sure that screenshots are more accurate. If we do them later, it might already show new stuff that isn't part of this PR.

### Possible Drawbacks

More work. :roll_eyes: But I'll keep an eye open and add them. Also, happy to get pinged about it.

### Applicable Issues

None. Came up in Slack talking to @kuychaco 

### Metrics

N/A

### Tests

N/A

### Documentation

N/A

### Release Notes

N/A

### User Experience Research (Optional)

N/A



-----
[View rendered PULL_REQUEST_TEMPLATE.md](https://github.com/atom/github/blob/sm/pr-template/PULL_REQUEST_TEMPLATE.md)