### PR TITLE
[wip] replace Commit Preview with Commit Detail upon committing

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -96,6 +96,7 @@ export default class RootController extends React.Component {
 
     this.subscription = new CompositeDisposable(
       this.props.repository.onPullError(this.gitTabTracker.ensureVisible),
+      this.props.repository.onDidCommit(this.swapCommitPreview),
     );
 
     this.props.commandRegistry.onDidDispatch(event => {
@@ -500,7 +501,9 @@ export default class RootController extends React.Component {
   componentDidUpdate() {
     this.subscription.dispose();
     this.subscription = new CompositeDisposable(
+      // TODO: find out why it has to be a nested function
       this.props.repository.onPullError(() => this.gitTabTracker.ensureVisible()),
+      this.props.repository.onDidCommit(this.swapCommitPreview),
     );
   }
 
@@ -531,6 +534,33 @@ export default class RootController extends React.Component {
   toggleCommitPreviewItem = () => {
     const workdir = this.props.repository.getWorkingDirectoryPath();
     return this.props.workspace.toggle(CommitPreviewItem.buildURI(workdir));
+  }
+
+  swapCommitPreview = async lastCommitSha => {
+    const commitPreviewUri = CommitPreviewItem.buildURI(
+      this.props.repository.getWorkingDirectoryPath(),
+    );
+    const commitDetailUri = CommitDetailItem.buildURI(
+      this.props.repository.getWorkingDirectoryPath(),
+      lastCommitSha,
+    );
+    const pane = this.props.workspace.paneForURI(commitPreviewUri);
+    if (pane) {
+      const commitPreviewIndex = pane.getItems().findIndex(item => item.getURI() === commitPreviewUri);
+      if (commitPreviewIndex > -1) { // found
+        const isPending = pane.getPendingItem() ? pane.getPendingItem().getURI() === commitPreviewUri : false;
+        const isActive = pane.getActiveItemIndex() === commitPreviewIndex;
+        const commitDetailItem = await this.props.workspace.createItemForURI(commitDetailUri);
+        await pane.destroyItem(pane.itemAtIndex(commitPreviewIndex));
+        pane.addItem(commitDetailItem, {
+          index: commitPreviewIndex,
+          pending: isPending,
+        });
+        if (isActive) {
+          pane.activateItemAtIndex(commitPreviewIndex);
+        }
+      }
+    }
   }
 
   showOpenIssueishDialog() {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -547,10 +547,11 @@ export default class RootController extends React.Component {
     const pane = this.props.workspace.paneForURI(commitPreviewUri);
     if (pane) {
       const commitPreviewIndex = pane.getItems().findIndex(item => item.getURI() === commitPreviewUri);
-      if (commitPreviewIndex > -1) { // found
+      if (commitPreviewIndex > -1) {
         const isPending = pane.getPendingItem() ? pane.getPendingItem().getURI() === commitPreviewUri : false;
         const isActive = pane.getActiveItemIndex() === commitPreviewIndex;
         const commitDetailItem = await this.props.workspace.createItemForURI(commitDetailUri);
+
         await pane.destroyItem(pane.itemAtIndex(commitPreviewIndex));
         pane.addItem(commitDetailItem, {
           index: commitPreviewIndex,

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -318,8 +318,8 @@ export default class Present extends State {
         };
 
         await this.git().commit(message, opts);
-        const lastCommit = await this.getLastCommit();
-        this.repository.didCommit(lastCommit.getSha());
+        const lastCommitSha = (await this.git().exec(['rev-parse', 'HEAD'])).trim();
+        this.repository.didCommit(lastCommitSha);
 
         // Collect commit metadata metrics
         // note: in GitShellOutStrategy we have counters for all git commands, including `commit`, but here we have

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -318,6 +318,8 @@ export default class Present extends State {
         };
 
         await this.git().commit(message, opts);
+        const lastCommit = await this.getLastCommit();
+        this.repository.didCommit(lastCommit.getSha());
 
         // Collect commit metadata metrics
         // note: in GitShellOutStrategy we have counters for all git commands, including `commit`, but here we have

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -115,6 +115,14 @@ export default class Repository {
     return this.emitter.emit('pull-error');
   }
 
+  onCommit(callback) {
+    return this.emitter.on('did-commit', callback);
+  }
+
+  didCommit(sha) {
+    return this.emitter.emit('did-commit', sha);
+  }
+
   // State-independent actions /////////////////////////////////////////////////////////////////////////////////////////
   // Actions that use direct filesystem access or otherwise don't need `this.git` to be available.
 

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -115,7 +115,7 @@ export default class Repository {
     return this.emitter.emit('pull-error');
   }
 
-  onCommit(callback) {
+  onDidCommit(callback) {
     return this.emitter.on('did-commit', callback);
   }
 

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -766,6 +766,17 @@ describe('Repository', function() {
         await assert.isRejected(repo.commit('Commit yo!'));
         assert.isFalse(reporterProxy.addEvent.called);
       });
+
+      it('emits did-commit with the last commit sha', async function() {
+        const workingDirPath = await cloneRepository('three-files');
+        const repo = new Repository(workingDirPath);
+        await repo.getLoadPromise();
+
+        sinon.spy(repo, 'didCommit');
+        await repo.commit('Regular commit', {allowEmpty: true});
+        const lastCommit = await repo.getLastCommit();
+        assert.isTrue(repo.didCommit.calledWith(lastCommit.getSha()));
+      });
     });
   });
 

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -774,7 +774,7 @@ describe('Repository', function() {
 
         sinon.spy(repo, 'didCommit');
         await repo.commit('Regular commit', {allowEmpty: true});
-        const lastCommitSha = await repo.git.exec(['rev-parse', 'HEAD']);
+        const lastCommitSha = (await repo.git.exec(['rev-parse', 'HEAD'])).trim();
         assert.isTrue(repo.didCommit.calledWith(lastCommitSha));
       });
     });

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -774,8 +774,8 @@ describe('Repository', function() {
 
         sinon.spy(repo, 'didCommit');
         await repo.commit('Regular commit', {allowEmpty: true});
-        const lastCommit = await repo.getLastCommit();
-        assert.isTrue(repo.didCommit.calledWith(lastCommit.getSha()));
+        const lastCommitSha = await repo.git.exec(['rev-parse', 'HEAD']);
+        assert.isTrue(repo.didCommit.calledWith(lastCommitSha));
       });
     });
   });


### PR DESCRIPTION
Supposedly resolves #770. 

This PR implements the following behaviour:
>When a commit has been made, any open Staged Changes (or Commit Preview) pane item will be replaced by a Commit Detail Item of the very last commit; the item index and pending & active states are preserved. 

This PR is still missing some tests to be considered "finished". However, I am a bit reluctant to continue until I get more buy-in on this, since I am personally unsure of it -- it seems inconsistent with how Unstaged Change view behaves after the file has been staged, or how Staged Change view behaves after the file has been committed.

Cc-ing @simurai since you originally requested this feature. 😄 Feel free to poke around in the branch to see how you feel about it. 