### PR TITLE
CodeCov package upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -264,31 +264,6 @@
         "tmp": "0.0.31"
       }
     },
-    "@smashwilson/codecov": {
-      "version": "3.1.1-azure0.0",
-      "resolved": "https://registry.npmjs.org/@smashwilson/codecov/-/codecov-3.1.1-azure0.0.tgz",
-      "integrity": "sha512-ctT6EDZ+uQpZhixzTJoWBOF32ZKEaAg+h4iVApEhTMxtLFNYzGSepz6hS5enIXzxMzQiMEzZgVUqGtk1G7kRXg==",
-      "dev": true,
-      "requires": {
-        "argv": "^0.0.2",
-        "ignore-walk": "^3.0.1",
-        "js-yaml": "^3.12.0",
-        "teeny-request": "^3.7.0",
-        "urlgrey": "^0.4.4"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        }
-      }
-    },
     "@types/node": {
       "version": "10.12.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
@@ -2079,6 +2054,19 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "codecov": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.2.0.tgz",
+      "integrity": "sha512-3NJvNARXxilqnqVfgzDHyVrF4oeVgaYW1c1O6Oi5mn93exE7HTSSFNiYdwojWW6IwrCZABJ8crpNbKoo9aUHQw==",
+      "dev": true,
+      "requires": {
+        "argv": "^0.0.2",
+        "ignore-walk": "^3.0.1",
+        "js-yaml": "^3.12.0",
+        "teeny-request": "^3.7.0",
+        "urlgrey": "^0.4.4"
+      }
     },
     "collection-visit": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -76,10 +76,10 @@
   },
   "devDependencies": {
     "@smashwilson/atom-mocha-test-runner": "1.4.0",
-    "@smashwilson/codecov": "3.1.1-azure0.0",
     "babel-plugin-istanbul": "5.1.0",
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
+    "codecov": "3.2.0",
     "cross-env": "5.2.0",
     "cross-unzip": "0.2.1",
     "dedent-js": "1.0.1",


### PR DESCRIPTION
Go back to the [official CodeCov package](https://www.npmjs.com/package/codecov) now that it has a release that includes [Azure DevOps support](https://github.com/codecov/codecov-node/pull/114).