### PR TITLE
Prefill some metadata for report abuse link in review comments

### DIFF
--- a/lib/views/reviews-view.js
+++ b/lib/views/reviews-view.js
@@ -537,7 +537,7 @@ export default class ReviewsView extends React.Component {
               <span className="github-Review-pendingBadge badge badge-warning">pending</span>
             )}
           </div>
-          <a className="github-Review-reportAbuseLink" title="report abuse" href="https://github.com/contact/report-content">
+          <a className="github-Review-reportAbuseLink" title="report abuse" href={`https://github.com/contact/report-content?report=${comment.author.login}&content_url=${encodeURIComponent(comment.url)}`}>
             <Octicon icon="alert" />
           </a>
         </header>

--- a/lib/views/reviews-view.js
+++ b/lib/views/reviews-view.js
@@ -540,7 +540,7 @@ export default class ReviewsView extends React.Component {
               <span className="github-Review-pendingBadge badge badge-warning">pending</span>
             )}
           </div>
-          <a className="github-Review-reportAbuseLink" title="report abuse" href={`https://github.com/contact/report-content?report=${comment.author.login}&content_url=${encodeURIComponent(comment.url)}`}>
+          <a className="github-Review-reportAbuseLink" title="report abuse" href={`https://github.com/contact/report-content?report=${commentAuthor.login}&content_url=${encodeURIComponent(comment.url)}`}>
             <Octicon icon="alert" />
           </a>
         </header>

--- a/lib/views/reviews-view.js
+++ b/lib/views/reviews-view.js
@@ -260,15 +260,15 @@ export default class ReviewsView extends React.Component {
       return null;
     }
 
-    const reviewAuthor = review.author ? review.author.login : '';
+    const reviewAuthor = {avatarUrl: '', login: '', ...review.author};
     return (
       <div className="github-ReviewSummary" key={review.id}>
         <header className="github-ReviewSummary-header">
           <span className={`github-ReviewSummary-icon icon ${icon}`} />
           <img className="github-ReviewSummary-avatar"
-            src={review.author ? review.author.avatarUrl : ''} alt={reviewAuthor}
+            src={reviewAuthor.avatarUrl} alt={reviewAuthor.login}
           />
-          <a className="github-ReviewSummary-username" href={`https://github.com/${reviewAuthor}`}>{reviewAuthor}</a>
+          <a className="github-ReviewSummary-username" href={`https://github.com/${reviewAuthor.login}`}>{reviewAuthor.login}</a>
           <span className="github-ReviewSummary-type">{copy}</span>
           {this.renderEditedLink(review)}
           <Timeago className="github-ReviewSummary-timeAgo" time={review.submittedAt} displayStyle="short" />
@@ -370,6 +370,8 @@ export default class ReviewsView extends React.Component {
       }
     };
 
+    const rootCommentAuthor = {avatarUrl: '', login: '', ...rootComment.author};
+
     return (
       <details
         ref={threadHolder.setter}
@@ -383,7 +385,7 @@ export default class ReviewsView extends React.Component {
           <span className="github-Review-file">{dir ? path.sep : ''}{base}</span>
           <span className="github-Review-lineNr">{positionText}</span>
           <img className="github-Review-referenceAvatar"
-            src={rootComment.author ? rootComment.author.avatarUrl : ''} alt={rootComment.author.login}
+            src={rootCommentAuthor.avatarUrl} alt={rootCommentAuthor.login}
           />
           <Timeago className="github-Review-referenceTimeAgo" time={rootComment.createdAt} displayStyle="short" />
         </summary>
@@ -519,15 +521,16 @@ export default class ReviewsView extends React.Component {
     }
 
     const commentClass = cx('github-Review-comment', {'github-Review-comment--pending': comment.state === 'PENDING'});
+    const commentAuthor = {avatarUrl: '', login: '', ...comment.author};
     return (
       <div className={commentClass} key={comment.id}>
         <header className="github-Review-header">
           <div className="github-Review-header-authorData">
             <img className="github-Review-avatar"
-              src={comment.author ? comment.author.avatarUrl : ''} alt={comment.author.login}
+              src={commentAuthor.avatarUrl} alt={commentAuthor.login}
             />
-            <a className="github-Review-username" href={`https://github.com/${comment.author.login}`}>
-              {comment.author.login}
+            <a className="github-Review-username" href={`https://github.com/${commentAuthor.login}`}>
+              {commentAuthor.login}
             </a>
             <a className="github-Review-timeAgo" href={comment.url}>
               <Timeago displayStyle="long" time={comment.createdAt} />


### PR DESCRIPTION
A piece of the feedback (#2056) we got from community & safety audit for the recently shipped review comments feature (#1995) suggests that the "report abuse" link in the review comment should include some metadata, so that important info can be prefilled. 