### PR TITLE
whitelist a bunch of dependencies (or: Let's Trust Bots To Not Mess Things Up)

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,31 @@
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) up to date as soon as
+  # new versions are published to the npm registry
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+
+    # Automerge all whitelisted dependency updates (after CI passes)
+    automerged_updates:
+      - match:
+          dependency_name: "*mocha*"
+          update_type: "all"
+      - match:
+          dependency_name: "chai*"
+          update_type: "all"
+      - match:
+          dependency_name: "enzyme*"
+          update_type: "all"
+      - match:
+          dependency_name: "eslint*"
+          update_type: "all"
+      - match:
+          dependency_name: "sinon"
+          update_type: "all"
+      - match:
+          dependency_name: "semver"
+          update_type: "all"
+      - match:
+          dependency_name: "test-until"
+          update_type: "all"


### PR DESCRIPTION
These are the "safest" dependencies to update automatically -- they are only used in tests, so we can trust that as long as tests are passing in CI, they should be good to merge. 