### PR TITLE
Fix bug expanding large-diff-gated patches with comments

### DIFF
--- a/lib/models/patch/multi-file-patch.js
+++ b/lib/models/patch/multi-file-patch.js
@@ -196,6 +196,10 @@ export default class MultiFilePatch {
     return Range.fromObject([[selectionRow, 0], [selectionRow, Infinity]]);
   }
 
+  isDiffRowOffsetIndexEmpty(filePatchPath) {
+    const diffRowOffsetIndex = this.diffRowOffsetIndices.get(filePatchPath);
+    return diffRowOffsetIndex.index.size === 0;
+  }
   populateDiffRowOffsetIndices(filePatch) {
     let diffRow = 1;
     const index = new RBTree((a, b) => a.diffRow - b.diffRow);
@@ -337,10 +341,9 @@ export default class MultiFilePatch {
       this.hunksByMarker.set(hunk.getMarker(), hunk);
     }
 
-    const diffRowOffsetIndex = this.diffRowOffsetIndices.get(filePatch.getPath());
     // if the patch was initially collapsed, we need to calculate
     // the diffRowOffsetIndices to calculate comment position.
-    if (diffRowOffsetIndex.index.size === 0) {
+    if (this.isDiffRowOffsetIndexEmpty(filePatch.getPath())) {
       this.populateDiffRowOffsetIndices(filePatch);
     }
   }

--- a/lib/models/patch/multi-file-patch.js
+++ b/lib/models/patch/multi-file-patch.js
@@ -336,7 +336,13 @@ export default class MultiFilePatch {
     for (const hunk of filePatch.getHunks()) {
       this.hunksByMarker.set(hunk.getMarker(), hunk);
     }
-    this.populateDiffRowOffsetIndices(filePatch);
+
+    const diffRowOffsetIndex = this.diffRowOffsetIndices.get(filePatch.getPath());
+    // if the patch was initially collapsed, we need to calculate
+    // the diffRowOffsetIndices to calculate comment position.
+    if (diffRowOffsetIndex.index.size === 0) {
+      this.populateDiffRowOffsetIndices(filePatch);
+    }
   }
 
   getMarkersBefore(filePatchIndex) {

--- a/lib/models/patch/multi-file-patch.js
+++ b/lib/models/patch/multi-file-patch.js
@@ -24,21 +24,7 @@ export default class MultiFilePatch {
       this.filePatchesByPath.set(filePatch.getPath(), filePatch);
       this.filePatchesByMarker.set(filePatch.getMarker(), filePatch);
 
-      let diffRow = 1;
-      const index = new RBTree((a, b) => a.diffRow - b.diffRow);
-      this.diffRowOffsetIndices.set(filePatch.getPath(), {startBufferRow: filePatch.getStartRange().start.row, index});
-
-      for (let hunkIndex = 0; hunkIndex < filePatch.getHunks().length; hunkIndex++) {
-        const hunk = filePatch.getHunks()[hunkIndex];
-        this.hunksByMarker.set(hunk.getMarker(), hunk);
-
-        // Advance past the hunk body
-        diffRow += hunk.bufferRowCount();
-        index.insert({diffRow, offset: hunkIndex + 1});
-
-        // Advance past the next hunk header
-        diffRow++;
-      }
+      this.populateDiffRowOffsetIndices(filePatch);
     }
   }
 
@@ -210,6 +196,24 @@ export default class MultiFilePatch {
     return Range.fromObject([[selectionRow, 0], [selectionRow, Infinity]]);
   }
 
+  populateDiffRowOffsetIndices(filePatch) {
+    let diffRow = 1;
+    const index = new RBTree((a, b) => a.diffRow - b.diffRow);
+    this.diffRowOffsetIndices.set(filePatch.getPath(), {startBufferRow: filePatch.getStartRange().start.row, index});
+
+    for (let hunkIndex = 0; hunkIndex < filePatch.getHunks().length; hunkIndex++) {
+      const hunk = filePatch.getHunks()[hunkIndex];
+      this.hunksByMarker.set(hunk.getMarker(), hunk);
+
+      // Advance past the hunk body
+      diffRow += hunk.bufferRowCount();
+      index.insert({diffRow, offset: hunkIndex + 1});
+
+      // Advance past the next hunk header
+      diffRow++;
+    }
+  }
+
   adoptBuffer(nextPatchBuffer) {
     nextPatchBuffer.clearAllLayers();
 
@@ -332,6 +336,7 @@ export default class MultiFilePatch {
     for (const hunk of filePatch.getHunks()) {
       this.hunksByMarker.set(hunk.getMarker(), hunk);
     }
+    this.populateDiffRowOffsetIndices(filePatch);
   }
 
   getMarkersBefore(filePatchIndex) {

--- a/test/models/patch/multi-file-patch.test.js
+++ b/test/models/patch/multi-file-patch.test.js
@@ -791,10 +791,10 @@ describe('MultiFilePatch', function() {
           fp.renderStatus(TOO_LARGE);
         })
         .build();
-      assert.strictEqual(multiFilePatch.diffRowOffsetIndices.get('1.txt').index.size, 0);
+      assert.isTrue(multiFilePatch.isDiffRowOffsetIndexEmpty('1.txt'));
       const [fp] = multiFilePatch.getFilePatches();
       multiFilePatch.expandFilePatch(fp);
-      assert.strictEqual(multiFilePatch.diffRowOffsetIndices.get('1.txt').index.size, 3);
+      assert.isFalse(multiFilePatch.isDiffRowOffsetIndexEmpty('1.txt'));
       assert.strictEqual(multiFilePatch.getBufferRowForDiffPosition('1.txt', 11), 9);
     });
 


### PR DESCRIPTION
### Description of the Change

Once upon a time, there was a bug where clicking "expand" on a file patch that exceeded the large diff gate size, that had comments, would throw a stacktrace.  Sadness!

@vanessayuenn and I determined that the root cause of this bug was that because large patches are initially collapsed, we were never populating the red and black tree used to keep track of the diff offset indices for comment placement.

Solution was to extract a function to populate the diff offset indices, and then call that function when expanding file patches.

### Screenshot/Gif

N/A

### Alternate Designs

None considered. 

### Benefits

Users can now expand large-diff-gated file patches that contain comments without errors and sadness.  (Well, I can't guarantee there will be no sadness.)

### Possible Drawbacks

Can't think of any drawbacks but if you can, I'm open to discussion.

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Metrics

N/A

### Tests

- Wrote unit test to ensure that:
  - we are only populating the `diffOffsetIndices` if it's empty
  - after expanding an initially-collapsed too large pass, calling `getBufferRowForDiffPosition` in fact gives us the correct buffer row.

- Manually testing expanding the file patch on https://github.com/kuychaco/test-repo/pull/7

### Documentation

Added one code comment like a champ. 

### Release Notes

This bug is for a feature that hasn't been released yet so I'm ok leaving it out of the release notes.

### User Experience Research (Optional)

N/A

