### PR TITLE
Test coverage for GitTempDir

### DIFF
--- a/test/git-temp-dir.test.js
+++ b/test/git-temp-dir.test.js
@@ -1,0 +1,71 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import GitTempDir, {BIN_SCRIPTS} from '../lib/git-temp-dir';
+
+describe('GitTempDir', function() {
+  it('ensures that a temporary directory is populated', async function() {
+    const tempDir = new GitTempDir();
+    await tempDir.ensure();
+
+    const root = tempDir.getRootPath();
+    for (const scriptName in BIN_SCRIPTS) {
+      const script = BIN_SCRIPTS[scriptName];
+      const stat = await fs.stat(path.join(root, script));
+      assert.isTrue(stat.isFile());
+      if (script.endsWith('.sh') && process.platform !== 'win32') {
+        // eslint-disable-next-line no-bitwise
+        assert.isTrue((stat.mode & fs.constants.S_IXUSR) === fs.constants.S_IXUSR);
+      }
+    }
+
+    await tempDir.ensure();
+    assert.strictEqual(root, tempDir.getRootPath());
+  });
+
+  it('generates getters for script paths', async function() {
+    const tempDir = new GitTempDir();
+    await tempDir.ensure();
+
+    const scriptPath = tempDir.getScriptPath('git-credential-atom.js');
+    assert.isTrue(scriptPath.startsWith(tempDir.getRootPath()));
+    assert.isTrue(scriptPath.endsWith('git-credential-atom.js'));
+
+    assert.strictEqual(tempDir.getCredentialHelperJs(), tempDir.getScriptPath('git-credential-atom.js'));
+    assert.strictEqual(tempDir.getCredentialHelperSh(), tempDir.getScriptPath('git-credential-atom.sh'));
+    assert.strictEqual(tempDir.getAskPassJs(), tempDir.getScriptPath('git-askpass-atom.js'));
+  });
+
+  it('fails when the temp dir is not yet created', function() {
+    const tempDir = new GitTempDir();
+    assert.throws(() => tempDir.getAskPassJs(), /uninitialized GitTempDir/);
+  });
+
+  if (process.platform === 'win32') {
+    it('generates a valid named pipe path for its socket', async function() {
+      const tempDir = new GitTempDir();
+      await tempDir.ensure();
+
+      assert.match(tempDir.getSocketPath(), /^\\\\\?\\pipe\\/);
+    });
+  } else {
+    it('generates a socket path within the directory', async function() {
+      const tempDir = new GitTempDir();
+      await tempDir.ensure();
+
+      assert.isTrue(tempDir.getSocketPath().startsWith(tempDir.getRootPath()));
+    });
+  }
+
+  it('deletes the directory on dispose', async function() {
+    const tempDir = new GitTempDir();
+    await tempDir.ensure();
+
+    const beforeStat = await fs.stat(tempDir.getRootPath());
+    assert.isTrue(beforeStat.isDirectory());
+
+    await tempDir.dispose();
+
+    await assert.isRejected(fs.stat(tempDir.getRootPath()), /ENOENT/);
+  });
+});


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Adds test coverage for `GitTempDir` to prevent coverage flapping in unrelated pull requests.

### Alternate Designs

I could have only covered the lines that weren't hit by other codepaths, but it's a small class so I just covered the whole thing.

### Benefits

GitTempDir is one of the culprits in test coverage flapping that we see on unrelated PRs. This is one step toward minimizing those changes and keeping CodeCov output relevent.

### Possible Drawbacks

_N/A_

### Applicable Issues

_N/A_

### Metrics

_N/A_

### Tests

This should raise GitTempDir's coverage to 100%.

### Documentation

_N/A_

### Release Notes

_N/A_

### User Experience Research (Optional)

_N/A_