### PR TITLE
add committer name to commit detail pane

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -700,12 +700,13 @@ export default class GitShellOutStrategy {
     // %x00 - null byte
     // %H - commit SHA
     // %ae - author email
+    // %an = author full name
     // %at - timestamp, UNIX timestamp
     // %s - subject
     // %b - body
     const args = [
       'log',
-      '--pretty=format:%H%x00%ae%x00%at%x00%s%x00%b%x00',
+      '--pretty=format:%H%x00%ae%x00%an%x00%at%x00%s%x00%b%x00',
       '--no-abbrev-commit',
       '--no-prefix',
       '--no-ext-diff',
@@ -733,13 +734,14 @@ export default class GitShellOutStrategy {
     }
 
     const fields = output.trim().split('\0');
+    console.log('fields', fields)
 
     const commits = [];
-    for (let i = 0; i < fields.length; i += 6) {
-      const body = fields[i + 4].trim();
+    for (let i = 0; i < fields.length; i += 7) {
+      const body = fields[i + 5].trim();
       let patch = [];
       if (includePatch) {
-        const diffs = fields[i + 5];
+        const diffs = fields[i + 6];
         patch = parseDiff(diffs.trim());
       }
 
@@ -748,8 +750,9 @@ export default class GitShellOutStrategy {
       commits.push({
         sha: fields[i] && fields[i].trim(),
         authorEmail: fields[i + 1] && fields[i + 1].trim(),
-        authorDate: parseInt(fields[i + 2], 10),
-        messageSubject: fields[i + 3],
+        authorName: fields[i + 2] && fields[i + 2].trim(),
+        authorDate: parseInt(fields[i + 3], 10),
+        messageSubject: fields[i + 4],
         messageBody,
         coAuthors,
         unbornRef: false,

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -734,7 +734,6 @@ export default class GitShellOutStrategy {
     }
 
     const fields = output.trim().split('\0');
-    console.log('fields', fields)
 
     const commits = [];
     for (let i = 0; i < fields.length; i += 7) {

--- a/lib/models/commit.js
+++ b/lib/models/commit.js
@@ -149,7 +149,8 @@ export default class Commit {
 
   isEqual(other) {
     // Directly comparable properties
-    for (const property of ['sha', 'authorEmail', 'authorDate', 'messageSubject', 'messageBody', 'unbornRef']) {
+    const properties = ['sha', 'authorEmail', 'authorDate', 'messageSubject', 'messageBody', 'unbornRef', 'authorName'];
+    for (const property of properties) {
       if (this[property] !== other[property]) {
         return false;
       }

--- a/lib/models/commit.js
+++ b/lib/models/commit.js
@@ -16,9 +16,10 @@ export default class Commit {
     return new Commit({unbornRef: UNBORN});
   }
 
-  constructor({sha, authorEmail, coAuthors, authorDate, messageSubject, messageBody, unbornRef, patch}) {
+  constructor({sha, authorEmail, authorName, coAuthors, authorDate, messageSubject, messageBody, unbornRef, patch}) {
     this.sha = sha;
     this.authorEmail = authorEmail;
+    this.authorName = authorName;
     this.coAuthors = coAuthors || [];
     this.authorDate = authorDate;
     this.messageSubject = messageSubject;
@@ -34,6 +35,10 @@ export default class Commit {
 
   getAuthorEmail() {
     return this.authorEmail;
+  }
+
+  getAuthorName() {
+    return this.authorName;
   }
 
   getAuthorDate() {

--- a/lib/views/commit-detail-view.js
+++ b/lib/views/commit-detail-view.js
@@ -56,6 +56,7 @@ export default class CommitDetailView extends React.Component {
             <h3 className="github-CommitDetailView-title">
               {emojify(commit.getMessageSubject())}
             </h3>
+            <div>{this.props.commit.authorName}</div>
             <div className="github-CommitDetailView-meta">
               {this.renderAuthors()}
               <span className="github-CommitDetailView-metaText">

--- a/lib/views/commit-detail-view.js
+++ b/lib/views/commit-detail-view.js
@@ -56,7 +56,6 @@ export default class CommitDetailView extends React.Component {
             <h3 className="github-CommitDetailView-title">
               {emojify(commit.getMessageSubject())}
             </h3>
-            <div className="github-CommitDetailView-authorName">{this.props.commit.authorName}</div>
             <div className="github-CommitDetailView-meta">
               {this.renderAuthors()}
               <span className="github-CommitDetailView-metaText">
@@ -132,11 +131,11 @@ export default class CommitDetailView extends React.Component {
     const commit = this.props.commit;
     const coAuthorCount = commit.getCoAuthors().length;
     if (coAuthorCount === 0) {
-      return commit.getAuthorEmail();
+    return commit.getAuthorName();
     } else if (coAuthorCount === 1) {
-      return `${commit.getAuthorEmail()} and ${commit.getCoAuthors()[0].email}`;
+      return `${commit.getAuthorName()} and ${commit.getCoAuthors()[0].name}`;
     } else {
-      return `${commit.getAuthorEmail()} and ${coAuthorCount} others`;
+      return `${commit.getAuthorName()} and ${coAuthorCount} others`;
     }
   }
 

--- a/lib/views/commit-detail-view.js
+++ b/lib/views/commit-detail-view.js
@@ -56,7 +56,7 @@ export default class CommitDetailView extends React.Component {
             <h3 className="github-CommitDetailView-title">
               {emojify(commit.getMessageSubject())}
             </h3>
-            <div>{this.props.commit.authorName}</div>
+            <div className="github-CommitDetailView-authorName">{this.props.commit.authorName}</div>
             <div className="github-CommitDetailView-meta">
               {this.renderAuthors()}
               <span className="github-CommitDetailView-metaText">

--- a/lib/views/commit-detail-view.js
+++ b/lib/views/commit-detail-view.js
@@ -131,7 +131,7 @@ export default class CommitDetailView extends React.Component {
     const commit = this.props.commit;
     const coAuthorCount = commit.getCoAuthors().length;
     if (coAuthorCount === 0) {
-    return commit.getAuthorName();
+      return commit.getAuthorName();
     } else if (coAuthorCount === 1) {
       return `${commit.getAuthorName()} and ${commit.getCoAuthors()[0].name}`;
     } else {

--- a/styles/commit-detail.less
+++ b/styles/commit-detail.less
@@ -41,7 +41,7 @@
 
   &-metaText {
     flex: 1;
-    margin-left: @avatar-dimensions * 1.3; // leave some space for the avatars
+    margin-left: @avatar-dimensions * 1.4; // leave some space for the avatars
     line-height: @avatar-dimensions;
     color: @text-color-subtle;
   }

--- a/test/builder/commit.js
+++ b/test/builder/commit.js
@@ -7,7 +7,7 @@ class CommitBuilder {
   constructor() {
     this._sha = '0123456789abcdefghij0123456789abcdefghij';
     this._authorEmail = 'default@email.com';
-    this._authorName = 'Tilde Ann Thurium'
+    this._authorName = 'Tilde Ann Thurium';
     this._authorDate = moment('2018-11-28T12:00:00', moment.ISO_8601).unix();
     this._coAuthors = [];
     this._messageSubject = 'subject';
@@ -62,7 +62,7 @@ class CommitBuilder {
     const commit = new Commit({
       sha: this._sha,
       authorEmail: this._authorEmail,
-      authorName: thus._authorName,
+      authorName: this._authorName,
       authorDate: this._authorDate,
       coAuthors: this._coAuthors,
       messageSubject: this._messageSubject,

--- a/test/builder/commit.js
+++ b/test/builder/commit.js
@@ -7,6 +7,7 @@ class CommitBuilder {
   constructor() {
     this._sha = '0123456789abcdefghij0123456789abcdefghij';
     this._authorEmail = 'default@email.com';
+    this._authorName = 'Tilde Ann Thurium'
     this._authorDate = moment('2018-11-28T12:00:00', moment.ISO_8601).unix();
     this._coAuthors = [];
     this._messageSubject = 'subject';
@@ -22,6 +23,11 @@ class CommitBuilder {
 
   authorEmail(newEmail) {
     this._authorEmail = newEmail;
+    return this;
+  }
+
+  authorName(newName) {
+    this._authorName = newName;
     return this;
   }
 
@@ -56,6 +62,7 @@ class CommitBuilder {
     const commit = new Commit({
       sha: this._sha,
       authorEmail: this._authorEmail,
+      authorName: thus._authorName,
       authorDate: this._authorDate,
       coAuthors: this._coAuthors,
       messageSubject: this._messageSubject,

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -188,6 +188,7 @@ import * as reporterProxy from '../lib/reporter-proxy';
         assert.deepEqual(commits[0], {
           sha: '90b17a8e3fa0218f42afc1dd24c9003e285f4a82',
           authorEmail: 'kuychaco@github.com',
+          authorName: 'Katrina Uychaco',
           authorDate: 1471113656,
           messageSubject: 'third commit',
           messageBody: '',
@@ -198,6 +199,7 @@ import * as reporterProxy from '../lib/reporter-proxy';
         assert.deepEqual(commits[1], {
           sha: '18920c900bfa6e4844853e7e246607a31c3e2e8c',
           authorEmail: 'kuychaco@github.com',
+          authorName: 'Katrina Uychaco',
           authorDate: 1471113642,
           messageSubject: 'second commit',
           messageBody: '',
@@ -208,6 +210,7 @@ import * as reporterProxy from '../lib/reporter-proxy';
         assert.deepEqual(commits[2], {
           sha: '46c0d7179fc4e348c3340ff5e7957b9c7d89c07f',
           authorEmail: 'kuychaco@github.com',
+          authorName: 'Katrina Uychaco',
           authorDate: 1471113625,
           messageSubject: 'first commit',
           messageBody: '',

--- a/test/models/commit.test.js
+++ b/test/models/commit.test.js
@@ -147,9 +147,9 @@ describe('Commit', function() {
   });
 
   it('returns the author name', function() {
-   const authorName = 'Tilde Ann Thurium';
-   const commit = commitBuilder().authorName(authorName).build();
-   assert.strictEqual(commit.getAuthorName(), authorName)
+    const authorName = 'Tilde Ann Thurium';
+    const commit = commitBuilder().authorName(authorName).build();
+    assert.strictEqual(commit.getAuthorName(), authorName);
   });
 
   describe('isEqual()', function() {

--- a/test/models/commit.test.js
+++ b/test/models/commit.test.js
@@ -178,6 +178,13 @@ describe('Commit', function() {
       assert.isFalse(a.isEqual(b));
     });
 
+    it('returns false if author differs', function() {
+      const a = commitBuilder().authorName('Tilde Ann Thurium').build();
+
+      const b = commitBuilder().authorName('Vanessa Yuen').build();
+      assert.isFalse(a.isEqual(b));
+    });
+
     it('returns false if a co-author differs', function() {
       const a = commitBuilder().addCoAuthor('me', 'me@email.com').build();
 

--- a/test/models/commit.test.js
+++ b/test/models/commit.test.js
@@ -146,6 +146,12 @@ describe('Commit', function() {
     });
   });
 
+  it('returns the author name', function() {
+   const authorName = 'Tilde Ann Thurium';
+   const commit = commitBuilder().authorName(authorName).build();
+   assert.strictEqual(commit.getAuthorName(), authorName)
+  });
+
   describe('isEqual()', function() {
     it('returns true when commits are identical', function() {
       const a = commitBuilder()

--- a/test/views/commit-detail-view.test.js
+++ b/test/views/commit-detail-view.test.js
@@ -10,7 +10,7 @@ import Remote, {nullRemote} from '../../lib/models/remote';
 import {cloneRepository, buildRepository} from '../helpers';
 import {commitBuilder} from '../builder/commit';
 
-describe.only('CommitDetailView', function() {
+describe('CommitDetailView', function() {
   let repository, atomEnv;
 
   beforeEach(async function() {

--- a/test/views/commit-detail-view.test.js
+++ b/test/views/commit-detail-view.test.js
@@ -62,6 +62,7 @@ describe('CommitDetailView', function() {
     const commit = commitBuilder()
       .sha('420')
       .authorEmail('very@nice.com')
+      .authorName('Forthe Win')
       .authorDate(moment().subtract(2, 'days').unix())
       .messageSubject('subject')
       .messageBody('body')
@@ -69,6 +70,7 @@ describe('CommitDetailView', function() {
       .build();
     const wrapper = shallow(buildApp({commit}));
 
+    assert.strictEqual(wrapper.find('.github-CommitDetailView-authorName').text(), 'Forthe Win');
     assert.strictEqual(wrapper.find('.github-CommitDetailView-title').text(), 'subject');
     assert.strictEqual(wrapper.find('.github-CommitDetailView-moreText').text(), 'body');
     assert.strictEqual(wrapper.find('.github-CommitDetailView-metaText').text(), 'very@nice.com committed 2 days ago');

--- a/test/views/commit-detail-view.test.js
+++ b/test/views/commit-detail-view.test.js
@@ -75,7 +75,7 @@ describe('CommitDetailView', function() {
     assert.strictEqual(wrapper.find('.github-CommitDetailView-moreText').text(), 'body');
     assert.strictEqual(wrapper.find('.github-CommitDetailView-metaText').text(), 'very@nice.com committed 2 days ago');
     assert.strictEqual(wrapper.find('.github-CommitDetailView-sha').text(), '420');
-    // assert.strictEqual(wrapper.find('.github-CommitDetailView-sha a').prop('href'), '420');
+    assert.strictEqual(wrapper.find('.github-CommitDetailView-sha a').prop('href'), 'https://github.com/atom/github/commit/420');
     assert.strictEqual(
       wrapper.find('img.github-RecentCommit-avatar').prop('src'),
       'https://avatars.githubusercontent.com/u/e?email=very%40nice.com&s=32',

--- a/test/views/commit-detail-view.test.js
+++ b/test/views/commit-detail-view.test.js
@@ -10,7 +10,7 @@ import Remote, {nullRemote} from '../../lib/models/remote';
 import {cloneRepository, buildRepository} from '../helpers';
 import {commitBuilder} from '../builder/commit';
 
-describe('CommitDetailView', function() {
+describe.only('CommitDetailView', function() {
   let repository, atomEnv;
 
   beforeEach(async function() {
@@ -70,10 +70,9 @@ describe('CommitDetailView', function() {
       .build();
     const wrapper = shallow(buildApp({commit}));
 
-    assert.strictEqual(wrapper.find('.github-CommitDetailView-authorName').text(), 'Forthe Win');
     assert.strictEqual(wrapper.find('.github-CommitDetailView-title').text(), 'subject');
     assert.strictEqual(wrapper.find('.github-CommitDetailView-moreText').text(), 'body');
-    assert.strictEqual(wrapper.find('.github-CommitDetailView-metaText').text(), 'very@nice.com committed 2 days ago');
+    assert.strictEqual(wrapper.find('.github-CommitDetailView-metaText').text(), 'Forthe Win committed 2 days ago');
     assert.strictEqual(wrapper.find('.github-CommitDetailView-sha').text(), '420');
     assert.strictEqual(wrapper.find('.github-CommitDetailView-sha a').prop('href'), 'https://github.com/atom/github/commit/420');
     assert.strictEqual(
@@ -162,33 +161,34 @@ describe('CommitDetailView', function() {
     describe('when there are no co-authors', function() {
       it('returns only the author', function() {
         const commit = commitBuilder()
-          .authorEmail('blaze@it.com')
+          .authorName('Steven Universe')
+          .authorEmail('steven@universe.com')
           .build();
         const wrapper = shallow(buildApp({commit}));
-        assert.strictEqual(wrapper.instance().getAuthorInfo(), 'blaze@it.com');
+        assert.strictEqual(wrapper.instance().getAuthorInfo(), 'Steven Universe');
       });
     });
 
     describe('when there is one co-author', function() {
       it('returns author and the co-author', function() {
         const commit = commitBuilder()
-          .authorEmail('blaze@it.com')
-          .addCoAuthor('two', 'two@coauthor.com')
+          .authorName('Ruby')
+          .addCoAuthor('Sapphire', 'sapphire@thecrystalgems.party')
           .build();
         const wrapper = shallow(buildApp({commit}));
-        assert.strictEqual(wrapper.instance().getAuthorInfo(), 'blaze@it.com and two@coauthor.com');
+        assert.strictEqual(wrapper.instance().getAuthorInfo(), 'Ruby and Sapphire');
       });
     });
 
     describe('when there is more than one co-author', function() {
       it('returns the author and number of co-authors', function() {
         const commit = commitBuilder()
-          .authorEmail('blaze@it.com')
-          .addCoAuthor('two', 'two@coauthor.com')
-          .addCoAuthor('three', 'three@coauthor.com')
+          .authorName('Amethyst')
+          .addCoAuthor('Peridot', 'peri@youclods.horse')
+          .addCoAuthor('Pearl', 'p@pinkhair.club')
           .build();
         const wrapper = shallow(buildApp({commit}));
-        assert.strictEqual(wrapper.instance().getAuthorInfo(), 'blaze@it.com and 2 others');
+        assert.strictEqual(wrapper.instance().getAuthorInfo(), 'Amethyst and 2 others');
       });
     });
   });


### PR DESCRIPTION
### Description of the Change

This change adds the committer's full name to the commit detail pane.  Instead of email address, we show the full name.

<img width="734" alt="screen shot 2019-01-15 at 1 38 23 pm" src="https://user-images.githubusercontent.com/3781742/51211589-d9ea9280-18ca-11e9-8a12-1e63902a9d1c.png">



### Alternate Designs

- I considered showing the name and email address.  However, it looked kinda cluttered, and I couldn't find a good way of showing co author info in that scenario. 

![image](https://user-images.githubusercontent.com/3781742/51211475-71031a80-18ca-11e9-8842-720f9651e643.png)


### Benefits

- Makes it easier to understand at a glance who made the commit
- Feature has been requested by folks in the community

### Possible Drawbacks

- If folks need the email address of a committer for some reason, now it would take more effort to find it. 

### Applicable Issues

https://github.com/atom/github/issues/1875

### Metrics

N/A

### Tests

- Manually tested that committer name shows up as expected for single commits
- Commiter name shows up as expected for co authored commits
- name falls back to something reasonable (such as email address or GitHub username) if committer name is not set in git config
- all new lines covered by unit tests

### Documentation

N/A

### Release Notes

TBD

### User Experience Research (Optional)

N/A

