### PR TITLE
Hide alt text when committer's avatar fails to load

### DIFF
--- a/styles/recent-commits.less
+++ b/styles/recent-commits.less
@@ -44,8 +44,10 @@
     width: @size;
     height: @size;
     border-radius: @component-border-radius;
+    color: transparent;
     background-color: mix(@text-color, @base-background-color, 15%);
     box-shadow: 1px 0 @base-background-color;
+    overflow: hidden;
     transition: margin .12s cubic-bezier(.5,.1,0,1);
 
     &:nth-child(1) { z-index: 3; }


### PR DESCRIPTION
### Description of the Change

When we start Atom with no internet connectivity, committer's email address is shown in the place of committer's avatar in recent comments list in Git pane, which overlaps git messages and makes them hard to read. I have hidden alt text setting text color to transparent and overflow to hidden for the image element. This leaves an empty box instead of showing committer's email address when avatar fails to load and doesn't make any visual change when avatar is visible.

### Screenshot/Gif

![image](https://user-images.githubusercontent.com/12229032/56117098-01fa9800-5f85-11e9-9d9c-ad7db915d9a4.png)

![image](https://user-images.githubusercontent.com/12229032/56117087-fb6c2080-5f84-11e9-8115-267088bfb74b.png)

### Alternate Designs

Alternatively we can show a default avatar but I went for just hiding the alt text as it was easy to implement.

### Benefits

Commits list no longer looks weird when Atom is started with no internet.

### Possible Drawbacks

Nothing I can think of.

### Applicable Issues

#1528

### Metrics

N/A

### Tests

N/A

### Documentation

N/A

### Release Notes

Fixed an issue where committer's email address is shown in the place of committer's avatar when Atom is started with no internet connection.
