### PR TITLE
Additional entry point for review comments

### DIFF
--- a/lib/containers/current-pull-request-container.js
+++ b/lib/containers/current-pull-request-container.js
@@ -147,7 +147,6 @@ export default class CurrentPullRequestContainer extends React.Component {
         results={associatedPullRequests.nodes}
         isLoading={false}
         workspace={this.props.workspace}
-        workingDirectory={this.props.workingDirectory}
         endpoint={this.props.endpoint}
         resultFilter={issueish => issueish.getHeadRepositoryID() === this.props.repository.id}
         {...this.controllerProps()}
@@ -176,9 +175,10 @@ export default class CurrentPullRequestContainer extends React.Component {
     return {
       title: 'Checked out pull request',
       onOpenIssueish: this.props.onOpenIssueish,
+      onOpenReviews: this.props.onOpenReviews,
       emptyComponent: this.renderEmptyTile,
       needReviewsButton: true,
-      workingDirectory: this.props.workingDirectory,
+      workdir: this.props.workingDirectory,
     };
   }
 }

--- a/lib/containers/current-pull-request-container.js
+++ b/lib/containers/current-pull-request-container.js
@@ -38,7 +38,6 @@ export default class CurrentPullRequestContainer extends React.Component {
     pushInProgress: PropTypes.bool.isRequired,
 
     workspace: PropTypes.object.isRequired,
-    workingDirectory: PropTypes.string.isRequired,
 
     // Actions
     onOpenIssueish: PropTypes.func.isRequired,
@@ -179,7 +178,6 @@ export default class CurrentPullRequestContainer extends React.Component {
       onOpenReviews: this.props.onOpenReviews,
       emptyComponent: this.renderEmptyTile,
       needReviewsButton: true,
-      workdir: this.props.workingDirectory,
     };
   }
 }

--- a/lib/containers/current-pull-request-container.js
+++ b/lib/containers/current-pull-request-container.js
@@ -42,6 +42,7 @@ export default class CurrentPullRequestContainer extends React.Component {
 
     // Actions
     onOpenIssueish: PropTypes.func.isRequired,
+    onOpenReviews: PropTypes.func.isRequired,
     onCreatePr: PropTypes.func.isRequired,
   }
 

--- a/lib/containers/issueish-search-container.js
+++ b/lib/containers/issueish-search-container.js
@@ -22,6 +22,7 @@ export default class IssueishSearchContainer extends React.Component {
     // Action methods
     onOpenIssueish: PropTypes.func.isRequired,
     onOpenSearch: PropTypes.func.isRequired,
+    onOpenReviews: PropTypes.func.isRequired,
   }
 
   static defaultProps = {

--- a/lib/containers/issueish-search-container.js
+++ b/lib/containers/issueish-search-container.js
@@ -116,6 +116,7 @@ export default class IssueishSearchContainer extends React.Component {
       title: this.props.search.getName(),
 
       onOpenIssueish: this.props.onOpenIssueish,
+      onOpenReviews: this.props.onOpenReviews,
       onOpenMore: () => this.props.onOpenSearch(this.props.search),
     };
   }

--- a/lib/containers/issueish-search-container.js
+++ b/lib/containers/issueish-search-container.js
@@ -119,6 +119,7 @@ export default class IssueishSearchContainer extends React.Component {
       onOpenIssueish: this.props.onOpenIssueish,
       onOpenReviews: this.props.onOpenReviews,
       onOpenMore: () => this.props.onOpenSearch(this.props.search),
+      workdir: '',
     };
   }
 }

--- a/lib/containers/issueish-search-container.js
+++ b/lib/containers/issueish-search-container.js
@@ -119,7 +119,6 @@ export default class IssueishSearchContainer extends React.Component {
       onOpenIssueish: this.props.onOpenIssueish,
       onOpenReviews: this.props.onOpenReviews,
       onOpenMore: () => this.props.onOpenSearch(this.props.search),
-      workdir: '',
     };
   }
 }

