### PR TITLE
Correct remaining flapping test coverage

### DIFF
--- a/lib/atom/decoration.js
+++ b/lib/atom/decoration.js
@@ -64,12 +64,12 @@ class BareDecoration extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.editorHolder !== prevProps.editorHolder) {
       this.editorSub.dispose();
-      this.editorSub = this.state.editorHolder.observe(this.observeParents);
+      this.editorSub = this.props.editorHolder.observe(this.observeParents);
     }
 
     if (this.props.decorableHolder !== prevProps.decorableHolder) {
       this.decorableSub.dispose();
-      this.decorableSub = this.state.decorableHolder.observe(this.observeParents);
+      this.decorableSub = this.props.decorableHolder.observe(this.observeParents);
     }
 
     if (
@@ -95,10 +95,10 @@ class BareDecoration extends React.Component {
     this.decorationHolder.map(decoration => decoration.destroy());
 
     const editorValid = this.props.editorHolder.map(editor => !editor.isDestroyed()).getOr(false);
-    const markableValid = this.props.decorableHolder.map(decorable => !decorable.isDestroyed()).getOr(false);
+    const decorableValid = this.props.decorableHolder.map(decorable => !decorable.isDestroyed()).getOr(false);
 
     // Ensure the Marker or MarkerLayer corresponds to the context's TextEditor
-    const markableMatches = this.props.decorableHolder.map(decorable => this.props.editorHolder.map(editor => {
+    const decorableMatches = this.props.decorableHolder.map(decorable => this.props.editorHolder.map(editor => {
       const layer = decorable.layer || decorable;
       const displayLayer = editor.getMarkerLayer(layer.id);
       if (!displayLayer) {
@@ -110,7 +110,7 @@ class BareDecoration extends React.Component {
       return true;
     }).getOr(false)).getOr(false);
 
-    if (!editorValid || !markableValid || !markableMatches) {
+    if (!editorValid || !decorableValid || !decorableMatches) {
       return;
     }
 

--- a/lib/controllers/editor-conflict-controller.js
+++ b/lib/controllers/editor-conflict-controller.js
@@ -18,11 +18,7 @@ export default class EditorConflictController extends React.Component {
     commandRegistry: PropTypes.object.isRequired,
     resolutionProgress: PropTypes.object.isRequired,
     isRebase: PropTypes.bool.isRequired,
-    refreshResolutionProgress: PropTypes.func,
-  }
-
-  static defaultProps = {
-    refreshResolutionProgress: () => {},
+    refreshResolutionProgress: PropTypes.func.isRequired,
   }
 
   constructor(props, context) {
@@ -49,7 +45,6 @@ export default class EditorConflictController extends React.Component {
     const buffer = this.props.editor.getBuffer();
 
     this.subscriptions.add(
-      this.props.editor.onDidStopChanging(() => this.forceUpdate()),
       this.props.editor.onDidDestroy(() => this.props.refreshResolutionProgress(this.props.editor.getPath())),
       buffer.onDidReload(() => this.reparseConflicts()),
     );
@@ -171,7 +166,7 @@ export default class EditorConflictController extends React.Component {
   }
 
   dismissConflicts(conflicts) {
-    this.setState((prevState, props) => {
+    this.setState(prevState => {
       const {added} = compareSets(new Set(conflicts), prevState.conflicts);
       return {conflicts: added};
     });

--- a/lib/models/conflicts/banner.js
+++ b/lib/models/conflicts/banner.js
@@ -26,6 +26,7 @@ export default class Banner {
   revert() {
     const range = this.getMarker().getBufferRange();
     this.editor.setTextInBufferRange(range, this.originalText);
+    this.getMarker().setBufferRange(range);
   }
 
   delete() {

--- a/lib/models/conflicts/side.js
+++ b/lib/models/conflicts/side.js
@@ -98,6 +98,7 @@ export default class Side {
   revert() {
     const range = this.getMarker().getBufferRange();
     this.editor.setTextInBufferRange(range, this.originalText);
+    this.getMarker().setBufferRange(range);
   }
 
   deleteBanner() {

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -610,9 +610,6 @@ export default class Present extends State {
         const bundle = await this.git().getStatusBundle();
         const results = await this.formatChangedFiles(bundle);
         results.branch = bundle.branch;
-        if (!results.branch.aheadBehind) {
-          results.branch.aheadBehind = {ahead: null, behind: null};
-        }
         return results;
       } catch (err) {
         if (err instanceof LargeRepoError) {
@@ -855,7 +852,7 @@ export default class Present extends State {
   // Direct blob access
 
   getBlobContents(sha) {
-    return this.cache.getOrSet(Keys.blob(sha), () => {
+    return this.cache.getOrSet(Keys.blob.oneWith(sha), () => {
       return this.git().getBlobContents(sha);
     });
   }
@@ -876,6 +873,7 @@ export default class Present extends State {
 
   // Cache
 
+  /* istanbul ignore next */
   getCache() {
     return this.cache;
   }
@@ -974,6 +972,7 @@ class Cache {
     this.didUpdate();
   }
 
+  /* istanbul ignore next */
   [Symbol.iterator]() {
     return this.storage[Symbol.iterator]();
   }
@@ -988,6 +987,7 @@ class Cache {
     this.emitter.emit('did-update');
   }
 
+  /* istanbul ignore next */
   onDidUpdate(callback) {
     return this.emitter.on('did-update', callback);
   }
@@ -1025,6 +1025,7 @@ class CacheKey {
     }
   }
 
+  /* istanbul ignore next */
   toString() {
     return `CacheKey(${this.primary})`;
   }
@@ -1041,6 +1042,7 @@ class GroupKey {
     }
   }
 
+  /* istanbul ignore next */
   toString() {
     return `GroupKey(${this.group})`;
   }

--- a/test/fixtures/conflict-marker-examples/single-2way-diff-empty.txt
+++ b/test/fixtures/conflict-marker-examples/single-2way-diff-empty.txt
@@ -1,0 +1,8 @@
+Before the start
+
+<<<<<<< HEAD
+These are my changes
+=======
+>>>>>>> master
+
+Past the end


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

I'm adding unit tests to cover the remaining lines that I've seen flap in our CodeCov reports, either by adding tests for specific lines I've seen flap, or just explicitly covering entire files and were only covered incidentally before.

Specifically:

- [x] `lib/models/conflicts/side.js`
- [x] `lib/atom/decoration.js`
- [x] `lib/controllers/editor-conflict-controller.js`
- [x] `lib/models/repository-states/present.js`

### Alternate Designs

_N/A_

### Benefits

More reliable and actionable CodeCov reports.

### Possible Drawbacks

It's a fair amount of rote work to do. But my head is thoroughly stuffed today so this is a good way to deliver some value without requiring higher-order thinking skills.

### Applicable Issues

Continuing the work begin in #1900 and #1901.

### Metrics

The [CodeCov master report](https://codecov.io/gh/atom/github/list/master/) is a good one to watch.

### Tests

Ideally we'll see coverage ⬆️ in the CodeCov report comment for those files. (Note that there is a delay while the Windows tests roll in.)

### Documentation

_N/A_

### Release Notes

_N/A_

### User Experience Research (Optional)

_N/A_

