### PR TITLE
Test coverage for GitShellOutStrategy

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -423,11 +423,7 @@ export default class GitShellOutStrategy {
       await fs.stat(this.workingDir); // fails if folder doesn't exist
       const output = await this.exec(['rev-parse', '--resolve-git-dir', path.join(this.workingDir, '.git')]);
       const dotGitDir = output.trim();
-      if (path.isAbsolute(dotGitDir)) {
-        return toNativePathSep(dotGitDir);
-      } else {
-        return toNativePathSep(path.resolve(path.join(this.workingDir, dotGitDir)));
-      }
+      return toNativePathSep(dotGitDir);
     } catch (e) {
       return null;
     }

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -454,6 +454,7 @@ export default class GitShellOutStrategy {
       // if no user is specified, fall back to using the home directory.
       return `${user ? path.join(path.dirname(homeDir), user) : homeDir}/`;
     });
+    templatePath = toNativePathSep(templatePath);
 
     if (!path.isAbsolute(templatePath)) {
       templatePath = path.join(this.workingDir, templatePath);

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -815,11 +815,8 @@ export default class GitShellOutStrategy {
     }
   }
 
-  mergeTrailers(commitMessage, trailers, unfold) {
+  mergeTrailers(commitMessage, trailers) {
     const args = ['interpret-trailers'];
-    if (unfold) {
-      args.push('--unfold');
-    }
     for (const trailer of trailers) {
       args.push('--trailer', `${trailer.token}=${trailer.value}`);
     }

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -61,9 +61,9 @@ const DISABLE_COLOR_FLAGS = [
  * Ex: on Mac ~kuychaco/ is expanded to the specified user’s home directory (/Users/kuychaco)
  * Regex translation:
  * ^~ line starts with tilde
- * ([^/]*)[\\/] captures non-forwardslash characters before first slash
+ * ([^\\/]*)[\\/] captures non-slash characters before first slash
  */
-const EXPAND_TILDE_REGEX = new RegExp('^~([^/]*)[\\/]');
+const EXPAND_TILDE_REGEX = new RegExp('^~([^\\/]*)[\\/]');
 
 export default class GitShellOutStrategy {
   static defaultExecArgs = {

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -61,9 +61,9 @@ const DISABLE_COLOR_FLAGS = [
  * Ex: on Mac ~kuychaco/ is expanded to the specified user’s home directory (/Users/kuychaco)
  * Regex translation:
  * ^~ line starts with tilde
- * ([^/]*)/ captures non-forwardslash characters before first slash
+ * ([^/]*)[\\/] captures non-forwardslash characters before first slash
  */
-const EXPAND_TILDE_REGEX = new RegExp('^~([^/]*)/');
+const EXPAND_TILDE_REGEX = new RegExp('^~([^/]*)[\\/]');
 
 export default class GitShellOutStrategy {
   static defaultExecArgs = {

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -119,6 +119,7 @@ export default class GitShellOutStrategy {
       // Attempt to collect the --exec-path from a native git installation.
       execPathPromise = new Promise((resolve, reject) => {
         childProcess.exec('git --exec-path', (error, stdout, stderr) => {
+          /* istanbul ignore if */
           if (error) {
             // Oh well
             resolve(null);
@@ -202,6 +203,7 @@ export default class GitShellOutStrategy {
         env.ATOM_GITHUB_GPG_PROMPT = 'true';
       }
 
+      /* istanbul ignore if */
       if (diagnosticsEnabled) {
         env.GIT_TRACE = 'true';
         env.GIT_TRACE_CURL = 'true';
@@ -214,9 +216,11 @@ export default class GitShellOutStrategy {
         opts.stdinEncoding = 'utf8';
       }
 
+      /* istanbul ignore if */
       if (process.env.PRINT_GIT_TIMES) {
         console.time(`git:${formattedArgs}`);
       }
+
       return new Promise(async (resolve, reject) => {
         if (options.beforeRun) {
           const newArgsOpts = await options.beforeRun({args, opts});
@@ -236,6 +240,7 @@ export default class GitShellOutStrategy {
             // chance to fall back to GIT_ASKPASS from the credential handler.
             await new Promise((resolveKill, rejectKill) => {
               require('tree-kill')(handlerPid, 'SIGTERM', err => {
+                /* istanbul ignore if */
                 if (err) { rejectKill(err); } else { resolveKill(); }
               });
             });
@@ -258,14 +263,18 @@ export default class GitShellOutStrategy {
           timingMarker.mark('ipc', now - ipcTime);
         }
         timingMarker.finalize();
+
+        /* istanbul ignore if */
         if (process.env.PRINT_GIT_TIMES) {
           console.timeEnd(`git:${formattedArgs}`);
         }
+
         if (gitPromptServer) {
           gitPromptServer.terminate();
         }
         subscriptions.dispose();
 
+        /* istanbul ignore if */
         if (diagnosticsEnabled) {
           const exposeControlCharacters = raw => {
             if (!raw) { return ''; }
@@ -374,6 +383,7 @@ export default class GitShellOutStrategy {
       options.processCallback = child => {
         childPid = child.pid;
 
+        /* istanbul ignore next */
         child.stdin.on('error', err => {
           throw new Error(
             `Error writing to stdin: git ${args.join(' ')} in ${this.workingDir}\n${options.stdin}\n${err}`);
@@ -385,12 +395,14 @@ export default class GitShellOutStrategy {
       return {
         promise,
         cancel: () => {
+          /* istanbul ignore if */
           if (!childPid) {
             return Promise.resolve();
           }
 
           return new Promise((resolve, reject) => {
             require('tree-kill')(childPid, 'SIGTERM', err => {
+              /* istanbul ignore if */
               if (err) { reject(err); } else { resolve(); }
             });
           });

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -61,9 +61,9 @@ const DISABLE_COLOR_FLAGS = [
  * Ex: on Mac ~kuychaco/ is expanded to the specified user’s home directory (/Users/kuychaco)
  * Regex translation:
  * ^~ line starts with tilde
- * ([^\\/]*)[\\/] captures non-slash characters before first slash
+ * ([^\\\\/]*)[\\\\/] captures non-slash characters before first slash
  */
-const EXPAND_TILDE_REGEX = new RegExp('^~([^\\/]*)[\\/]');
+const EXPAND_TILDE_REGEX = new RegExp('^~([^\\\\/]*)[\\\\/]');
 
 export default class GitShellOutStrategy {
   static defaultExecArgs = {

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -1302,6 +1302,17 @@ import * as reporterProxy from '../lib/reporter-proxy';
       });
     });
 
+    describe('checkoutSide', function() {
+      it('is a no-op when no paths are provided', async function() {
+        const workdir = await cloneRepository();
+        const git = await createTestStrategy(workdir);
+        sinon.spy(git, 'exec');
+
+        await git.checkoutSide('ours', []);
+        assert.isFalse(git.exec.called);
+      });
+    });
+
     // Only needs to be tested on strategies that actually implement gpgExec
     describe('GPG signing', function() {
       let git;

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -165,7 +165,8 @@ import * as reporterProxy from '../lib/reporter-proxy';
       });
 
       it('replaces ~ with your home directory', async function() {
-        await git.setConfig('commit.template', `~${path.sep}does-not-exist.txt`);
+        // Fun fact: even on Windows, git does not accept "~\does-not-exist.txt"
+        await git.setConfig('commit.template', '~/does-not-exist.txt');
         await assert.isRejected(
           git.fetchCommitMessageTemplate(),
           `Invalid commit template path set in Git config: ${path.join(os.homedir(), 'does-not-exist.txt')}`,
@@ -174,7 +175,7 @@ import * as reporterProxy from '../lib/reporter-proxy';
 
       it("replaces ~user with user's home directory", async function() {
         const expectedFullPath = path.join(path.dirname(os.homedir()), 'nope/does-not-exist.txt');
-        await git.setConfig('commit.template', `~nope${path.sep}does-not-exist.txt`);
+        await git.setConfig('commit.template', '~nope/does-not-exist.txt');
         await assert.isRejected(
           git.fetchCommitMessageTemplate(),
           `Invalid commit template path set in Git config: ${expectedFullPath}`,

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -1198,6 +1198,13 @@ import * as reporterProxy from '../lib/reporter-proxy';
           assert.strictEqual(amendedCommit.messageSubject, 'first');
           assert.strictEqual(amendedCommit.messageBody, 'second\n\nthird');
         });
+
+        it('attempts to amend an unborn commit', async function() {
+          const workingDirPath = await initRepository();
+          const git = createTestStrategy(workingDirPath);
+
+          await assert.isRejected(git.commit('', {amend: true, allowEmpty: true}), /You have nothing to amend/);
+        });
       });
     });
 

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -165,7 +165,7 @@ import * as reporterProxy from '../lib/reporter-proxy';
       });
 
       it('replaces ~ with your home directory', async function() {
-        await git.setConfig('commit.template', path.join('~/does-not-exist.txt'));
+        await git.setConfig('commit.template', `~${path.sep}does-not-exist.txt`);
         await assert.isRejected(
           git.fetchCommitMessageTemplate(),
           `Invalid commit template path set in Git config: ${path.join(os.homedir(), 'does-not-exist.txt')}`,
@@ -174,7 +174,7 @@ import * as reporterProxy from '../lib/reporter-proxy';
 
       it("replaces ~user with user's home directory", async function() {
         const expectedFullPath = path.join(path.dirname(os.homedir()), 'nope/does-not-exist.txt');
-        await git.setConfig('commit.template', path.join('~nope/does-not-exist.txt'));
+        await git.setConfig('commit.template', `~nope${path.sep}does-not-exist.txt`);
         await assert.isRejected(
           git.fetchCommitMessageTemplate(),
           `Invalid commit template path set in Git config: ${expectedFullPath}`,

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -59,6 +59,11 @@ import * as reporterProxy from '../lib/reporter-proxy';
         });
       });
 
+      it('rejects if the process fails to spawn for an unexpected reason', async function() {
+        sinon.stub(git, 'executeGitCommand').returns({promise: Promise.reject(new Error('wat'))});
+        await assert.isRejected(git.exec(['version']), /wat/);
+      });
+
       it('does not call incrementCounter when git command is on the ignore list', async function() {
         await git.exec(['status']);
         assert.equal(incrementCounterStub.callCount, 0);

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -971,6 +971,12 @@ import * as reporterProxy from '../lib/reporter-proxy';
           assert.deepEqual(stagedChange.hunks[0].lines, [' foo', '+bar']);
         });
       });
+
+      it('fails when an invalid type is passed', async function() {
+        const workingDirPath = await cloneRepository('three-files');
+        const git = createTestStrategy(workingDirPath);
+        assert.throws(() => git.reset('scrambled'), /Invalid type scrambled/);
+      });
     });
 
     describe('deleteRef()', function() {
@@ -1506,6 +1512,12 @@ import * as reporterProxy from '../lib/reporter-proxy';
         sinon.stub(git, 'exec').rejects(new Error('shiiiit'));
 
         await assert.isRejected(git.createBlob({filePath: 'a.txt'}), /shiiiit/);
+      });
+
+      it('rejects if neither file path or stdin are provided', async function() {
+        const workingDirPath = await cloneRepository();
+        const git = createTestStrategy(workingDirPath);
+        await assert.isRejected(git.createBlob(), /Must supply file path or stdin/);
       });
     });
 

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -609,6 +609,42 @@ import * as reporterProxy from '../lib/reporter-proxy';
         assert.isDefined(diffOutput);
       });
 
+      it('rejects if an unexpected number of diffs is returned', async function() {
+        const workingDirPath = await cloneRepository();
+        const git = createTestStrategy(workingDirPath);
+        sinon.stub(git, 'exec').resolves(dedent`
+          diff --git aaa.txt aaa.txt
+          index df565d30..244a7225 100644
+          --- aaa.txt
+          +++ aaa.txt
+          @@ -100,3 +100,3 @@
+           000
+          -001
+          +002
+           003
+          diff --git aaa.txt aaa.txt
+          index df565d30..244a7225 100644
+          --- aaa.txt
+          +++ aaa.txt
+          @@ -100,3 +100,3 @@
+           000
+          -001
+          +002
+           003
+          diff --git aaa.txt aaa.txt
+          index df565d30..244a7225 100644
+          --- aaa.txt
+          +++ aaa.txt
+          @@ -100,3 +100,3 @@
+           000
+          -001
+          +002
+           003
+        `);
+
+        await assert.isRejected(git.getDiffsForFilePath('aaa.txt'), /Expected between 0 and 2 diffs/);
+      });
+
       describe('when the file is unstaged', function() {
         it('returns a diff comparing the working directory copy of the file and the version on the index', async function() {
           const workingDirPath = await cloneRepository('three-files');

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -165,7 +165,7 @@ import * as reporterProxy from '../lib/reporter-proxy';
       });
 
       it('replaces ~ with your home directory', async function() {
-        await git.setConfig('commit.template', '~/does-not-exist.txt');
+        await git.setConfig('commit.template', path.join('~/does-not-exist.txt'));
         await assert.isRejected(
           git.fetchCommitMessageTemplate(),
           `Invalid commit template path set in Git config: ${path.join(os.homedir(), 'does-not-exist.txt')}`,
@@ -174,7 +174,7 @@ import * as reporterProxy from '../lib/reporter-proxy';
 
       it("replaces ~user with user's home directory", async function() {
         const expectedFullPath = path.join(path.dirname(os.homedir()), 'nope/does-not-exist.txt');
-        await git.setConfig('commit.template', '~nope/does-not-exist.txt');
+        await git.setConfig('commit.template', path.join('~nope/does-not-exist.txt'));
         await assert.isRejected(
           git.fetchCommitMessageTemplate(),
           `Invalid commit template path set in Git config: ${expectedFullPath}`,


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

This adds unit tests to `git-strategies.test.js` to cover the [remaining uncovered lines reported by CodeCov](https://codecov.io/gh/atom/github/src/4786390d181001cb97ad7fa20d36fa1fb1ec1e89/lib/git-shell-out-strategy.js).

### Alternate Designs

_N/A_

### Benefits

GitShellOutStrategy is one of the more prevalent culprits in test coverage flapping that we see on unrelated PRs. This is one step toward minimizing those changes and keeping CodeCov output relavent.

### Possible Drawbacks

_N/A_

### Applicable Issues

_N/A_

### Metrics

_N/A_

### Tests

Ideally this should raise [GitShellOutStrategy's coverage](https://codecov.io/gh/atom/github/src/master/lib/git-shell-out-strategy.js) to 100%.

### Documentation

_N/A_

### Release Notes

_N/A_

### User Experience Research (Optional)

_N/A_