--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -90,23 +90,6 @@ export class BareIssueishListController extends React.Component {
     return null;
   }
 
-  openReviews = async () => {
-    /* istanbul ignore next */
-    if (this.props.results.length < 1) {
-      return;
-    }
-    const result = this.props.results[0];
-    const uri = ReviewsItem.buildURI({
-      host: this.props.endpoint.getHost(),
-      owner: result.repository.owner.login,
-      repo: result.repository.name,
-      number: result.number,
-      workdir: this.props.workingDirectory,
-    });
-    await this.props.workspace.open(uri);
-    addEvent('open-reviews-tab', {package: 'github', from: this.constructor.name});
-  }
-
   render() {
     return (
       <IssueishListView

--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -5,6 +5,7 @@ import {EndpointPropType} from '../prop-types';
 import IssueishListView from '../views/issueish-list-view';
 import Issueish from '../models/issueish';
 import {shell} from 'electron';
+import {addEvent} from '../reporter-proxy';
 
 const StatePropType = PropTypes.oneOf(['EXPECTED', 'PENDING', 'SUCCESS', 'ERROR', 'FAILURE']);
 
@@ -90,10 +91,13 @@ export class BareIssueishListController extends React.Component {
     return null;
   }
 
-  openOnGitHub = issueish => {
+  openOnGitHub = url => {
     return new Promise((resolve, reject) => {
-      shell.openExternal(issueish.getGitHubURL(), {}, err => {
-        if (err) { reject(err); } else { resolve(); }
+      shell.openExternal(url, {}, err => {
+        if (err) { reject(err); } else {
+          resolve();
+          addEvent('open-issueish-in-browser', {package: 'github', component: this.constructor.name});
+        }
       });
     });
   }

--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -56,7 +56,7 @@ export class BareIssueishListController extends React.Component {
     emptyComponent: PropTypes.func,
     workspace: PropTypes.object,
     endpoint: EndpointPropType,
-    workingDirectory: PropTypes.string,
+    workdir: PropTypes.string.isRequired,
     needReviewsButton: PropTypes.bool,
   };
 
@@ -118,7 +118,7 @@ export class BareIssueishListController extends React.Component {
         needReviewsButton={this.props.needReviewsButton}
         onIssueishClick={this.props.onOpenIssueish}
         onMoreClick={this.props.onOpenMore}
-        openReviews={this.openReviews}
+        openReviews={this.props.onOpenReviews}
         emptyComponent={this.props.emptyComponent}
       />
     );

--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -4,6 +4,7 @@ import {graphql, createFragmentContainer} from 'react-relay';
 import {EndpointPropType} from '../prop-types';
 import IssueishListView from '../views/issueish-list-view';
 import Issueish from '../models/issueish';
+import {shell} from 'electron';
 
 const StatePropType = PropTypes.oneOf(['EXPECTED', 'PENDING', 'SUCCESS', 'ERROR', 'FAILURE']);
 
@@ -89,6 +90,14 @@ export class BareIssueishListController extends React.Component {
     return null;
   }
 
+  openOnGitHub = issueish => {
+    return new Promise((resolve, reject) => {
+      shell.openExternal(issueish.getGitHubURL(), {}, err => {
+        if (err) { reject(err); } else { resolve(); }
+      });
+    });
+  }
+
   render() {
     return (
       <IssueishListView
@@ -101,6 +110,7 @@ export class BareIssueishListController extends React.Component {
         onIssueishClick={this.props.onOpenIssueish}
         onMoreClick={this.props.onOpenMore}
         openReviews={this.props.onOpenReviews}
+        openOnGitHub={this.openOnGitHub}
         emptyComponent={this.props.emptyComponent}
       />
     );

--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -4,8 +4,6 @@ import {graphql, createFragmentContainer} from 'react-relay';
 import {EndpointPropType} from '../prop-types';
 import IssueishListView from '../views/issueish-list-view';
 import Issueish from '../models/issueish';
-import ReviewsItem from '../items/reviews-item';
-import {addEvent} from '../reporter-proxy';
 
 const StatePropType = PropTypes.oneOf(['EXPECTED', 'PENDING', 'SUCCESS', 'ERROR', 'FAILURE']);
 
@@ -51,6 +49,7 @@ export class BareIssueishListController extends React.Component {
 
     resultFilter: PropTypes.func,
     onOpenIssueish: PropTypes.func.isRequired,
+    onOpenReviews: PropTypes.func.isRequired,
     onOpenMore: PropTypes.func,
 
     emptyComponent: PropTypes.func,

--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -58,7 +58,6 @@ export class BareIssueishListController extends React.Component {
     emptyComponent: PropTypes.func,
     workspace: PropTypes.object,
     endpoint: EndpointPropType,
-    workdir: PropTypes.string.isRequired,
     needReviewsButton: PropTypes.bool,
   };
 

--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -4,7 +4,8 @@ import {graphql, createFragmentContainer} from 'react-relay';
 import {EndpointPropType} from '../prop-types';
 import IssueishListView from '../views/issueish-list-view';
 import Issueish from '../models/issueish';
-import {shell} from 'electron';
+import {shell, remote} from 'electron';
+const {Menu, MenuItem} = remote;
 import {addEvent} from '../reporter-proxy';
 
 const StatePropType = PropTypes.oneOf(['EXPECTED', 'PENDING', 'SUCCESS', 'ERROR', 'FAILURE']);
@@ -100,6 +101,23 @@ export class BareIssueishListController extends React.Component {
         }
       });
     });
+  }
+
+  /* istanbul ignore next */
+  showActionsMenu(event, issueish) {
+    const menu = new Menu();
+
+    menu.append(new MenuItem({
+      label: 'See reviews',
+      click: () => this.props.onOpenReviews(issueish),
+    }));
+
+    menu.append(new MenuItem({
+      label: 'Open on GitHub',
+      click: () => this.openOnGitHub(issueish.getGitHubURL()),
+    }));
+
+    menu.popup(remote.getCurrentWindow());
   }
 
   render() {

--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -103,7 +103,7 @@ export class BareIssueishListController extends React.Component {
   }
 
   /* istanbul ignore next */
-  showActionsMenu(event, issueish) {
+  showActionsMenu = (event, issueish) => {
     const menu = new Menu();
 
     menu.append(new MenuItem({

--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -132,6 +132,7 @@ export class BareIssueishListController extends React.Component {
         onMoreClick={this.props.onOpenMore}
         openReviews={this.props.onOpenReviews}
         openOnGitHub={this.openOnGitHub}
+        showActionsMenu={this.showActionsMenu}
         emptyComponent={this.props.emptyComponent}
       />
     );

--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -102,8 +102,8 @@ export class BareIssueishListController extends React.Component {
     });
   }
 
-  /* istanbul ignore next */
   showActionsMenu = issueish => {
+    /* istanbul ignore next */
     const menu = new Menu();
 
     menu.append(new MenuItem({

--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -102,8 +102,7 @@ export class BareIssueishListController extends React.Component {
     });
   }
 
-  showActionsMenu = issueish => {
-    /* istanbul ignore next */
+  showActionsMenu = /* istanbul ignore next */ issueish => {
     const menu = new Menu();
 
     menu.append(new MenuItem({

--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -103,7 +103,7 @@ export class BareIssueishListController extends React.Component {
   }
 
   /* istanbul ignore next */
-  showActionsMenu = (event, issueish) => {
+  showActionsMenu = issueish => {
     const menu = new Menu();
 
     menu.append(new MenuItem({

--- a/lib/controllers/issueish-searches-controller.js
+++ b/lib/controllers/issueish-searches-controller.js
@@ -9,6 +9,7 @@ import Search from '../models/search';
 import IssueishSearchContainer from '../containers/issueish-search-container';
 import CurrentPullRequestContainer from '../containers/current-pull-request-container';
 import IssueishDetailItem from '../items/issueish-detail-item';
+import ReviewsItem from '../items/reviews-item';
 import {addEvent} from '../reporter-proxy';
 
 export default class IssueishSearchesController extends React.Component {
@@ -68,6 +69,7 @@ export default class IssueishSearchesController extends React.Component {
           workspace={this.props.workspace}
           workingDirectory={this.props.workingDirectory}
           onOpenIssueish={this.onOpenIssueish}
+          onOpenReviews={this.onOpenReviews}
           onCreatePr={this.props.onCreatePr}
         />
         {this.state.searches.map(search => (
@@ -81,10 +83,25 @@ export default class IssueishSearchesController extends React.Component {
 
             onOpenIssueish={this.onOpenIssueish}
             onOpenSearch={this.onOpenSearch}
+            onOpenReviews={this.onOpenReviews}
           />
         ))}
       </div>
     );
+  }
+
+  onOpenReviews = issueish => {
+    const uri = ReviewsItem.buildURI({
+      host: this.props.endpoint.getHost(),
+      owner: this.props.remote.getOwner(),
+      repo: this.props.remote.getRepo(),
+      number: issueish.getNumber(),
+      workdir: this.props.workingDirectory,
+    });
+    return this.props.workspace.open(uri).then(() => {
+      // TODO: specify if from button or context menu?
+      addEvent('open-reviews-tab', {package: 'github', from: this.constructor.name});
+    });
   }
 
   onOpenIssueish = issueish => {

--- a/lib/controllers/issueish-searches-controller.js
+++ b/lib/controllers/issueish-searches-controller.js
@@ -99,7 +99,6 @@ export default class IssueishSearchesController extends React.Component {
       workdir: this.props.workingDirectory,
     });
     return this.props.workspace.open(uri).then(() => {
-      // TODO: specify if from button or context menu?
       addEvent('open-reviews-tab', {package: 'github', from: this.constructor.name});
     });
   }

--- a/lib/views/issueish-list-view.js
+++ b/lib/views/issueish-list-view.js
@@ -58,13 +58,16 @@ export default class IssueishListView extends React.Component {
   }
 
   renderReviewsButton = () => {
-    if (!this.props.needReviewsButton || this.props.total < 1) {
+    if (!this.props.needReviewsButton || this.props.issueishes.length < 1) {
       return null;
     }
     return (
       <button
         className="btn btn-primary btn-sm github-IssueishList-openReviewsButton"
-        onClick={this.openReviews}>
+        onClick={e => {
+          e.stopPropagation();
+          this.props.openReviews(this.props.issueishes[0]);
+        }}>
         See reviews
       </button>
     );

--- a/lib/views/issueish-list-view.js
+++ b/lib/views/issueish-list-view.js
@@ -26,7 +26,9 @@ export default class IssueishListView extends React.Component {
     needReviewsButton: PropTypes.bool,
     onIssueishClick: PropTypes.func.isRequired,
     onMoreClick: PropTypes.func,
-    openReviews: PropTypes.func,
+    openReviews: PropTypes.func.isRequired,
+    openOnGitHub: PropTypes.func.isRequired,
+    showActionsMenu: PropTypes.func.isRequired,
 
     emptyComponent: PropTypes.func,
     error: PropTypes.object,

--- a/lib/views/issueish-list-view.js
+++ b/lib/views/issueish-list-view.js
@@ -1,7 +1,5 @@
 import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
-import {remote} from 'electron';
-const {Menu, MenuItem} = remote;
 
 import {autobind} from '../helpers';
 import {IssueishPropType} from '../prop-types';

--- a/lib/views/issueish-list-view.js
+++ b/lib/views/issueish-list-view.js
@@ -1,5 +1,7 @@
 import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
+import {remote} from 'electron';
+const {Menu, MenuItem} = remote;
 
 import {autobind} from '../helpers';
 import {IssueishPropType} from '../prop-types';
@@ -68,9 +70,18 @@ export default class IssueishListView extends React.Component {
     );
   }
 
-  openReviews = e => {
-    e.stopPropagation();
-    this.props.openReviews();
+  showActionsMenu(event, issueish) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const menu = new Menu();
+
+    menu.append(new MenuItem({
+      label: 'See reviews',
+      click: () => this.props.openReviews(issueish),
+    }));
+
+    menu.popup(remote.getCurrentWindow());
   }
 
   renderIssueish(issueish) {
@@ -96,6 +107,7 @@ export default class IssueishListView extends React.Component {
         />
         <Octicon icon="ellipses"
           className="github-IssueishList-item github-IssueishList-item--menu"
+          onClick={event => this.showActionsMenu(event, issueish)}
         />
       </Fragment>
     );

--- a/lib/views/issueish-list-view.js
+++ b/lib/views/issueish-list-view.js
@@ -94,6 +94,9 @@ export default class IssueishListView extends React.Component {
           displayStyle="short"
           className="github-IssueishList-item github-IssueishList-item--age"
         />
+        <Octicon icon="ellipses"
+          className="github-IssueishList-item github-IssueishList-item--menu"
+        />
       </Fragment>
     );
   }

--- a/lib/views/issueish-list-view.js
+++ b/lib/views/issueish-list-view.js
@@ -1,6 +1,6 @@
 import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
-import {remote} from 'electron';
+import {remote, shell} from 'electron';
 const {Menu, MenuItem} = remote;
 
 import {autobind} from '../helpers';
@@ -84,7 +84,20 @@ export default class IssueishListView extends React.Component {
       click: () => this.props.openReviews(issueish),
     }));
 
+    menu.append(new MenuItem({
+      label: 'Open on GitHub',
+      click: () => this.onOpenIssueish(issueish),
+    }));
+
     menu.popup(remote.getCurrentWindow());
+  }
+
+  onOpenIssueish = issueish => {
+    return new Promise((resolve, reject) => {
+      shell.openExternal(issueish.getGitHubURL(), {}, err => {
+        if (err) { reject(err); } else { resolve(); }
+      });
+    });
   }
 
   renderIssueish(issueish) {

--- a/lib/views/issueish-list-view.js
+++ b/lib/views/issueish-list-view.js
@@ -73,6 +73,7 @@ export default class IssueishListView extends React.Component {
     );
   }
 
+  /* istanbul ignore next */
   showActionsMenu(event, issueish) {
     event.preventDefault();
     event.stopPropagation();

--- a/lib/views/issueish-list-view.js
+++ b/lib/views/issueish-list-view.js
@@ -1,6 +1,6 @@
 import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
-import {remote, shell} from 'electron';
+import {remote} from 'electron';
 const {Menu, MenuItem} = remote;
 
 import {autobind} from '../helpers';
@@ -87,18 +87,10 @@ export default class IssueishListView extends React.Component {
 
     menu.append(new MenuItem({
       label: 'Open on GitHub',
-      click: () => this.onOpenIssueish(issueish),
+      click: () => this.props.openOnGitHub(issueish),
     }));
 
     menu.popup(remote.getCurrentWindow());
-  }
-
-  onOpenIssueish = issueish => {
-    return new Promise((resolve, reject) => {
-      shell.openExternal(issueish.getGitHubURL(), {}, err => {
-        if (err) { reject(err); } else { resolve(); }
-      });
-    });
   }
 
   renderIssueish(issueish) {

--- a/lib/views/issueish-list-view.js
+++ b/lib/views/issueish-list-view.js
@@ -73,26 +73,6 @@ export default class IssueishListView extends React.Component {
     );
   }
 
-  /* istanbul ignore next */
-  showActionsMenu(event, issueish) {
-    event.preventDefault();
-    event.stopPropagation();
-
-    const menu = new Menu();
-
-    menu.append(new MenuItem({
-      label: 'See reviews',
-      click: () => this.props.openReviews(issueish),
-    }));
-
-    menu.append(new MenuItem({
-      label: 'Open on GitHub',
-      click: () => this.props.openOnGitHub(issueish),
-    }));
-
-    menu.popup(remote.getCurrentWindow());
-  }
-
   renderIssueish(issueish) {
     return (
       <Fragment>
@@ -120,6 +100,13 @@ export default class IssueishListView extends React.Component {
         />
       </Fragment>
     );
+  }
+
+  showActionsMenu(event, issueish) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.props.showActionsMenu(issueish);
   }
 
   renderStatusSummary(statusCounts) {

--- a/lib/views/issueish-list-view.js
+++ b/lib/views/issueish-list-view.js
@@ -64,13 +64,15 @@ export default class IssueishListView extends React.Component {
     return (
       <button
         className="btn btn-primary btn-sm github-IssueishList-openReviewsButton"
-        onClick={e => {
-          e.stopPropagation();
-          this.props.openReviews(this.props.issueishes[0]);
-        }}>
+        onClick={this.openReviews}>
         See reviews
       </button>
     );
+  }
+
+  openReviews = e => {
+    e.stopPropagation();
+    this.props.openReviews(this.props.issueishes[0]);
   }
 
   renderIssueish(issueish) {

--- a/styles/issueish-list-view.less
+++ b/styles/issueish-list-view.less
@@ -63,6 +63,11 @@
       text-align: center;
     }
 
+    &--menu {
+      color: @text-color-subtle;
+      transform: rotate(90deg);
+    }
+
   }
 
   &-more {

--- a/styles/issueish-list-view.less
+++ b/styles/issueish-list-view.less
@@ -65,7 +65,7 @@
 
     &--menu {
       color: @text-color-subtle;
-      transform: rotate(90deg);
+      line-height: 1;
     }
 
   }

--- a/test/controllers/issueish-list-controller.test.js
+++ b/test/controllers/issueish-list-controller.test.js
@@ -4,8 +4,6 @@ import {shallow} from 'enzyme';
 import {createPullRequestResult} from '../fixtures/factories/pull-request-result';
 import Issueish from '../../lib/models/issueish';
 import {BareIssueishListController} from '../../lib/controllers/issueish-list-controller';
-import {getEndpoint} from '../../lib/models/endpoint';
-import * as reporterProxy from '../../lib/reporter-proxy';
 
 describe('IssueishListController', function() {
 

--- a/test/controllers/issueish-list-controller.test.js
+++ b/test/controllers/issueish-list-controller.test.js
@@ -84,23 +84,4 @@ describe('IssueishListController', function() {
     assert.strictEqual(view.prop('total'), 5);
     assert.deepEqual(view.prop('issueishes').map(issueish => issueish.getNumber()), [11, 13, 12]);
   });
-
-  it('opens reviews', async function() {
-    const atomEnv = global.buildAtomEnvironment();
-    sinon.stub(atomEnv.workspace, 'open').resolves();
-    sinon.stub(reporterProxy, 'addEvent');
-    const pr = createPullRequestResult({number: 1337});
-    Object.assign(pr.repository, {owner: {login: 'owner'}, name: 'repo'});
-    const wrapper = shallow(buildApp({
-      workspace: atomEnv.workspace,
-      endpoint: getEndpoint('github.com'),
-      results: [pr],
-    }));
-
-    await wrapper.find('IssueishListView').prop('openReviews')();
-    assert.isTrue(atomEnv.workspace.open.called);
-    assert.isTrue(reporterProxy.addEvent.calledWith('open-reviews-tab', {package: 'github', from: 'BareIssueishListController'}));
-
-    atomEnv.destroy();
-  });
 });

--- a/test/controllers/issueish-list-controller.test.js
+++ b/test/controllers/issueish-list-controller.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
+import {shell} from 'electron';
 
 import {createPullRequestResult} from '../fixtures/factories/pull-request-result';
 import Issueish from '../../lib/models/issueish';
@@ -82,4 +83,18 @@ describe('IssueishListController', function() {
     assert.strictEqual(view.prop('total'), 5);
     assert.deepEqual(view.prop('issueishes').map(issueish => issueish.getNumber()), [11, 13, 12]);
   });
+
+  describe('openOnGitHub', function() {
+    const url = 'https://github.com/atom/github/pull/2084';
+
+    it('calls shell.openExternal with specified url', async function() {
+      const wrapper = shallow(buildApp());
+      sinon.stub(shell, 'openExternal').callsArg(2);
+
+      await wrapper.instance().openOnGitHub(url);
+      assert.equal(shell.openExternal.args[0][0], url);
+    });
+    });
+  });
+
 });

--- a/test/controllers/issueish-list-controller.test.js
+++ b/test/controllers/issueish-list-controller.test.js
@@ -93,7 +93,7 @@ describe('IssueishListController', function() {
       sinon.stub(shell, 'openExternal').callsArg(2);
 
       await wrapper.instance().openOnGitHub(url);
-      assert.equal(shell.openExternal.args[0][0], url);
+      assert.isTrue(shell.openExternal.calledWith(url));
     });
 
     it('fires `open-issueish-in-browser` event upon success', async function() {

--- a/test/controllers/issueish-list-controller.test.js
+++ b/test/controllers/issueish-list-controller.test.js
@@ -102,7 +102,7 @@ describe('IssueishListController', function() {
       sinon.stub(reporterProxy, 'addEvent');
 
       await wrapper.instance().openOnGitHub(url);
-      assert.equal(reporterProxy.addEvent.callCount, 1);
+      assert.strictEqual(reporterProxy.addEvent.callCount, 1);
 
       await assert.isTrue(reporterProxy.addEvent.calledWith('open-issueish-in-browser', {package: 'github', component: 'BareIssueishListController'}));
     });
@@ -115,9 +115,9 @@ describe('IssueishListController', function() {
       try {
         await wrapper.instance().openOnGitHub(url);
       } catch (err) {
-        assert.equal(err.message, 'oh noes');
+        assert.strictEqual(err.message, 'oh noes');
       }
-      assert.equal(reporterProxy.addEvent.callCount, 0);
+      assert.strictEqual(reporterProxy.addEvent.callCount, 0);
     });
   });
 

--- a/test/controllers/issueish-searches-controller.test.js
+++ b/test/controllers/issueish-searches-controller.test.js
@@ -115,4 +115,29 @@ describe('IssueishSearchesController', function() {
     );
     assert.isTrue(reporterProxy.addEvent.calledWith('open-issueish-in-pane', {package: 'github', from: 'issueish-list'}));
   });
+
+  it('passes a handler to open reviews and reports an event', async function() {
+    sinon.spy(atomEnv.workspace, 'open');
+
+    const wrapper = shallow(buildApp());
+    const container = wrapper.find('IssueishSearchContainer').at(0);
+
+    const issueish = new Issueish({
+      number: 2084,
+      url: 'https://github.com/atom/github/pull/2084',
+      author: {login: 'kuychaco', avatarUrl: 'https://avatars3.githubusercontent.com/u/7910250?v=4'},
+      createdAt: '2019-04-01T10:00:00',
+      repository: {id: '0'},
+      commits: {nodes: []},
+    });
+
+    sinon.stub(reporterProxy, 'addEvent');
+    await container.prop('onOpenReviews')(issueish);
+    assert.isTrue(
+      atomEnv.workspace.open.calledWith(
+        `atom-github://reviews/github.com/atom/github/2084?workdir=${encodeURIComponent(__dirname)}`,
+      ),
+    );
+    assert.isTrue(reporterProxy.addEvent.calledWith('open-reviews-tab', {package: 'github', from: 'IssueishSearchesController'}));
+  });
 });

--- a/test/views/issueish-list-view.test.js
+++ b/test/views/issueish-list-view.test.js
@@ -145,7 +145,7 @@ describe('IssueishListView', function() {
 
   it('renders review button only if needed', function() {
     const openReviews = sinon.spy();
-    const wrapper = mount(buildApp({total: 1, openReviews}));
+    const wrapper = mount(buildApp({issueishes: [allGreen], openReviews}));
     assert.isFalse(wrapper.find('.github-IssueishList-openReviewsButton').exists());
 
     wrapper.setProps({needReviewsButton: true});

--- a/test/views/issueish-list-view.test.js
+++ b/test/views/issueish-list-view.test.js
@@ -141,6 +141,20 @@ describe('IssueishListView', function() {
       wrapper.find('.github-IssueishList-more a').simulate('click');
       assert.isTrue(onMoreClick.called);
     });
+
+    it('calls its `showActionsMenu` handler when the menu icon is clicked', function() {
+      const issueishes = [allGreen, mixed, allRed];
+      const showActionsMenu = sinon.stub();
+      const wrapper = mount(buildApp({
+        isLoading: false,
+        total: 3,
+        issueishes,
+        showActionsMenu,
+      }));
+
+      wrapper.find('Octicon.github-IssueishList-item--menu').at(1).simulate('click');
+      assert.isTrue(showActionsMenu.calledWith(mixed));
+    });
   });
 
   it('renders review button only if needed', function() {


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

We received feedback asking to save users clicks when looking at reviews for non-checked out branches. See #2077.

This PR enables users to access reviews for _any_ PR listed in the GitHub tab (not just the checked out PR) via a "See reviews" context menu item.

I also took this opportunity to add a quick way to view the PR on dotcom via a "View on GitHub" context menu item.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Screenshot/Gif

<!-- If the changes are visual, add a screenshot or record a Gif. This doesn't have to be updated during implementation, but after a PR is merged, a final screenshot/gif should be added. It might get used for blog posts, documentation etc. Write "N/A" if not applicable. -->

![open-reviews](https://user-images.githubusercontent.com/7910250/56391830-a9c1d100-61e4-11e9-9083-ca01f44df8fb.gif)

<img width="437" alt="Fullscreen_4_18_19__2_14_PM" src="https://user-images.githubusercontent.com/7910250/56391726-59e30a00-61e4-11e9-8e5a-cb91e63ca0f6.png">

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Initially considered hiding the option behind a right-click context menu, but figured adding a kebab icon would make this more discoverable. The drawback is that the icon takes up some UI real-estate, but in my opinion it's small and discreet enough that it's fine. Open to feedback and other suggestions.

### Benefits

<!-- What benefits will be realized by the code change? -->

Currently, it is only possible to view review comments for the checked out PR from the PR list.

In order to view review comments for a PR that is **not** checked out the user has to click the desired PR in the PR list to open the PR detail pane item, open the "Files" tab, and click the "See reviews" button in the footer of the tab. 

With this change, we increase consistency by allowing the user to open reviews for _any_ PR directly from the PR list. Previously this was only possible for the checked out PR. 

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None really... the only mild concern is that the additional icon might increase visual noise.

### Applicable Issues

<!-- Enter any applicable Issues here -->
Fixes #2077 

### Metrics

<!-- What metrics are associated with this code change and what questions can they help us answer? Write "N/A" if not applicable. -->

Adding an event for 'open-reviews-tab'. 
Adding an event for 'open-issueish-in-browser' to collect information about the users leaving the editor for the browser.

### Tests

<!-- 

How did you verify that your change has the desired effects?
- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

What unit or integration tests were (or will be) added to help protect against future regressions? 
For manual testing, be sure to describe in detail the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and the results you observed.
If you chose not to include a specific test, please explain why. 

Write "N/A" if not applicable. 

-->

Tested `openOnGitHub` method along with `open-issueish-in-browser` event firing
Tested that `showActionsMenu` handler is called when the menu icon is clicked
Currently there is no good way to test Electron Menus.


### Documentation

<!-- Describe the documentation added or improved. Write "N/A" if not applicable. -->

N/A

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where the merge message did not show up in the commit message box.
- Increased the performance of rendering diffs.

-->

> Access review comments for any PR listed in the GitHub panel via an "ellipses" icon

### User Experience Research (Optional)

<!-- If this change would benefit from UXR, please state assumptions or hypotheses and specify if they are to be validated before or after releasing. Examples include investigating discoverability, verifying performance improvements, tracking metrics, etc. -->

N/A
 