### PR TITLE
State management prototype

### DIFF
--- a/lib/courier.js
+++ b/lib/courier.js
@@ -1,0 +1,245 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Disposable} from 'event-kit';
+
+const Courier = React.createContext(null);
+
+class PostOffice {
+  constructor(parent) {
+    this.parent = parent;
+    this.providers = {};
+    this.subscriptionsByInstance = new Map();
+    this.dirty = new Set();
+  }
+
+  registerProviders(registerFn) {
+    registerFn({
+      provider: (name, callback) => {
+        if (!this.providers[name]) {
+          this.providers[name] = {
+            properties: {},
+          };
+        }
+
+        const provider = this.providers[name];
+
+        const initProperty = {
+          lastModel: undefined,
+          value: undefined,
+          loading: false,
+          error: null,
+          subscribers: new Set(),
+        };
+
+        callback({
+          syncProperty: (propertyName, getter) => {
+            provider.properties[propertyName] = {getter, async: false, ...initProperty};
+          },
+
+          asyncProperty: (propertyName, getter) => {
+            provider.properties[propertyName] = {getter, async: true, ...initProperty};
+          },
+        });
+      },
+    });
+  }
+
+  provideModel(name, model) {
+    const provider = this.providers[name];
+    for (const propertyName in provider.properties) {
+      const property = provider.properties[propertyName];
+      property.lastModel = model;
+      property.error = null;
+      const oldValue = property.value;
+
+      if (property.async) {
+        property.loading = true;
+        property.getter(model).then(value => {
+          if (property.lastModel === model) {
+            property.value = value;
+            property.loading = false;
+
+            if (!Object.is(value, oldValue)) {
+              for (const instance of property.subscribers) {
+                this.dirty.add(instance);
+              }
+              this.triggerUpdateForLoadedSubscribers(property);
+            }
+          }
+        }, error => {
+          if (property.lastModel === model) {
+            property.error = error;
+            property.loading = false;
+            this.triggerUpdateForLoadedSubscribers(property);
+          }
+        });
+      } else {
+        property.loading = false;
+        property.value = property.getter(model);
+        if (!Object.is(property.value, oldValue)) {
+          for (const instance of property.subscribers) {
+            this.dirty.add(instance);
+          }
+        }
+      }
+    }
+  }
+
+  bind(instance) {
+    let m = instance.m;
+    if (m) {
+      const parentIsLoading = m.isLoading;
+      m.isLoading = () => parentIsLoading() || this.subscriptionsByInstance.get(instance).some(p => p.loading);
+    } else {
+      m = {};
+      Object.defineProperty(instance, 'm', {
+        value: m,
+        writable: false,
+      });
+      m.isLoading = () => this.subscriptionsByInstance.get(instance).some(p => p.loading);
+    }
+
+    const channels = instance.constructor.mailbox;
+    const subscribedProperties = [];
+    for (const providerName in channels) {
+      const propertyNames = channels[providerName];
+
+      let p = m[providerName];
+      if (!p) {
+        p = {};
+        Object.defineProperty(m, providerName, {
+          value: p,
+          writable: false,
+        });
+      }
+
+      // TODO fail on unknown provider or property name
+      const provider = this.providers[providerName];
+      for (const propertyName of propertyNames) {
+        const property = provider.properties[propertyName];
+        property.subscribers.add(instance);
+        subscribedProperties.push(property);
+
+        Object.defineProperty(p, propertyName, {
+          get() { return property.value; },
+        });
+      }
+    }
+
+    this.subscriptionsByInstance.set(instance, subscribedProperties);
+    this.dirty.add(instance);
+
+    return new Disposable(() => {
+      for (const providerName in channels) {
+        const propertyNames = channels[providerName];
+
+        const provider = this.providers[providerName];
+        if (!provider) {
+          continue;
+        }
+
+        for (const propertyName of propertyNames) {
+          provider.properties[propertyName].subscribers.delete(instance);
+        }
+      }
+
+      this.subscriptionsByInstance.delete(instance);
+    });
+  }
+
+  triggerUpdates() {
+    return Promise.all(
+      Array.from(this.dirty, instance => new Promise(resolve => instance.forceUpdate(resolve))),
+    );
+  }
+
+  triggerUpdateForLoadedSubscribers(property) {
+    const promises = [];
+    for (const instance of property.subscribers) {
+      if (!this.subscriptionsByInstance.get(instance).some(p => p.loading)) {
+        promises.push(new Promise(resolve => instance.forceUpdate(resolve)));
+      }
+    }
+    return Promise.all(promises);
+  }
+
+  didRender(instance) {
+    this.dirty.delete(instance);
+  }
+}
+
+function installAround(proto, methodName, before, after) {
+  const existing = proto[methodName] || (() => {});
+  proto[methodName] = function(...args) {
+    if (before) { before.apply(this, args); }
+    const returnValue = existing.apply(this, args);
+    if (after) { after.apply(this, args); }
+    return returnValue;
+  };
+}
+
+function register(Component) {
+  // TODO fail if contextType is already set to something else
+  Component.contextType = Courier;
+
+  let bound = false;
+  let binding = new Disposable();
+
+  // eslint-disable-next-line prefer-arrow-callback
+  installAround(Component.prototype, 'render', function() {
+    if (!bound) {
+      binding = this.context.bind(this);
+      bound = true;
+    }
+  }, function() {
+    this.context.didRender(this);
+  });
+
+  installAround(Component.prototype, 'componentWillUnmount', null, () => {
+    binding.dispose();
+  });
+
+  return Component;
+}
+
+class Provider extends React.Component {
+  static contextType = Courier;
+
+  static propTypes = {
+    registerProviders: PropTypes.func.isRequired,
+    children: PropTypes.node,
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.office = new PostOffice(this.context);
+  }
+
+  render() {
+    this.office.registerProviders(this.props.registerProviders);
+
+    for (const propName in this.props) {
+      if (propName === 'registerProviders' || propName === 'children') {
+        continue;
+      }
+
+      this.office.provideModel(propName, this.props[propName]);
+    }
+
+    return (
+      <Courier.Provider value={this.office}>
+        {this.props.children}
+      </Courier.Provider>
+    );
+  }
+
+  componentDidUpdate() {
+    this.office.triggerUpdates();
+  }
+}
+
+export default {
+  Provider,
+  register,
+};

