### PR TITLE
Suggested changes styling

### DIFF
--- a/styles/file-patch-view.less
+++ b/styles/file-patch-view.less
@@ -183,32 +183,16 @@
   // Line decorations
 
   &-line {
-    // mixin
-    .hunk-line-mixin(@color) {
-      background-color: fade(@color, 15%);
-
+    &--deleted {
+      background-color: @github-diff-deleted;
       &.line.cursor-line {
-        background-color: fade(@color, 25%);
+        background-color: fadein(@github-diff-deleted, 3%);
       }
     }
-
-    // light themes
-    & when (lightness(@syntax-background-color) >= 50) {
-      &--deleted {
-        .hunk-line-mixin( hsl(353, 100%, 55%) ); // close to .com's hsl(353, 100%, 93%)
-      }
-      &--added {
-        .hunk-line-mixin( hsl(133, 100%, 50%) ); // close to .com's hsl(133, 100%, 90%)
-      }
-    }
-
-    // dark themes
-    & when (lightness(@syntax-background-color) < 50) {
-      &--deleted {
-        .hunk-line-mixin( hsl(353, 100%, 65%) ); // close to .com's hsl(353, 100%, 93%)
-      }
-      &--added {
-        .hunk-line-mixin( hsl(133, 40%, 60%) ); // close to .com's hsl(133, 100%, 90%)
+    &--added {
+      background-color: @github-diff-added;
+      &.line.cursor-line {
+        background-color: fadein(@github-diff-added, 3%);
       }
     }
   }

--- a/styles/github-dotcom-markdown.less
+++ b/styles/github-dotcom-markdown.less
@@ -2,7 +2,7 @@
 
 // This styles Markdown used in issueish panes.
 
-@margin: 1.5em;
+@margin: 1em;
 
 .github-DotComMarkdownHtml {
 
@@ -177,6 +177,10 @@
 
   .issue-link {
     color: @text-color-subtle; // same as .cross-referenced-event-label-number
+  }
+
+  .js-suggested-changes-blob { // gets used for suggested changes
+    margin: @margin 0;
   }
 
 }

--- a/styles/pr-comment.less
+++ b/styles/pr-comment.less
@@ -5,7 +5,7 @@
 
 
 .github-PrCommentThread {
-  padding: @component-padding 0;
+  padding: @component-padding @component-padding @component-padding 0;
 }
 
 

--- a/styles/pr-comment.less
+++ b/styles/pr-comment.less
@@ -58,4 +58,86 @@
     vertical-align: middle;
   }
 
+
+  // Suggested changes
+  .js-suggested-changes-blob {
+    font-size: .9em;
+    border: 1px solid @base-border-color;
+    border-radius: @component-border-radius;
+
+    .d-flex { display: flex; }
+    .d-inline-block { display: inline-block; }
+    .flex-auto { flex: 1 1 auto; }
+    .p-1 { padding: @component-padding/2; }
+    .px-1 { padding-left: @component-padding/2; padding-right: @component-padding/2; }
+    .p-2 { padding: @component-padding; }
+    .text-gray { color: @text-color-subtle; }
+    .lh-condensed { line-height: 1.25; }
+    .rounded-1 { border-radius: @component-border-radius; }
+    .border { border: 1px solid; }
+    .border-bottom { border-bottom: 1px solid @base-border-color; }
+    .border-green { border-color: @text-color-success; }
+    .octicon { vertical-align: -4px; fill: currentColor; }
+
+    .blob-wrapper > table {
+      width: 100%;
+      margin: 0;
+      font-family: var(--editor-font-family);
+      font-size: var(--editor-font-size);
+      line-height: var(--editor-line-height);
+
+      td {
+        border: none;
+        padding: 0 .5em;
+      }
+    }
+
+    .blob-num {
+      padding: 0 .5em;
+      color: @text-color-subtle;
+      &:before {
+        content: attr(data-line-number);
+      }
+      &-addition {
+        background-color: fadein(@github-diff-added, 10%);
+      }
+      &-deletion {
+        background-color: fadein(@github-diff-deleted, 10%);
+      }
+    }
+
+    .blob-code {
+      &-inner {
+        &:before { margin-right: .5em; }
+        .x {
+          &-first {
+            border-bottom-left-radius: @component-border-radius;
+            border-top-left-radius: @component-border-radius;
+          }
+          &-last {
+            border-bottom-right-radius: @component-border-radius;
+            border-top-right-radius: @component-border-radius;
+          }
+        }
+      }
+
+      &-addition {
+        background-color: @github-diff-added;
+        &:before { content: "+"; }
+        .x {
+          background-color: @github-diff-added-highlight;
+        }
+      }
+
+      &-deletion {
+        background-color: @github-diff-deleted;
+        &:before { content: "-"; }
+        .x {
+          background-color: @github-diff-deleted-highlight;
+        }
+      }
+    }
+
+  }
+
 }

--- a/styles/pr-comment.less
+++ b/styles/pr-comment.less
@@ -138,6 +138,71 @@
       }
     }
 
