### PR TITLE
Diff color tweaks

### DIFF
--- a/styles/file-patch-view.less
+++ b/styles/file-patch-view.less
@@ -298,6 +298,16 @@
   }
 }
 
+// Selected + focused hunkmode
+.github-FilePatchView.github-FilePatchView--hunkMode:focus-within {
+
+  atom-text-editor {
+    .selection .region {
+      background-color: mix(@button-background-color-selected, @syntax-background-color, 12%);
+    }
+  }
+}
+
 .gitub-FilePatchHeaderView-basename {
   font-weight: bold;
 }

--- a/styles/file-patch-view.less
+++ b/styles/file-patch-view.less
@@ -184,20 +184,32 @@
 
   &-line {
     // mixin
-    .hunk-line-mixin(@bg;) {
-      background-color: fade(@bg, 16%);
+    .hunk-line-mixin(@color) {
+      background-color: fade(@color, 15%);
 
       &.line.cursor-line {
-        background-color: fade(@bg, 22%);
+        background-color: fade(@color, 25%);
       }
     }
 
-    &--deleted {
-      .hunk-line-mixin(@background-color-error);
+    // light themes
+    & when (lightness(@syntax-background-color) >= 50) {
+      &--deleted {
+        .hunk-line-mixin( hsl(353, 100%, 55%) ); // close to .com's hsl(353, 100%, 93%)
+      }
+      &--added {
+        .hunk-line-mixin( hsl(133, 100%, 50%) ); // close to .com's hsl(133, 100%, 90%)
+      }
     }
 
-    &--added {
-      .hunk-line-mixin(@background-color-success);
+    // dark themes
+    & when (lightness(@syntax-background-color) < 50) {
+      &--deleted {
+        .hunk-line-mixin( hsl(353, 100%, 65%) ); // close to .com's hsl(353, 100%, 93%)
+      }
+      &--added {
+        .hunk-line-mixin( hsl(133, 40%, 60%) ); // close to .com's hsl(133, 100%, 90%)
+      }
     }
   }
 
@@ -276,7 +288,7 @@
 
   atom-text-editor {
     .selection .region {
-      background-color: transparent;
+      background-color: transparent; // remove default selection
     }
   }
 }
@@ -296,7 +308,7 @@
 
   atom-text-editor {
     .selection .region {
-      background-color: mix(@button-background-color-selected, @syntax-background-color, 24%);
+      background-color: mix(@button-background-color-selected, @syntax-background-color, 25%);
     }
   }
 }
@@ -306,7 +318,7 @@
 
   atom-text-editor {
     .selection .region {
-      background-color: mix(@button-background-color-selected, @syntax-background-color, 12%);
+      background-color: mix(@button-background-color-selected, @syntax-background-color, 8%);
     }
   }
 }

--- a/styles/file-patch-view.less
+++ b/styles/file-patch-view.less
@@ -250,7 +250,10 @@
       }
 
       &.github-FilePatchView-line--nonewline:before {
-        content: @no-newline; // TODO replace icon
+        content: @no-newline;
+        .octicon-font();
+        width: inherit;
+        min-width: auto;
       }
     }
   }

--- a/styles/file-patch-view.less
+++ b/styles/file-patch-view.less
@@ -216,26 +216,29 @@
     }
 
     &.icons .line-number {
-      .octicon-font();
+      padding: 0;
       opacity: 1;
       width: 2ch;
+      font-family: @font-family;
+      text-align: center;
+      color: mix(@syntax-gutter-text-color, @syntax-text-color);
+      -webkit-font-smoothing: antialiased;
 
       &:before {
         display: inline-block;
-        min-width: 1ch;
-        text-align: center;
+        min-width: 2ch;
       }
 
       &.github-FilePatchView-line--added:before {
-        content: @plus;
+        content: "+";
       }
 
       &.github-FilePatchView-line--deleted:before {
-        content: @dash;
+        content: "-";
       }
 
       &.github-FilePatchView-line--nonewline:before {
-        content: @no-newline;
+        content: @no-newline; // TODO replace icon
       }
     }
   }


### PR DESCRIPTION
### Description of the Change

This makes the blue-ish background color weaker when selecting the whole hunk. But keeps it stronger when selecting individual lines/words/characters.

Some additional changes:

- Tweaked the diff colors
- Replaced the gutter icons to be text based. The icons felt a bit too bold.

### Screenshot/Gif

Before | After
--- | ---
![screen shot 2019-02-07 at 5 40 10 pm](https://user-images.githubusercontent.com/378023/52399403-75a0a480-2aff-11e9-9cbf-df22526d5410.png) | ![screen shot 2019-02-07 at 5 39 34 pm](https://user-images.githubusercontent.com/378023/52399406-79ccc200-2aff-11e9-8034-da797114811b.png)

![diff](https://user-images.githubusercontent.com/378023/52399623-227b2180-2b00-11e9-985c-a7f22a52675c.gif)


### Alternate Designs

1. When clicking the "See All Staged Changes" button with the mouse, we could keep the focus on the button and not move it to the first hunk. That would also match the behaviour of single file diffs.
2. We could differentiate between making a selections of single characters/words and selecting the whole line. Maybe have two classes `github-FilePatchView-line--selected` and `github-FilePatchView-line--partiallySelected`.
3. Separate "selecting text/code" and "select to staging". Same behaviour as in Desktop. Maybe necessary for editable diffs.
4. Also add diff coloring (red/green) to the gutters. Then when selecting characters/words, it's still easy to see if a line is deleted or added.

/cc @kuychaco ☝️ 


### Benefits

Easier to read the diff when the first hunk gets automatically selected in commit previews.


### Possible Drawbacks

The difference between a selected hunk and selected lines might be confusing?


### Applicable Issues

Closes #1933


### Metrics

N/A

### Tests

Tested with Atom's bundled themes and a few community themes. Certain themes work better than others.

### Documentation

N/A

### Release Notes

N/A

### User Experience Research (Optional)

N/A