--- a/test/courier.test.js
+++ b/test/courier.test.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import Courier from '../lib/courier';
+
+describe('Courier', function() {
+  it('accesses requested synchronous properties', function() {
+    class Consumer extends React.Component {
+      static mailbox = {
+        atom: ['tooltips', 'config'],
+      }
+
+      render() {
+        return (
+          <div>
+            <p className="tooltips">{this.m.atom.tooltips}</p>
+            <p className="config">{this.m.atom.config}</p>
+          </div>
+        );
+      }
+    }
+
+    Courier.register(Consumer);
+
+    function registerProviders(courier) {
+      courier.provider('atom', c => {
+        c.syncProperty('tooltips', model => model.tooltips);
+        c.syncProperty('config', model => model.config);
+      });
+    }
+
+    const atomModel = {
+      tooltips: 'tooltips',
+      config: 'config',
+    };
+
+    const app = (
+      <Courier.Provider registerProviders={registerProviders} atom={atomModel}>
+        <Consumer />
+      </Courier.Provider>
+    );
+    const wrapper = mount(app);
+
+    assert.strictEqual(wrapper.find('.tooltips').text(), 'tooltips');
+    assert.strictEqual(wrapper.find('.config').text(), 'config');
+  });
+
+  it('accesses properties available asynchronously', async function() {
+    class Consumer extends React.Component {
+      static mailbox = {
+        repo: ['remotes', 'branches'],
+      }
+
+      render() {
+        if (this.m.isLoading()) {
+          return <div>Loading</div>;
+        }
+
+        return (
+          <div className="loaded">
+            <p className="remotes">{this.m.repo.remotes}</p>
+            <p className="branches">{this.m.repo.branches}</p>
+          </div>
+        );
+      }
+    }
+
+    Courier.register(Consumer);
+
+    function registerProviders(courier) {
+      courier.provider('repo', c => {
+        c.asyncProperty('remotes', model => model.getRemotes());
+        c.asyncProperty('branches', model => model.getBranches());
+      });
+    }
+
+    let resolveRemotes = () => {};
+    let resolveBranches = () => {};
+
+    const repoModel = {
+      getRemotes() {
+        return new Promise(resolve => { resolveRemotes = resolve; });
+      },
+
+      getBranches() {
+        return new Promise(resolve => { resolveBranches = resolve; });
+      },
+    };
+
+    const app = (
+      <Courier.Provider registerProviders={registerProviders} repo={repoModel}>
+        <Consumer />
+      </Courier.Provider>
+    );
+    const wrapper = mount(app);
+
+    assert.strictEqual(wrapper.find('div').text(), 'Loading');
+
+    resolveRemotes('remotes');
+    assert.strictEqual(wrapper.find('div').text(), 'Loading');
+
+    resolveBranches('branches');
+
+    await assert.async.isTrue(wrapper.update().exists('.loaded'));
+    assert.strictEqual(wrapper.find('.remotes').text(), 'remotes');
+    assert.strictEqual(wrapper.find('.branches').text(), 'branches');
+  });
+});


