### PR TITLE
support new reaction emoji from GitHub.com

### DIFF
--- a/lib/views/emoji-reactions-view.js
+++ b/lib/views/emoji-reactions-view.js
@@ -9,6 +9,8 @@ const reactionTypeToEmoji = {
   HOORAY: '🎉',
   CONFUSED: '😕',
   HEART: '❤️',
+  ROCKET: '🚀',
+  EYES: '👀',
 };
 
 export default class EmojiReactionsView extends React.Component {
@@ -26,14 +28,19 @@ export default class EmojiReactionsView extends React.Component {
   render() {
     return (
       <div className="github-IssueishDetailView-reactions">
-        {this.props.reactionGroups.map(group => (
-          group.users.totalCount > 0
-            ? <span className={cx('github-IssueishDetailView-reactionsGroup', group.content.toLowerCase())}
-              key={group.content}>
-              {reactionTypeToEmoji[group.content]} &nbsp; {group.users.totalCount}
-            </span>
-            : null
-        ))}
+        {this.props.reactionGroups.map(group => {
+          const emoji = reactionTypeToEmoji[group.content];
+          if (!emoji) {
+            return null;
+          }
+          return (
+            group.users.totalCount > 0
+              ? <span className={cx('github-IssueishDetailView-reactionsGroup', group.content.toLowerCase())}
+                key={group.content}>
+                {reactionTypeToEmoji[group.content]} &nbsp; {group.users.totalCount}
+              </span>
+              : null);
+        })}
       </div>
     );
   }

--- a/test/views/emoji-reactions-view.test.js
+++ b/test/views/emoji-reactions-view.test.js
@@ -7,6 +7,9 @@ describe('EmojiReactionsView', function() {
   const reactionGroups = [
     {content: 'THUMBS_UP', users: {totalCount: 10}},
     {content: 'THUMBS_DOWN', users: {totalCount: 5}},
+    {content: 'ROCKET', users: {totalCount: 42}},
+    {content: 'EYES', users: {totalCount: 13}},
+    {content: 'AVOCADO', users: {totalCount: 11}},
     {content: 'LAUGH', users: {totalCount: 0}}];
   beforeEach(function() {
     wrapper = shallow(<EmojiReactionsView reactionGroups={reactionGroups} />);
@@ -15,6 +18,13 @@ describe('EmojiReactionsView', function() {
     const groups = wrapper.find('.github-IssueishDetailView-reactionsGroup');
     assert.lengthOf(groups.findWhere(n => /👍/u.test(n.text()) && /\b10\b/.test(n.text())), 1);
     assert.lengthOf(groups.findWhere(n => /👎/u.test(n.text()) && /\b5\b/.test(n.text())), 1);
+    assert.lengthOf(groups.findWhere(n => /🚀/u.test(n.text()) && /\b42\b/.test(n.text())), 1);
+    assert.lengthOf(groups.findWhere(n => /👀/u.test(n.text()) && /\b13\b/.test(n.text())), 1);
     assert.isFalse(groups.someWhere(n => /😆/u.test(n.text())));
+  });
+  it('gracefully skips unknown emoji', function() {
+    assert.isFalse(wrapper.text().includes(11));
+    const groups = wrapper.find('.github-IssueishDetailView-reactionsGroup');
+    assert.lengthOf(groups, 4);
   });
 });


### PR DESCRIPTION
### Description of the Change

GitHub.com now supports reaction emoji: 👀 and 🚀 .  Therefore, we should make sure these new emoji render when viewing pull requests and issues within Atom.

Also, now we don't render anything if the emoji is unrecognized.  Hooray for graceful degradation.
### Screenshot/Gif

N/A

### Alternate Designs

N/A

### Benefits

Emoji make subtext into text and enable remote communication and brings empathy into the development process.  Letting our users use more kinds of emoji enables more communication modes.  

### Possible Drawbacks

Can't think of any.

### Applicable Issues

https://github.com/atom/github/issues/1916

### Metrics

N/A

### Tests

- Wrote unit tests for the new emoji, graceful degradation
- Manually rendered the issue that describes this problem (so meta) to verify the new emoji show up.

### Documentation

N/A

### Release Notes

- The GitHub package now supports new reaction emoji: 👀 and 🚀 

### User Experience Research (Optional)

N/A

