### PR TITLE
make commit message template ignore commented lines

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -506,8 +506,12 @@ export default class GitShellOutStrategy {
       msg = rawMessage;
     }
 
+    // if commit template is used, that will not play nicely with `verbatim`
+    // because we want to strip commented lines from templates.
+    const template = await this.fetchCommitMessageTemplate();
+
     // Determine the cleanup mode.
-    if (verbatim) {
+    if (verbatim && !template) {
       args.push('--cleanup=verbatim');
     } else {
       const configured = await this.getConfig('commit.cleanup');

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -506,12 +506,15 @@ export default class GitShellOutStrategy {
       msg = rawMessage;
     }
 
-    // if commit template is used, that will not play nicely with `verbatim`
-    // because we want to strip commented lines from templates.
+    // if commit template is used, strip commented lines from commit
+    // to be consistent with command line git.
     const template = await this.fetchCommitMessageTemplate();
+    if (template) {
+      msg = msg.split('\n').filter(line => !line.startsWith('#')).join('\n');
+    }
 
     // Determine the cleanup mode.
-    if (verbatim && !template) {
+    if (verbatim) {
       args.push('--cleanup=verbatim');
     } else {
       const configured = await this.getConfig('commit.cleanup');

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -1036,6 +1036,24 @@ import * as reporterProxy from '../lib/reporter-proxy';
             'and things',
           ].join('\n'));
         });
+        it('ignores verbatim flag if commit template is used', async function() {
+          const workingDirPath = await cloneRepository('three-files');
+          const git = createTestStrategy(workingDirPath);
+          const templateText = '# this line should be stripped';
+
+          const commitMsgTemplatePath = path.join(workingDirPath, '.gitmessage');
+          await fs.writeFile(commitMsgTemplatePath, templateText, {encoding: 'utf8'});
+
+          await git.setConfig('commit.template', commitMsgTemplatePath);
+          await git.setConfig('commit.cleanup', 'default');
+          const commitMessage = ['this line should not be stripped', '', 'neither should this one', templateText].join('\n');
+          await git.commit(commitMessage, {allowEmpty: true, verbatim: true});
+
+          const lastCommit = await git.getHeadCommit();
+          assert.strictEqual(lastCommit.messageSubject, 'this line should not be stripped');
+          //  message body should not contain the template text
+          assert.strictEqual(lastCommit.messageBody, 'neither should this one');
+        });
       });
 
       describe('when amend option is true', function() {

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -1036,7 +1036,7 @@ import * as reporterProxy from '../lib/reporter-proxy';
             'and things',
           ].join('\n'));
         });
-        it('ignores verbatim flag if commit template is used', async function() {
+        it('strips commented lines if commit template is used', async function() {
           const workingDirPath = await cloneRepository('three-files');
           const git = createTestStrategy(workingDirPath);
           const templateText = '# this line should be stripped';

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -1186,6 +1186,7 @@ import * as reporterProxy from '../lib/reporter-proxy';
       beforeEach(async function() {
         const workingDirPath = await cloneRepository('multiple-commits');
         git = createTestStrategy(workingDirPath);
+        sinon.stub(git, 'fetchCommitMessageTemplate').returns(null);
       });
 
       const operations = [


### PR DESCRIPTION
### Description of the Change

This change fixes a bug  where commit message templates that include commented lines were included in the body of the commit. 

If a commit template exists, istrip commented lines from the commit message. 

### Alternate Designs

- My initial approach had us ignoring the `verbatim` flag if a commit template was present.  However, we want to preserve the verbatim flag because otherwise commits made from the mini editor might be formatted weirdly in some cases.  See https://github.com/atom/github/pull/1500 for more info. 

- We discussed ripping out the `verbatim` flag entirely, to aid complexity, but wanted to maintain the hard wrapping so as not to break formatting for users who are using the mini editor but not using a template.

### Benefits

- Users can make commits with message templates, without including commented lines in the commit output, because probably they do not want that.
- Consistent with command line git behavior

### Possible Drawbacks

- Adds more complexity to some code that's already rife with special cases.
- There might be some users who have commit templates and want to keep lines that start with `#`

### Applicable Issues

https://github.com/atom/github/issues/1817

### Metrics

N/A

### Tests

- Manually tested making a commit with a commit template set, where the template included `#` characters.  Verified that those commented lines did not show up when using `git log` to inspect the commit.
- unit test in `git-shell-out-strategy` to verify that commented lines are stripped when using commit message templates.  (We already have a unit test for validating that commented lines are not stripped, if a commit template does not exist.)

### Documentation

Added some code comments.

### Release Notes

Fixed an issue where commits made with commit message templates were not stripping comment characters.