### PR DESCRIPTION
I've been musing about #1437 recently. This is a prototype for a possible context-based state management framework we could use to address our prop-drilling woes.

My specific goals for this are:

* Avoid contributing to "wrapper hell" or requiring nested higher-order components. These make it challenging to read the React dev tools or Enzyme's `.debug()` output.
* Producer and consumer components should both be easily testable by Enzyme using the shallow renderer.
* Subscribing to a collection of asynchronous properties should be a first-class concept. One of the primary use-cases of this is to consume the "current" Repository.
* Consider that properties may be expensive to fetch. Property values (synchronous or asynchronous) should only be evaluated when a child component that is currently rendered will actually consume them.
* The smallest subtrees that actually require a re-render on a property change should be re-rendered.
* Avoid unnecessary re-renders.

#### API

Here's a draft of the initial API that I've come up with:

```js
import React from 'react';

import Courier from '../courier';

export default class SomeView extends React.Component {
  static mailbox = {
    atom: ['tooltips', 'config'],
    repo: ['workingDirectory', 'remotes', 'branches'],
    login: ['token'],
  };

  render() {
    // true if *any* of the async properties are still being fetched
    if (this.m.isLoading()) {
      return <LoadingView />;
    }

    // Synchronous and asynchronous property values alike are available on `this.m`.
    return (
      <div>
        <p>{this.m.repo.workingDirectory}</p>
        <p>{this.m.repo.remotes.getHeadBranch().getName()</p>
      </div>
    );
  }
}

Courier.register(SomeView);
```

And on the provider side:

```js
import React from 'react';

import Courier from '../courier';

export default class SomeContainer {
  render() {
    return (
      <Courier.Provider
        registerProviders={this.registerProviders}
        atom={this.props.atomEnv}
        repo={this.props.repository}>
        <SomeChild />
      </Courier.Provider>
    );
  }

  registerProviders = courier => {
    courier.provider('atom', c => {
      c.syncProperty('tooltips', model => model.tooltips);
      c.syncProperty('config', model => model.config);
    });

    courier.provider('repo', c => {
      // Subscribe to "onDidUpdate" and re-evaluate properties when it fires
      c.observeModel();
      c.syncProperty('workingDirectory', model => model.getWorkingDirectoryPath());
      c.asyncProperty('remotes', model => model.getRemotes());
      c.asyncProperty('branches', model => model.getBranches());
    });
  }
}
```

#### Remaining

- [ ] Subscribe to model updates with `c.observeModel()`.
- [ ] Test coverage for the Courier to ensure we're working properly and rendering when we expect to render.
- [ ] Figure out how to allow nested providers.
- [ ] Come up with a better name if we don't like the post office / mailbox / courier metaphor.

_External factors_

- [ ] Feedback from @atom/github-package :smile:.
- [ ] Enzyme doesn't support `static contextType` yet, but it's underway. See airbnb/enzyme#1913 and airbnb/enzyme#1553.
