### PR TITLE
respect `core.commentChar` from git settings.

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -519,7 +519,14 @@ export default class GitShellOutStrategy {
     // to be consistent with command line git.
     const template = await this.fetchCommitMessageTemplate();
     if (template) {
-      msg = msg.split('\n').filter(line => !line.startsWith('#')).join('\n');
+
+      // respecting the comment character from user settings or fall back to # as default.
+      // https://git-scm.com/docs/git-config#git-config-corecommentChar
+      let commentChar = await this.getConfig('core.commentChar');
+      if (!commentChar) {
+        commentChar = '#';
+      }
+      msg = msg.split('\n').filter(line => !line.startsWith(commentChar)).join('\n');
     }
 
     // Determine the cleanup mode.

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -1190,7 +1190,7 @@ import * as reporterProxy from '../lib/reporter-proxy';
 
           await git.setConfig('commit.template', commitMsgTemplatePath);
           await git.setConfig('commit.cleanup', 'default');
-          const commitMessage = ['this line should not be stripped', '', 'neither should this one', templateText].join('\n');
+          const commitMessage = ['this line should not be stripped', '', 'neither should this one', '', '# but this one should', templateText].join('\n');
           await git.commit(commitMessage, {allowEmpty: true, verbatim: true});
 
           const lastCommit = await git.getHeadCommit();


### PR DESCRIPTION
### Description of the Change

If a user is using commit templates, previously we were assuming their comment character is `#`.  Git provides the ability to set a custom comment char.  This change respects a custom comment character the user has set and strips lines beginning with that character from the commit message.

Also, I made the original unit test for stripping `#` from commit message templates more robust, by adding some lines to the commit message that start with '#'.  There were lines in the commit message template that start with '#', but we aren't actually doing anything with the template in `gitShellOutStrategy.commit` other than checking for existence, so that test wasn't checking anything very meaningful.

### Screenshot/Gif

N/A

### Alternate Designs

None.

### Benefits

Users who have set a custom comment character will be able to make commits and ensure that commented characters are properly stripped.  

### Possible Drawbacks

There's always the risk of introducing additional bugs.  Other than that, can't think of any. 

### Applicable Issues

https://github.com/atom/github/issues/1909

### Metrics

N/A

### Tests

- Manual testing setting `core.commentChar` in local git settings, setting a commit template that contained lines that start with that character, making a commit, and verifying that lines that started with that character are stripped out of the commit. 
- Manual tested unsetting `core.commentChar`, setting a commit template, making a commit, and verifying that lines that started with `#` were still stripped out of the ensuing commit message.
- Added unit test to ensure that lines that start with core.commentChar are stripped from commit messages

### Documentation

N/A

### Release Notes

Fixed bug with commit message templates in the GitHub package -- now, lines starting with `core.commentChar` are stripped if `core.commentChar` is set in local git settings.

### User Experience Research (Optional)

N/A