+    // These styles are mostly copied from the Primer tooltips
+    .tooltipped {
+      position: relative;
+
+      // This is the tooltip bubble
+      &::after {
+        position: absolute;
+        z-index: 1000000;
+        display: none;
+        width: max-content;
+        max-width: 22em;
+        padding: .5em .6em;
+        font-weight: 500;
+        color: @base-background-color;
+        text-align: center;
+        pointer-events: none;
+        content: attr(aria-label);
+        background: @background-color-info;
+        border-radius: @component-border-radius;
+      }
+
+      // This is the tooltip arrow
+      &::before {
+        position: absolute;
+        z-index: 1000001;
+        display: none;
+        width: 0;
+        height: 0;
+        color: @background-color-info;
+        pointer-events: none;
+        content: "";
+        border: 6px solid transparent;
+      }
+
+      // This will indicate when we'll activate the tooltip
+      &:hover,
+      &:active,
+      &:focus {
+        &::before,
+        &::after {
+          display: inline-block;
+          text-decoration: none;
+        }
+      }
+
+      // Tooltipped south
+      &::after {
+        top: 100%;
+        right: 50%;
+        margin-top: 6px;
+      }
+      &::before {
+        top: auto;
+        right: 50%;
+        bottom: -7px;
+        margin-right: -6px;
+        border-bottom-color: @background-color-info;
+      }
+
+      // Move the tooltip body to the center of the object.
+      &::after {
+        transform: translateX(50%);
+      }
+    }
+
   }
 
 }

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -7,3 +7,13 @@
 @gh-background-color-red: #dc3545;
 @gh-background-color-purple: #6f42c1;
 @gh-background-color-green: #28a745;
+
+
+// diff colors -----------------
+// Needs to be semi transparent make it work with selections and different themes
+
+@github-diff-deleted:           fade(hsl(353, 100%, 66%), 15%); // similar to .com's hsl(353, 100%, 97%)
+@github-diff-added:             fade(hsl(137, 100%, 55%), 15%); // similar to .com's hsl(137, 100%, 95%)
+
+@github-diff-deleted-highlight: fade(hsl(353, 95%, 66%), 25%); // similar to .com's hsl(353, 95%, 86%)
+@github-diff-added-highlight:   fade(hsl(135, 73%, 55%), 25%); // similar to .com's hsl(135, 73%, 81%)

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -10,7 +10,7 @@
 
 
 // diff colors -----------------
-// Needs to be semi transparent make it work with selections and different themes
+// Needs to be semi transparent to make it work with selections and different themes
 
 @github-diff-deleted:           fade(hsl(353, 100%, 66%), 15%); // similar to .com's hsl(353, 100%, 97%)
 @github-diff-added:             fade(hsl(137, 100%, 55%), 15%); // similar to .com's hsl(137, 100%, 95%)


### PR DESCRIPTION
### Description of the Change

This styles the suggested changes in review comments.

### Screenshot/Gif

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/378023/53469639-169cd280-3aa2-11e9-9bc6-b0cc2adb3d95.png) | ![after](https://user-images.githubusercontent.com/378023/53469640-169cd280-3aa2-11e9-855c-d5bf30c3fa45.png)


### Alternate Designs

N/A

### Benefits

Looks less broken. Easier to see what the suggestion is.

### Possible Drawbacks

The diffs use the same colors for dark and light themes again. This could make certain themes look less optimized.

### Applicable Issues

Closes #1970

### Metrics

N/A

### Tests

1. Open a review comment that has a "suggested change".
2. Verify the suggested change looks styled.

### Documentation

N/A

### Release Notes

N/A

### User Experience Research (Optional)

N/A

