### PR TITLE
Add author association to review summaries and thread comments

### DIFF
--- a/lib/containers/__generated__/aggregatedReviewsContainerRefetchQuery.graphql.js
+++ b/lib/containers/__generated__/aggregatedReviewsContainerRefetchQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 506dea36862f12d2e0edbc78524af987
+ * @relayHash d7e618d188b6bc38f26d7663e47e1847
  */
 
 /* eslint-disable */
@@ -156,6 +156,7 @@ fragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThrea
         createdAt
         lastEditedAt
         url
+        authorAssociation
         ...emojiReactionsController_reactable
         __typename
       }
@@ -729,7 +730,7 @@ return {
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
-                                        "name": "path",
+                                        "name": "position",
                                         "args": null,
                                         "storageKey": null
                                       },
@@ -744,6 +745,13 @@ return {
                                       },
                                       (v10/*: any*/),
                                       (v14/*: any*/),
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "path",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
                                       {
                                         "kind": "LinkedField",
                                         "alias": null,
@@ -762,19 +770,19 @@ return {
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
-                                        "name": "position",
-                                        "args": null,
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "kind": "ScalarField",
-                                        "alias": null,
                                         "name": "createdAt",
                                         "args": null,
                                         "storageKey": null
                                       },
                                       (v11/*: any*/),
                                       (v4/*: any*/),
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "authorAssociation",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
                                       (v13/*: any*/),
                                       (v2/*: any*/)
                                     ]
@@ -818,7 +826,7 @@ return {
     "operationKind": "query",
     "name": "aggregatedReviewsContainerRefetchQuery",
     "id": null,
-    "text": "query aggregatedReviewsContainerRefetchQuery(\n  $prId: ID!\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  pullRequest: node(id: $prId) {\n    __typename\n    ...prCheckoutController_pullRequest\n    ...aggregatedReviewsContainer_pullRequest_qdneZ\n    id\n  }\n}\n\nfragment prCheckoutController_pullRequest on PullRequest {\n  number\n  headRefName\n  headRepository {\n    name\n    url\n    sshUrl\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
+    "text": "query aggregatedReviewsContainerRefetchQuery(\n  $prId: ID!\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  pullRequest: node(id: $prId) {\n    __typename\n    ...prCheckoutController_pullRequest\n    ...aggregatedReviewsContainer_pullRequest_qdneZ\n    id\n  }\n}\n\nfragment prCheckoutController_pullRequest on PullRequest {\n  number\n  headRefName\n  headRepository {\n    name\n    url\n    sshUrl\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
     "metadata": {}
   }
 };

--- a/lib/containers/__generated__/aggregatedReviewsContainerRefetchQuery.graphql.js
+++ b/lib/containers/__generated__/aggregatedReviewsContainerRefetchQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash d7e618d188b6bc38f26d7663e47e1847
+ * @relayHash 783c15f002e51fadaa8569e1a26e79ef
  */
 
 /* eslint-disable */
@@ -96,6 +96,7 @@ fragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {
             id
           }
         }
+        authorAssociation
         ...emojiReactionsController_reactable
         __typename
       }
@@ -312,21 +313,21 @@ v8 = {
 v9 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "bodyHTML",
+  "name": "state",
   "args": null,
   "storageKey": null
 },
 v10 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "state",
+  "name": "lastEditedAt",
   "args": null,
   "storageKey": null
 },
 v11 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "lastEditedAt",
+  "name": "bodyHTML",
   "args": null,
   "storageKey": null
 },
@@ -338,6 +339,13 @@ v12 = {
   "storageKey": null
 },
 v13 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "authorAssociation",
+  "args": null,
+  "storageKey": null
+},
+v14 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "reactionGroups",
@@ -380,14 +388,14 @@ v13 = {
     }
   ]
 },
-v14 = {
+v15 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "viewerCanReact",
   "args": null,
   "storageKey": null
 },
-v15 = [
+v16 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -401,7 +409,7 @@ v15 = [
     "type": "Int"
   }
 ],
-v16 = [
+v17 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -589,9 +597,9 @@ return {
                         "concreteType": "PullRequestReview",
                         "plural": false,
                         "selections": [
+                          (v4/*: any*/),
                           (v3/*: any*/),
                           (v9/*: any*/),
-                          (v10/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -599,8 +607,8 @@ return {
                             "args": null,
                             "storageKey": null
                           },
+                          (v10/*: any*/),
                           (v11/*: any*/),
-                          (v4/*: any*/),
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -618,6 +626,7 @@ return {
                           },
                           (v13/*: any*/),
                           (v14/*: any*/),
+                          (v15/*: any*/),
                           (v2/*: any*/)
                         ]
                       }
@@ -639,7 +648,7 @@ return {
                 "alias": null,
                 "name": "reviewThreads",
                 "storageKey": null,
-                "args": (v15/*: any*/),
+                "args": (v16/*: any*/),
                 "concreteType": "PullRequestReviewThreadConnection",
                 "plural": false,
                 "selections": [
@@ -703,7 +712,7 @@ return {
                             "alias": null,
                             "name": "comments",
                             "storageKey": null,
-                            "args": (v16/*: any*/),
+                            "args": (v17/*: any*/),
                             "concreteType": "PullRequestReviewCommentConnection",
                             "plural": false,
                             "selections": [
@@ -735,7 +744,7 @@ return {
                                         "storageKey": null
                                       },
                                       (v3/*: any*/),
-                                      (v9/*: any*/),
+                                      (v11/*: any*/),
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
@@ -743,8 +752,8 @@ return {
                                         "args": null,
                                         "storageKey": null
                                       },
-                                      (v10/*: any*/),
-                                      (v14/*: any*/),
+                                      (v9/*: any*/),
+                                      (v15/*: any*/),
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
@@ -774,16 +783,10 @@ return {
                                         "args": null,
                                         "storageKey": null
                                       },
-                                      (v11/*: any*/),
+                                      (v10/*: any*/),
                                       (v4/*: any*/),
-                                      {
-                                        "kind": "ScalarField",
-                                        "alias": null,
-                                        "name": "authorAssociation",
-                                        "args": null,
-                                        "storageKey": null
-                                      },
                                       (v13/*: any*/),
+                                      (v14/*: any*/),
                                       (v2/*: any*/)
                                     ]
                                   }
@@ -795,7 +798,7 @@ return {
                             "kind": "LinkedHandle",
                             "alias": null,
                             "name": "comments",
-                            "args": (v16/*: any*/),
+                            "args": (v17/*: any*/),
                             "handle": "connection",
                             "key": "ReviewCommentsAccumulator_comments",
                             "filters": null
@@ -811,7 +814,7 @@ return {
                 "kind": "LinkedHandle",
                 "alias": null,
                 "name": "reviewThreads",
-                "args": (v15/*: any*/),
+                "args": (v16/*: any*/),
                 "handle": "connection",
                 "key": "ReviewThreadsAccumulator_reviewThreads",
                 "filters": null
@@ -826,7 +829,7 @@ return {
     "operationKind": "query",
     "name": "aggregatedReviewsContainerRefetchQuery",
     "id": null,
-    "text": "query aggregatedReviewsContainerRefetchQuery(\n  $prId: ID!\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  pullRequest: node(id: $prId) {\n    __typename\n    ...prCheckoutController_pullRequest\n    ...aggregatedReviewsContainer_pullRequest_qdneZ\n    id\n  }\n}\n\nfragment prCheckoutController_pullRequest on PullRequest {\n  number\n  headRefName\n  headRepository {\n    name\n    url\n    sshUrl\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
+    "text": "query aggregatedReviewsContainerRefetchQuery(\n  $prId: ID!\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  pullRequest: node(id: $prId) {\n    __typename\n    ...prCheckoutController_pullRequest\n    ...aggregatedReviewsContainer_pullRequest_qdneZ\n    id\n  }\n}\n\nfragment prCheckoutController_pullRequest on PullRequest {\n  number\n  headRefName\n  headRepository {\n    name\n    url\n    sshUrl\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
     "metadata": {}
   }
 };

--- a/lib/containers/__generated__/commentDecorationsContainerQuery.graphql.js
+++ b/lib/containers/__generated__/commentDecorationsContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 149f75a5dadb3940a285a60d8c3b0e71
+ * @relayHash aff71ba816e3f22014536a17edfe5fd8
  */
 
 /* eslint-disable */
@@ -189,6 +189,7 @@ fragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThrea
         createdAt
         lastEditedAt
         url
+        authorAssociation
         ...emojiReactionsController_reactable
         __typename
       }
@@ -882,7 +883,7 @@ return {
                                               {
                                                 "kind": "ScalarField",
                                                 "alias": null,
-                                                "name": "path",
+                                                "name": "position",
                                                 "args": null,
                                                 "storageKey": null
                                               },
@@ -897,6 +898,13 @@ return {
                                               },
                                               (v16/*: any*/),
                                               (v20/*: any*/),
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "path",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
                                               {
                                                 "kind": "LinkedField",
                                                 "alias": null,
@@ -915,19 +923,19 @@ return {
                                               {
                                                 "kind": "ScalarField",
                                                 "alias": null,
-                                                "name": "position",
-                                                "args": null,
-                                                "storageKey": null
-                                              },
-                                              {
-                                                "kind": "ScalarField",
-                                                "alias": null,
                                                 "name": "createdAt",
                                                 "args": null,
                                                 "storageKey": null
                                               },
                                               (v17/*: any*/),
                                               (v11/*: any*/),
+                                              {
+                                                "kind": "ScalarField",
+                                                "alias": null,
+                                                "name": "authorAssociation",
+                                                "args": null,
+                                                "storageKey": null
+                                              },
                                               (v19/*: any*/),
                                               (v7/*: any*/)
                                             ]
@@ -977,7 +985,7 @@ return {
     "operationKind": "query",
     "name": "commentDecorationsContainerQuery",
     "id": null,
-    "text": "query commentDecorationsContainerQuery(\n  $headOwner: String!\n  $headName: String!\n  $headRef: String!\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n  $first: Int!\n) {\n  repository(owner: $headOwner, name: $headName) {\n    ref(qualifiedName: $headRef) {\n      associatedPullRequests(first: $first, states: [OPEN]) {\n        totalCount\n        nodes {\n          number\n          headRefOid\n          ...commentDecorationsController_pullRequests\n          ...aggregatedReviewsContainer_pullRequest_qdneZ\n          id\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment commentDecorationsController_pullRequests on PullRequest {\n  number\n  headRefName\n  headRefOid\n  headRepository {\n    name\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n  repository {\n    name\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
+    "text": "query commentDecorationsContainerQuery(\n  $headOwner: String!\n  $headName: String!\n  $headRef: String!\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n  $first: Int!\n) {\n  repository(owner: $headOwner, name: $headName) {\n    ref(qualifiedName: $headRef) {\n      associatedPullRequests(first: $first, states: [OPEN]) {\n        totalCount\n        nodes {\n          number\n          headRefOid\n          ...commentDecorationsController_pullRequests\n          ...aggregatedReviewsContainer_pullRequest_qdneZ\n          id\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment commentDecorationsController_pullRequests on PullRequest {\n  number\n  headRefName\n  headRefOid\n  headRepository {\n    name\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n  repository {\n    name\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
     "metadata": {}
   }
 };

--- a/lib/containers/__generated__/commentDecorationsContainerQuery.graphql.js
+++ b/lib/containers/__generated__/commentDecorationsContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash aff71ba816e3f22014536a17edfe5fd8
+ * @relayHash 6102c2ed0015fd6092f361f17cfec637
  */
 
 /* eslint-disable */
@@ -129,6 +129,7 @@ fragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {
             id
           }
         }
+        authorAssociation
         ...emojiReactionsController_reactable
         __typename
       }
@@ -438,21 +439,21 @@ v14 = {
 v15 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "bodyHTML",
+  "name": "state",
   "args": null,
   "storageKey": null
 },
 v16 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "state",
+  "name": "lastEditedAt",
   "args": null,
   "storageKey": null
 },
 v17 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "lastEditedAt",
+  "name": "bodyHTML",
   "args": null,
   "storageKey": null
 },
@@ -464,6 +465,13 @@ v18 = {
   "storageKey": null
 },
 v19 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "authorAssociation",
+  "args": null,
+  "storageKey": null
+},
+v20 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "reactionGroups",
@@ -500,14 +508,14 @@ v19 = {
     }
   ]
 },
-v20 = {
+v21 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "viewerCanReact",
   "args": null,
   "storageKey": null
 },
-v21 = [
+v22 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -521,7 +529,7 @@ v21 = [
     "type": "Int"
   }
 ],
-v22 = [
+v23 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -742,9 +750,9 @@ return {
                                 "concreteType": "PullRequestReview",
                                 "plural": false,
                                 "selections": [
+                                  (v11/*: any*/),
                                   (v9/*: any*/),
                                   (v15/*: any*/),
-                                  (v16/*: any*/),
                                   {
                                     "kind": "ScalarField",
                                     "alias": null,
@@ -752,8 +760,8 @@ return {
                                     "args": null,
                                     "storageKey": null
                                   },
+                                  (v16/*: any*/),
                                   (v17/*: any*/),
-                                  (v11/*: any*/),
                                   {
                                     "kind": "LinkedField",
                                     "alias": null,
@@ -771,6 +779,7 @@ return {
                                   },
                                   (v19/*: any*/),
                                   (v20/*: any*/),
+                                  (v21/*: any*/),
                                   (v7/*: any*/)
                                 ]
                               }
@@ -792,7 +801,7 @@ return {
                         "alias": null,
                         "name": "reviewThreads",
                         "storageKey": null,
-                        "args": (v21/*: any*/),
+                        "args": (v22/*: any*/),
                         "concreteType": "PullRequestReviewThreadConnection",
                         "plural": false,
                         "selections": [
@@ -856,7 +865,7 @@ return {
                                     "alias": null,
                                     "name": "comments",
                                     "storageKey": null,
-                                    "args": (v22/*: any*/),
+                                    "args": (v23/*: any*/),
                                     "concreteType": "PullRequestReviewCommentConnection",
                                     "plural": false,
                                     "selections": [
@@ -888,7 +897,7 @@ return {
                                                 "storageKey": null
                                               },
                                               (v9/*: any*/),
-                                              (v15/*: any*/),
+                                              (v17/*: any*/),
                                               {
                                                 "kind": "ScalarField",
                                                 "alias": null,
@@ -896,8 +905,8 @@ return {
                                                 "args": null,
                                                 "storageKey": null
                                               },
-                                              (v16/*: any*/),
-                                              (v20/*: any*/),
+                                              (v15/*: any*/),
+                                              (v21/*: any*/),
                                               {
                                                 "kind": "ScalarField",
                                                 "alias": null,
@@ -927,16 +936,10 @@ return {
                                                 "args": null,
                                                 "storageKey": null
                                               },
-                                              (v17/*: any*/),
+                                              (v16/*: any*/),
                                               (v11/*: any*/),
-                                              {
-                                                "kind": "ScalarField",
-                                                "alias": null,
-                                                "name": "authorAssociation",
-                                                "args": null,
-                                                "storageKey": null
-                                              },
                                               (v19/*: any*/),
+                                              (v20/*: any*/),
                                               (v7/*: any*/)
                                             ]
                                           }
@@ -948,7 +951,7 @@ return {
                                     "kind": "LinkedHandle",
                                     "alias": null,
                                     "name": "comments",
-                                    "args": (v22/*: any*/),
+                                    "args": (v23/*: any*/),
                                     "handle": "connection",
                                     "key": "ReviewCommentsAccumulator_comments",
                                     "filters": null
@@ -964,7 +967,7 @@ return {
                         "kind": "LinkedHandle",
                         "alias": null,
                         "name": "reviewThreads",
-                        "args": (v21/*: any*/),
+                        "args": (v22/*: any*/),
                         "handle": "connection",
                         "key": "ReviewThreadsAccumulator_reviewThreads",
                         "filters": null
@@ -985,7 +988,7 @@ return {
     "operationKind": "query",
     "name": "commentDecorationsContainerQuery",
     "id": null,
-    "text": "query commentDecorationsContainerQuery(\n  $headOwner: String!\n  $headName: String!\n  $headRef: String!\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n  $first: Int!\n) {\n  repository(owner: $headOwner, name: $headName) {\n    ref(qualifiedName: $headRef) {\n      associatedPullRequests(first: $first, states: [OPEN]) {\n        totalCount\n        nodes {\n          number\n          headRefOid\n          ...commentDecorationsController_pullRequests\n          ...aggregatedReviewsContainer_pullRequest_qdneZ\n          id\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment commentDecorationsController_pullRequests on PullRequest {\n  number\n  headRefName\n  headRefOid\n  headRepository {\n    name\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n  repository {\n    name\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
+    "text": "query commentDecorationsContainerQuery(\n  $headOwner: String!\n  $headName: String!\n  $headRef: String!\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n  $first: Int!\n) {\n  repository(owner: $headOwner, name: $headName) {\n    ref(qualifiedName: $headRef) {\n      associatedPullRequests(first: $first, states: [OPEN]) {\n        totalCount\n        nodes {\n          number\n          headRefOid\n          ...commentDecorationsController_pullRequests\n          ...aggregatedReviewsContainer_pullRequest_qdneZ\n          id\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment commentDecorationsController_pullRequests on PullRequest {\n  number\n  headRefName\n  headRefOid\n  headRepository {\n    name\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n  repository {\n    name\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
     "metadata": {}
   }
 };

--- a/lib/containers/__generated__/issueishDetailContainerQuery.graphql.js
+++ b/lib/containers/__generated__/issueishDetailContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 7185b2a4ff3b97fb74d3ac01b242f815
+ * @relayHash bf72973756978c785a2590eddfcd0176
  */
 
 /* eslint-disable */
@@ -632,6 +632,7 @@ fragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThrea
         createdAt
         lastEditedAt
         url
+        authorAssociation
         ...emojiReactionsController_reactable
         __typename
       }
@@ -949,17 +950,24 @@ v23 = [
 v24 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "position",
+  "args": null,
+  "storageKey": null
+},
+v25 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "path",
   "args": null,
   "storageKey": null
 },
-v25 = [
+v26 = [
   (v3/*: any*/),
   (v15/*: any*/),
   (v14/*: any*/),
   (v4/*: any*/)
 ],
-v26 = {
+v27 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "author",
@@ -967,14 +975,7 @@ v26 = {
   "args": null,
   "concreteType": null,
   "plural": false,
-  "selections": (v25/*: any*/)
-},
-v27 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "position",
-  "args": null,
-  "storageKey": null
+  "selections": (v26/*: any*/)
 },
 v28 = {
   "kind": "ScalarField",
@@ -1163,7 +1164,7 @@ v39 = {
   "kind": "InlineFragment",
   "type": "IssueComment",
   "selections": [
-    (v26/*: any*/),
+    (v27/*: any*/),
     (v11/*: any*/),
     (v28/*: any*/),
     (v5/*: any*/)
@@ -1291,7 +1292,7 @@ v46 = {
   "args": null,
   "concreteType": null,
   "plural": false,
-  "selections": (v25/*: any*/)
+  "selections": (v26/*: any*/)
 };
 return {
   "kind": "Request",
@@ -1603,11 +1604,18 @@ return {
                                           },
                                           (v12/*: any*/),
                                           (v20/*: any*/),
-                                          (v26/*: any*/),
+                                          (v25/*: any*/),
                                           (v27/*: any*/),
                                           (v28/*: any*/),
                                           (v13/*: any*/),
                                           (v5/*: any*/),
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "authorAssociation",
+                                            "args": null,
+                                            "storageKey": null
+                                          },
                                           (v19/*: any*/),
                                           (v3/*: any*/)
                                         ]
@@ -2099,8 +2107,8 @@ return {
                                               (v45/*: any*/),
                                               (v11/*: any*/),
                                               (v28/*: any*/),
-                                              (v24/*: any*/),
-                                              (v27/*: any*/)
+                                              (v25/*: any*/),
+                                              (v24/*: any*/)
                                             ]
                                           }
                                         ]
@@ -2184,7 +2192,7 @@ return {
     "operationKind": "query",
     "name": "issueishDetailContainerQuery",
     "id": null,
-    "text": "query issueishDetailContainerQuery(\n  $repoOwner: String!\n  $repoName: String!\n  $issueishNumber: Int!\n  $timelineCount: Int!\n  $timelineCursor: String\n  $commitCount: Int!\n  $commitCursor: String\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  repository(owner: $repoOwner, name: $repoName) {\n    issueish: issueOrPullRequest(number: $issueishNumber) {\n      __typename\n      ... on PullRequest {\n        ...aggregatedReviewsContainer_pullRequest_qdneZ\n      }\n      ... on Node {\n        id\n      }\n    }\n    ...issueishDetailController_repository_1mXVvq\n    id\n  }\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment issueishDetailController_repository_1mXVvq on Repository {\n  ...issueDetailView_repository\n  ...prCheckoutController_repository\n  ...prDetailView_repository\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n  issue: issueOrPullRequest(number: $issueishNumber) {\n    __typename\n    ... on Issue {\n      title\n      number\n      ...issueDetailView_issue_3D8CP9\n    }\n    ... on Node {\n      id\n    }\n  }\n  pullRequest: issueOrPullRequest(number: $issueishNumber) {\n    __typename\n    ... on PullRequest {\n      title\n      number\n      ...prCheckoutController_pullRequest\n      ...prDetailView_pullRequest_1TnD8A\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment issueDetailView_repository on Repository {\n  id\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n\nfragment prCheckoutController_repository on Repository {\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n\nfragment prDetailView_repository on Repository {\n  id\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n\nfragment issueDetailView_issue_3D8CP9 on Issue {\n  id\n  __typename\n  url\n  state\n  number\n  title\n  bodyHTML\n  author {\n    __typename\n    login\n    avatarUrl\n    url\n    ... on Node {\n      id\n    }\n  }\n  ...issueTimelineController_issue_3D8CP9\n  ...emojiReactionsView_reactable\n}\n\nfragment prCheckoutController_pullRequest on PullRequest {\n  number\n  headRefName\n  headRepository {\n    name\n    url\n    sshUrl\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment prDetailView_pullRequest_1TnD8A on PullRequest {\n  id\n  __typename\n  url\n  isCrossRepository\n  changedFiles\n  state\n  number\n  title\n  bodyHTML\n  baseRefName\n  headRefName\n  countedCommits: commits {\n    totalCount\n  }\n  author {\n    __typename\n    login\n    avatarUrl\n    url\n    ... on Node {\n      id\n    }\n  }\n  ...prCommitsView_pullRequest_38TpXw\n  ...prStatusesView_pullRequest\n  ...prTimelineController_pullRequest_3D8CP9\n  ...emojiReactionsController_reactable\n}\n\nfragment prCommitsView_pullRequest_38TpXw on PullRequest {\n  url\n  commits(first: $commitCount, after: $commitCursor) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        commit {\n          id\n          ...prCommitView_item\n        }\n        id\n        __typename\n      }\n    }\n  }\n}\n\nfragment prStatusesView_pullRequest on PullRequest {\n  id\n  recentCommits: commits(last: 1) {\n    edges {\n      node {\n        commit {\n          status {\n            state\n            contexts {\n              id\n              state\n              ...prStatusContextView_context\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment prTimelineController_pullRequest_3D8CP9 on PullRequest {\n  url\n  ...headRefForcePushedEventView_issueish\n  timeline(first: $timelineCount, after: $timelineCursor) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        __typename\n        ...commitsView_nodes\n        ...issueCommentView_item\n        ...mergedEventView_item\n        ...headRefForcePushedEventView_item\n        ...commitCommentThreadView_item\n        ...crossReferencedEventsView_nodes\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n\nfragment headRefForcePushedEventView_issueish on PullRequest {\n  headRefName\n  headRepositoryOwner {\n    __typename\n    login\n    id\n  }\n  repository {\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment commitsView_nodes on Commit {\n  id\n  author {\n    name\n    user {\n      login\n      id\n    }\n  }\n  ...commitView_commit\n}\n\nfragment issueCommentView_item on IssueComment {\n  author {\n    __typename\n    avatarUrl\n    login\n    ... on Node {\n      id\n    }\n  }\n  bodyHTML\n  createdAt\n  url\n}\n\nfragment mergedEventView_item on MergedEvent {\n  actor {\n    __typename\n    avatarUrl\n    login\n    ... on Node {\n      id\n    }\n  }\n  commit {\n    oid\n    id\n  }\n  mergeRefName\n  createdAt\n}\n\nfragment headRefForcePushedEventView_item on HeadRefForcePushedEvent {\n  actor {\n    __typename\n    avatarUrl\n    login\n    ... on Node {\n      id\n    }\n  }\n  beforeCommit {\n    oid\n    id\n  }\n  afterCommit {\n    oid\n    id\n  }\n  createdAt\n}\n\nfragment commitCommentThreadView_item on CommitCommentThread {\n  commit {\n    oid\n    id\n  }\n  comments(first: 100) {\n    edges {\n      node {\n        id\n        ...commitCommentView_item\n      }\n    }\n  }\n}\n\nfragment crossReferencedEventsView_nodes on CrossReferencedEvent {\n  id\n  referencedAt\n  isCrossRepository\n  actor {\n    __typename\n    login\n    avatarUrl\n    ... on Node {\n      id\n    }\n  }\n  source {\n    __typename\n    ... on RepositoryNode {\n      repository {\n        name\n        owner {\n          __typename\n          login\n          id\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...crossReferencedEventView_item\n}\n\nfragment crossReferencedEventView_item on CrossReferencedEvent {\n  id\n  isCrossRepository\n  source {\n    __typename\n    ... on Issue {\n      number\n      title\n      url\n      issueState: state\n    }\n    ... on PullRequest {\n      number\n      title\n      url\n      prState: state\n    }\n    ... on RepositoryNode {\n      repository {\n        name\n        isPrivate\n        owner {\n          __typename\n          login\n          id\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment commitCommentView_item on CommitComment {\n  author {\n    __typename\n    login\n    avatarUrl\n    ... on Node {\n      id\n    }\n  }\n  commit {\n    oid\n    id\n  }\n  bodyHTML\n  createdAt\n  path\n  position\n}\n\nfragment commitView_commit on Commit {\n  author {\n    name\n    avatarUrl\n    user {\n      login\n      id\n    }\n  }\n  committer {\n    name\n    avatarUrl\n    user {\n      login\n      id\n    }\n  }\n  authoredByCommitter\n  sha: oid\n  message\n  messageHeadlineHTML\n  commitUrl\n}\n\nfragment prStatusContextView_context on StatusContext {\n  context\n  description\n  state\n  targetUrl\n}\n\nfragment prCommitView_item on Commit {\n  committer {\n    avatarUrl\n    name\n    date\n  }\n  messageHeadline\n  messageBody\n  shortSha: abbreviatedOid\n  sha: oid\n  url\n}\n\nfragment issueTimelineController_issue_3D8CP9 on Issue {\n  url\n  timeline(first: $timelineCount, after: $timelineCursor) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        __typename\n        ...commitsView_nodes\n        ...issueCommentView_item\n        ...crossReferencedEventsView_nodes\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n",
+    "text": "query issueishDetailContainerQuery(\n  $repoOwner: String!\n  $repoName: String!\n  $issueishNumber: Int!\n  $timelineCount: Int!\n  $timelineCursor: String\n  $commitCount: Int!\n  $commitCursor: String\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  repository(owner: $repoOwner, name: $repoName) {\n    issueish: issueOrPullRequest(number: $issueishNumber) {\n      __typename\n      ... on PullRequest {\n        ...aggregatedReviewsContainer_pullRequest_qdneZ\n      }\n      ... on Node {\n        id\n      }\n    }\n    ...issueishDetailController_repository_1mXVvq\n    id\n  }\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment issueishDetailController_repository_1mXVvq on Repository {\n  ...issueDetailView_repository\n  ...prCheckoutController_repository\n  ...prDetailView_repository\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n  issue: issueOrPullRequest(number: $issueishNumber) {\n    __typename\n    ... on Issue {\n      title\n      number\n      ...issueDetailView_issue_3D8CP9\n    }\n    ... on Node {\n      id\n    }\n  }\n  pullRequest: issueOrPullRequest(number: $issueishNumber) {\n    __typename\n    ... on PullRequest {\n      title\n      number\n      ...prCheckoutController_pullRequest\n      ...prDetailView_pullRequest_1TnD8A\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment issueDetailView_repository on Repository {\n  id\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n\nfragment prCheckoutController_repository on Repository {\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n\nfragment prDetailView_repository on Repository {\n  id\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n\nfragment issueDetailView_issue_3D8CP9 on Issue {\n  id\n  __typename\n  url\n  state\n  number\n  title\n  bodyHTML\n  author {\n    __typename\n    login\n    avatarUrl\n    url\n    ... on Node {\n      id\n    }\n  }\n  ...issueTimelineController_issue_3D8CP9\n  ...emojiReactionsView_reactable\n}\n\nfragment prCheckoutController_pullRequest on PullRequest {\n  number\n  headRefName\n  headRepository {\n    name\n    url\n    sshUrl\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment prDetailView_pullRequest_1TnD8A on PullRequest {\n  id\n  __typename\n  url\n  isCrossRepository\n  changedFiles\n  state\n  number\n  title\n  bodyHTML\n  baseRefName\n  headRefName\n  countedCommits: commits {\n    totalCount\n  }\n  author {\n    __typename\n    login\n    avatarUrl\n    url\n    ... on Node {\n      id\n    }\n  }\n  ...prCommitsView_pullRequest_38TpXw\n  ...prStatusesView_pullRequest\n  ...prTimelineController_pullRequest_3D8CP9\n  ...emojiReactionsController_reactable\n}\n\nfragment prCommitsView_pullRequest_38TpXw on PullRequest {\n  url\n  commits(first: $commitCount, after: $commitCursor) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        commit {\n          id\n          ...prCommitView_item\n        }\n        id\n        __typename\n      }\n    }\n  }\n}\n\nfragment prStatusesView_pullRequest on PullRequest {\n  id\n  recentCommits: commits(last: 1) {\n    edges {\n      node {\n        commit {\n          status {\n            state\n            contexts {\n              id\n              state\n              ...prStatusContextView_context\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment prTimelineController_pullRequest_3D8CP9 on PullRequest {\n  url\n  ...headRefForcePushedEventView_issueish\n  timeline(first: $timelineCount, after: $timelineCursor) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        __typename\n        ...commitsView_nodes\n        ...issueCommentView_item\n        ...mergedEventView_item\n        ...headRefForcePushedEventView_item\n        ...commitCommentThreadView_item\n        ...crossReferencedEventsView_nodes\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n\nfragment headRefForcePushedEventView_issueish on PullRequest {\n  headRefName\n  headRepositoryOwner {\n    __typename\n    login\n    id\n  }\n  repository {\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment commitsView_nodes on Commit {\n  id\n  author {\n    name\n    user {\n      login\n      id\n    }\n  }\n  ...commitView_commit\n}\n\nfragment issueCommentView_item on IssueComment {\n  author {\n    __typename\n    avatarUrl\n    login\n    ... on Node {\n      id\n    }\n  }\n  bodyHTML\n  createdAt\n  url\n}\n\nfragment mergedEventView_item on MergedEvent {\n  actor {\n    __typename\n    avatarUrl\n    login\n    ... on Node {\n      id\n    }\n  }\n  commit {\n    oid\n    id\n  }\n  mergeRefName\n  createdAt\n}\n\nfragment headRefForcePushedEventView_item on HeadRefForcePushedEvent {\n  actor {\n    __typename\n    avatarUrl\n    login\n    ... on Node {\n      id\n    }\n  }\n  beforeCommit {\n    oid\n    id\n  }\n  afterCommit {\n    oid\n    id\n  }\n  createdAt\n}\n\nfragment commitCommentThreadView_item on CommitCommentThread {\n  commit {\n    oid\n    id\n  }\n  comments(first: 100) {\n    edges {\n      node {\n        id\n        ...commitCommentView_item\n      }\n    }\n  }\n}\n\nfragment crossReferencedEventsView_nodes on CrossReferencedEvent {\n  id\n  referencedAt\n  isCrossRepository\n  actor {\n    __typename\n    login\n    avatarUrl\n    ... on Node {\n      id\n    }\n  }\n  source {\n    __typename\n    ... on RepositoryNode {\n      repository {\n        name\n        owner {\n          __typename\n          login\n          id\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...crossReferencedEventView_item\n}\n\nfragment crossReferencedEventView_item on CrossReferencedEvent {\n  id\n  isCrossRepository\n  source {\n    __typename\n    ... on Issue {\n      number\n      title\n      url\n      issueState: state\n    }\n    ... on PullRequest {\n      number\n      title\n      url\n      prState: state\n    }\n    ... on RepositoryNode {\n      repository {\n        name\n        isPrivate\n        owner {\n          __typename\n          login\n          id\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment commitCommentView_item on CommitComment {\n  author {\n    __typename\n    login\n    avatarUrl\n    ... on Node {\n      id\n    }\n  }\n  commit {\n    oid\n    id\n  }\n  bodyHTML\n  createdAt\n  path\n  position\n}\n\nfragment commitView_commit on Commit {\n  author {\n    name\n    avatarUrl\n    user {\n      login\n      id\n    }\n  }\n  committer {\n    name\n    avatarUrl\n    user {\n      login\n      id\n    }\n  }\n  authoredByCommitter\n  sha: oid\n  message\n  messageHeadlineHTML\n  commitUrl\n}\n\nfragment prStatusContextView_context on StatusContext {\n  context\n  description\n  state\n  targetUrl\n}\n\nfragment prCommitView_item on Commit {\n  committer {\n    avatarUrl\n    name\n    date\n  }\n  messageHeadline\n  messageBody\n  shortSha: abbreviatedOid\n  sha: oid\n  url\n}\n\nfragment issueTimelineController_issue_3D8CP9 on Issue {\n  url\n  timeline(first: $timelineCount, after: $timelineCursor) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        __typename\n        ...commitsView_nodes\n        ...issueCommentView_item\n        ...crossReferencedEventsView_nodes\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/lib/containers/__generated__/issueishDetailContainerQuery.graphql.js
+++ b/lib/containers/__generated__/issueishDetailContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash bf72973756978c785a2590eddfcd0176
+ * @relayHash f86d65375ce1021e879ebe33b77d309e
  */
 
 /* eslint-disable */
@@ -572,6 +572,7 @@ fragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {
             id
           }
         }
+        authorAssociation
         ...emojiReactionsController_reactable
         __typename
       }
@@ -816,21 +817,21 @@ v10 = {
 v11 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "bodyHTML",
+  "name": "state",
   "args": null,
   "storageKey": null
 },
 v12 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "state",
+  "name": "lastEditedAt",
   "args": null,
   "storageKey": null
 },
 v13 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "lastEditedAt",
+  "name": "bodyHTML",
   "args": null,
   "storageKey": null
 },
@@ -864,7 +865,14 @@ v17 = {
   "plural": false,
   "selections": (v16/*: any*/)
 },
-v18 = [
+v18 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "authorAssociation",
+  "args": null,
+  "storageKey": null
+},
+v19 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -873,7 +881,7 @@ v18 = [
     "storageKey": null
   }
 ],
-v19 = {
+v20 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "reactionGroups",
@@ -904,18 +912,18 @@ v19 = {
       "args": null,
       "concreteType": "ReactingUserConnection",
       "plural": false,
-      "selections": (v18/*: any*/)
+      "selections": (v19/*: any*/)
     }
   ]
 },
-v20 = {
+v21 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "viewerCanReact",
   "args": null,
   "storageKey": null
 },
-v21 = [
+v22 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -929,11 +937,11 @@ v21 = [
     "type": "Int"
   }
 ],
-v22 = [
+v23 = [
   (v14/*: any*/),
   (v4/*: any*/)
 ],
-v23 = [
+v24 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -947,27 +955,27 @@ v23 = [
     "type": "Int"
   }
 ],
-v24 = {
+v25 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "position",
   "args": null,
   "storageKey": null
 },
-v25 = {
+v26 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "path",
   "args": null,
   "storageKey": null
 },
-v26 = [
+v27 = [
   (v3/*: any*/),
   (v15/*: any*/),
   (v14/*: any*/),
   (v4/*: any*/)
 ],
-v27 = {
+v28 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "author",
@@ -975,28 +983,28 @@ v27 = {
   "args": null,
   "concreteType": null,
   "plural": false,
-  "selections": (v26/*: any*/)
+  "selections": (v27/*: any*/)
 },
-v28 = {
+v29 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "createdAt",
   "args": null,
   "storageKey": null
 },
-v29 = {
+v30 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v30 = [
+v31 = [
   (v3/*: any*/),
   (v14/*: any*/),
   (v4/*: any*/)
 ],
-v31 = {
+v32 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "owner",
@@ -1004,23 +1012,23 @@ v31 = {
   "args": null,
   "concreteType": null,
   "plural": false,
-  "selections": (v30/*: any*/)
+  "selections": (v31/*: any*/)
 },
-v32 = {
+v33 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v33 = {
+v34 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "number",
   "args": null,
   "storageKey": null
 },
-v34 = {
+v35 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "author",
@@ -1036,7 +1044,7 @@ v34 = {
     (v4/*: any*/)
   ]
 },
-v35 = [
+v36 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -1050,7 +1058,7 @@ v35 = [
     "type": "Int"
   }
 ],
-v36 = {
+v37 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "pageInfo",
@@ -1063,14 +1071,14 @@ v36 = {
     (v7/*: any*/)
   ]
 },
-v37 = {
+v38 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "isCrossRepository",
   "args": null,
   "storageKey": null
 },
-v38 = {
+v39 = {
   "kind": "InlineFragment",
   "type": "CrossReferencedEvent",
   "selections": [
@@ -1081,7 +1089,7 @@ v38 = {
       "args": null,
       "storageKey": null
     },
-    (v37/*: any*/),
+    (v38/*: any*/),
     {
       "kind": "LinkedField",
       "alias": null,
@@ -1111,8 +1119,8 @@ v38 = {
           "concreteType": "Repository",
           "plural": false,
           "selections": [
-            (v29/*: any*/),
-            (v31/*: any*/),
+            (v30/*: any*/),
+            (v32/*: any*/),
             (v4/*: any*/),
             {
               "kind": "ScalarField",
@@ -1128,8 +1136,8 @@ v38 = {
           "kind": "InlineFragment",
           "type": "PullRequest",
           "selections": [
+            (v34/*: any*/),
             (v33/*: any*/),
-            (v32/*: any*/),
             (v5/*: any*/),
             {
               "kind": "ScalarField",
@@ -1144,8 +1152,8 @@ v38 = {
           "kind": "InlineFragment",
           "type": "Issue",
           "selections": [
+            (v34/*: any*/),
             (v33/*: any*/),
-            (v32/*: any*/),
             (v5/*: any*/),
             {
               "kind": "ScalarField",
@@ -1160,17 +1168,17 @@ v38 = {
     }
   ]
 },
-v39 = {
+v40 = {
   "kind": "InlineFragment",
   "type": "IssueComment",
   "selections": [
-    (v27/*: any*/),
-    (v11/*: any*/),
     (v28/*: any*/),
+    (v13/*: any*/),
+    (v29/*: any*/),
     (v5/*: any*/)
   ]
 },
-v40 = {
+v41 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "user",
@@ -1178,16 +1186,16 @@ v40 = {
   "args": null,
   "concreteType": "User",
   "plural": false,
-  "selections": (v22/*: any*/)
+  "selections": (v23/*: any*/)
 },
-v41 = {
+v42 = {
   "kind": "ScalarField",
   "alias": "sha",
   "name": "oid",
   "args": null,
   "storageKey": null
 },
-v42 = {
+v43 = {
   "kind": "InlineFragment",
   "type": "Commit",
   "selections": [
@@ -1200,8 +1208,8 @@ v42 = {
       "concreteType": "GitActor",
       "plural": false,
       "selections": [
-        (v29/*: any*/),
-        (v40/*: any*/),
+        (v30/*: any*/),
+        (v41/*: any*/),
         (v15/*: any*/)
       ]
     },
@@ -1214,9 +1222,9 @@ v42 = {
       "concreteType": "GitActor",
       "plural": false,
       "selections": [
-        (v29/*: any*/),
+        (v30/*: any*/),
         (v15/*: any*/),
-        (v40/*: any*/)
+        (v41/*: any*/)
       ]
     },
     {
@@ -1226,7 +1234,7 @@ v42 = {
       "args": null,
       "storageKey": null
     },
-    (v41/*: any*/),
+    (v42/*: any*/),
     {
       "kind": "ScalarField",
       "alias": null,
@@ -1250,7 +1258,7 @@ v42 = {
     }
   ]
 },
-v43 = [
+v44 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -1264,7 +1272,7 @@ v43 = [
     "type": "Int"
   }
 ],
-v44 = [
+v45 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -1274,7 +1282,7 @@ v44 = [
   },
   (v4/*: any*/)
 ],
-v45 = {
+v46 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "commit",
@@ -1282,9 +1290,9 @@ v45 = {
   "args": null,
   "concreteType": "Commit",
   "plural": false,
-  "selections": (v44/*: any*/)
+  "selections": (v45/*: any*/)
 },
-v46 = {
+v47 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "actor",
@@ -1292,7 +1300,7 @@ v46 = {
   "args": null,
   "concreteType": null,
   "plural": false,
-  "selections": (v26/*: any*/)
+  "selections": (v27/*: any*/)
 };
 return {
   "kind": "Request",
@@ -1471,9 +1479,9 @@ return {
                             "concreteType": "PullRequestReview",
                             "plural": false,
                             "selections": [
+                              (v5/*: any*/),
                               (v4/*: any*/),
                               (v11/*: any*/),
-                              (v12/*: any*/),
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1481,11 +1489,12 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
+                              (v12/*: any*/),
                               (v13/*: any*/),
-                              (v5/*: any*/),
                               (v17/*: any*/),
-                              (v19/*: any*/),
+                              (v18/*: any*/),
                               (v20/*: any*/),
+                              (v21/*: any*/),
                               (v3/*: any*/)
                             ]
                           }
@@ -1507,7 +1516,7 @@ return {
                     "alias": null,
                     "name": "reviewThreads",
                     "storageKey": null,
-                    "args": (v21/*: any*/),
+                    "args": (v22/*: any*/),
                     "concreteType": "PullRequestReviewThreadConnection",
                     "plural": false,
                     "selections": [
@@ -1547,7 +1556,7 @@ return {
                                 "args": null,
                                 "concreteType": "User",
                                 "plural": false,
-                                "selections": (v22/*: any*/)
+                                "selections": (v23/*: any*/)
                               },
                               {
                                 "kind": "ScalarField",
@@ -1568,7 +1577,7 @@ return {
                                 "alias": null,
                                 "name": "comments",
                                 "storageKey": null,
-                                "args": (v23/*: any*/),
+                                "args": (v24/*: any*/),
                                 "concreteType": "PullRequestReviewCommentConnection",
                                 "plural": false,
                                 "selections": [
@@ -1592,9 +1601,9 @@ return {
                                         "concreteType": "PullRequestReviewComment",
                                         "plural": false,
                                         "selections": [
-                                          (v24/*: any*/),
+                                          (v25/*: any*/),
                                           (v4/*: any*/),
-                                          (v11/*: any*/),
+                                          (v13/*: any*/),
                                           {
                                             "kind": "ScalarField",
                                             "alias": null,
@@ -1602,21 +1611,15 @@ return {
                                             "args": null,
                                             "storageKey": null
                                           },
-                                          (v12/*: any*/),
-                                          (v20/*: any*/),
-                                          (v25/*: any*/),
-                                          (v27/*: any*/),
+                                          (v11/*: any*/),
+                                          (v21/*: any*/),
+                                          (v26/*: any*/),
                                           (v28/*: any*/),
-                                          (v13/*: any*/),
+                                          (v29/*: any*/),
+                                          (v12/*: any*/),
                                           (v5/*: any*/),
-                                          {
-                                            "kind": "ScalarField",
-                                            "alias": null,
-                                            "name": "authorAssociation",
-                                            "args": null,
-                                            "storageKey": null
-                                          },
-                                          (v19/*: any*/),
+                                          (v18/*: any*/),
+                                          (v20/*: any*/),
                                           (v3/*: any*/)
                                         ]
                                       }
@@ -1628,7 +1631,7 @@ return {
                                 "kind": "LinkedHandle",
                                 "alias": null,
                                 "name": "comments",
-                                "args": (v23/*: any*/),
+                                "args": (v24/*: any*/),
                                 "handle": "connection",
                                 "key": "ReviewCommentsAccumulator_comments",
                                 "filters": null
@@ -1644,7 +1647,7 @@ return {
                     "kind": "LinkedHandle",
                     "alias": null,
                     "name": "reviewThreads",
-                    "args": (v21/*: any*/),
+                    "args": (v22/*: any*/),
                     "handle": "connection",
                     "key": "ReviewThreadsAccumulator_reviewThreads",
                     "filters": null
@@ -1654,8 +1657,8 @@ return {
             ]
           },
           (v4/*: any*/),
-          (v29/*: any*/),
-          (v31/*: any*/),
+          (v30/*: any*/),
+          (v32/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "issue",
@@ -1671,22 +1674,22 @@ return {
                 "kind": "InlineFragment",
                 "type": "Issue",
                 "selections": [
-                  (v12/*: any*/),
-                  (v32/*: any*/),
-                  (v5/*: any*/),
-                  (v33/*: any*/),
                   (v11/*: any*/),
+                  (v33/*: any*/),
+                  (v5/*: any*/),
                   (v34/*: any*/),
+                  (v13/*: any*/),
+                  (v35/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
                     "name": "timeline",
                     "storageKey": null,
-                    "args": (v35/*: any*/),
+                    "args": (v36/*: any*/),
                     "concreteType": "IssueTimelineConnection",
                     "plural": false,
                     "selections": [
-                      (v36/*: any*/),
+                      (v37/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1708,9 +1711,9 @@ return {
                             "selections": [
                               (v3/*: any*/),
                               (v4/*: any*/),
-                              (v38/*: any*/),
                               (v39/*: any*/),
-                              (v42/*: any*/)
+                              (v40/*: any*/),
+                              (v43/*: any*/)
                             ]
                           }
                         ]
@@ -1721,13 +1724,13 @@ return {
                     "kind": "LinkedHandle",
                     "alias": null,
                     "name": "timeline",
-                    "args": (v35/*: any*/),
+                    "args": (v36/*: any*/),
                     "handle": "connection",
                     "key": "IssueTimelineController_timeline",
                     "filters": null
                   },
-                  (v19/*: any*/),
-                  (v20/*: any*/)
+                  (v20/*: any*/),
+                  (v21/*: any*/)
                 ]
               }
             ]
@@ -1747,8 +1750,8 @@ return {
                 "kind": "InlineFragment",
                 "type": "PullRequest",
                 "selections": [
-                  (v11/*: any*/),
-                  (v32/*: any*/),
+                  (v13/*: any*/),
+                  (v33/*: any*/),
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1765,7 +1768,7 @@ return {
                     "concreteType": "Repository",
                     "plural": false,
                     "selections": [
-                      (v29/*: any*/),
+                      (v30/*: any*/),
                       (v5/*: any*/),
                       {
                         "kind": "ScalarField",
@@ -1774,12 +1777,12 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v31/*: any*/),
+                      (v32/*: any*/),
                       (v4/*: any*/)
                     ]
                   },
                   (v5/*: any*/),
-                  (v37/*: any*/),
+                  (v38/*: any*/),
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1787,8 +1790,8 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v12/*: any*/),
-                  (v33/*: any*/),
+                  (v11/*: any*/),
+                  (v34/*: any*/),
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -1804,19 +1807,19 @@ return {
                     "args": null,
                     "concreteType": "PullRequestCommitConnection",
                     "plural": false,
-                    "selections": (v18/*: any*/)
+                    "selections": (v19/*: any*/)
                   },
-                  (v34/*: any*/),
+                  (v35/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
                     "name": "commits",
                     "storageKey": null,
-                    "args": (v43/*: any*/),
+                    "args": (v44/*: any*/),
                     "concreteType": "PullRequestCommitConnection",
                     "plural": false,
                     "selections": [
-                      (v36/*: any*/),
+                      (v37/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1856,7 +1859,7 @@ return {
                                     "plural": false,
                                     "selections": [
                                       (v15/*: any*/),
-                                      (v29/*: any*/),
+                                      (v30/*: any*/),
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
@@ -1887,7 +1890,7 @@ return {
                                     "args": null,
                                     "storageKey": null
                                   },
-                                  (v41/*: any*/),
+                                  (v42/*: any*/),
                                   (v5/*: any*/)
                                 ]
                               },
@@ -1903,7 +1906,7 @@ return {
                     "kind": "LinkedHandle",
                     "alias": null,
                     "name": "commits",
-                    "args": (v43/*: any*/),
+                    "args": (v44/*: any*/),
                     "handle": "connection",
                     "key": "prCommitsView_commits",
                     "filters": null
@@ -1960,7 +1963,7 @@ return {
                                     "concreteType": "Status",
                                     "plural": false,
                                     "selections": [
-                                      (v12/*: any*/),
+                                      (v11/*: any*/),
                                       {
                                         "kind": "LinkedField",
                                         "alias": null,
@@ -1971,7 +1974,7 @@ return {
                                         "plural": true,
                                         "selections": [
                                           (v4/*: any*/),
-                                          (v12/*: any*/),
+                                          (v11/*: any*/),
                                           {
                                             "kind": "ScalarField",
                                             "alias": null,
@@ -2016,7 +2019,7 @@ return {
                     "args": null,
                     "concreteType": null,
                     "plural": false,
-                    "selections": (v30/*: any*/)
+                    "selections": (v31/*: any*/)
                   },
                   {
                     "kind": "LinkedField",
@@ -2027,7 +2030,7 @@ return {
                     "concreteType": "Repository",
                     "plural": false,
                     "selections": [
-                      (v31/*: any*/),
+                      (v32/*: any*/),
                       (v4/*: any*/)
                     ]
                   },
@@ -2036,11 +2039,11 @@ return {
                     "alias": null,
                     "name": "timeline",
                     "storageKey": null,
-                    "args": (v35/*: any*/),
+                    "args": (v36/*: any*/),
                     "concreteType": "PullRequestTimelineConnection",
                     "plural": false,
                     "selections": [
-                      (v36/*: any*/),
+                      (v37/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -2062,12 +2065,12 @@ return {
                             "selections": [
                               (v3/*: any*/),
                               (v4/*: any*/),
-                              (v38/*: any*/),
+                              (v39/*: any*/),
                               {
                                 "kind": "InlineFragment",
                                 "type": "CommitCommentThread",
                                 "selections": [
-                                  (v45/*: any*/),
+                                  (v46/*: any*/),
                                   {
                                     "kind": "LinkedField",
                                     "alias": null,
@@ -2104,11 +2107,11 @@ return {
                                             "selections": [
                                               (v4/*: any*/),
                                               (v17/*: any*/),
-                                              (v45/*: any*/),
-                                              (v11/*: any*/),
-                                              (v28/*: any*/),
-                                              (v25/*: any*/),
-                                              (v24/*: any*/)
+                                              (v46/*: any*/),
+                                              (v13/*: any*/),
+                                              (v29/*: any*/),
+                                              (v26/*: any*/),
+                                              (v25/*: any*/)
                                             ]
                                           }
                                         ]
@@ -2121,7 +2124,7 @@ return {
                                 "kind": "InlineFragment",
                                 "type": "HeadRefForcePushedEvent",
                                 "selections": [
-                                  (v46/*: any*/),
+                                  (v47/*: any*/),
                                   {
                                     "kind": "LinkedField",
                                     "alias": null,
@@ -2130,7 +2133,7 @@ return {
                                     "args": null,
                                     "concreteType": "Commit",
                                     "plural": false,
-                                    "selections": (v44/*: any*/)
+                                    "selections": (v45/*: any*/)
                                   },
                                   {
                                     "kind": "LinkedField",
@@ -2140,17 +2143,17 @@ return {
                                     "args": null,
                                     "concreteType": "Commit",
                                     "plural": false,
-                                    "selections": (v44/*: any*/)
+                                    "selections": (v45/*: any*/)
                                   },
-                                  (v28/*: any*/)
+                                  (v29/*: any*/)
                                 ]
                               },
                               {
                                 "kind": "InlineFragment",
                                 "type": "MergedEvent",
                                 "selections": [
+                                  (v47/*: any*/),
                                   (v46/*: any*/),
-                                  (v45/*: any*/),
                                   {
                                     "kind": "ScalarField",
                                     "alias": null,
@@ -2158,11 +2161,11 @@ return {
                                     "args": null,
                                     "storageKey": null
                                   },
-                                  (v28/*: any*/)
+                                  (v29/*: any*/)
                                 ]
                               },
-                              (v39/*: any*/),
-                              (v42/*: any*/)
+                              (v40/*: any*/),
+                              (v43/*: any*/)
                             ]
                           }
                         ]
@@ -2173,13 +2176,13 @@ return {
                     "kind": "LinkedHandle",
                     "alias": null,
                     "name": "timeline",
-                    "args": (v35/*: any*/),
+                    "args": (v36/*: any*/),
                     "handle": "connection",
                     "key": "prTimelineContainer_timeline",
                     "filters": null
                   },
-                  (v19/*: any*/),
-                  (v20/*: any*/)
+                  (v20/*: any*/),
+                  (v21/*: any*/)
                 ]
               }
             ]
@@ -2192,7 +2195,7 @@ return {
     "operationKind": "query",
     "name": "issueishDetailContainerQuery",
     "id": null,
-    "text": "query issueishDetailContainerQuery(\n  $repoOwner: String!\n  $repoName: String!\n  $issueishNumber: Int!\n  $timelineCount: Int!\n  $timelineCursor: String\n  $commitCount: Int!\n  $commitCursor: String\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  repository(owner: $repoOwner, name: $repoName) {\n    issueish: issueOrPullRequest(number: $issueishNumber) {\n      __typename\n      ... on PullRequest {\n        ...aggregatedReviewsContainer_pullRequest_qdneZ\n      }\n      ... on Node {\n        id\n      }\n    }\n    ...issueishDetailController_repository_1mXVvq\n    id\n  }\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment issueishDetailController_repository_1mXVvq on Repository {\n  ...issueDetailView_repository\n  ...prCheckoutController_repository\n  ...prDetailView_repository\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n  issue: issueOrPullRequest(number: $issueishNumber) {\n    __typename\n    ... on Issue {\n      title\n      number\n      ...issueDetailView_issue_3D8CP9\n    }\n    ... on Node {\n      id\n    }\n  }\n  pullRequest: issueOrPullRequest(number: $issueishNumber) {\n    __typename\n    ... on PullRequest {\n      title\n      number\n      ...prCheckoutController_pullRequest\n      ...prDetailView_pullRequest_1TnD8A\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment issueDetailView_repository on Repository {\n  id\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n\nfragment prCheckoutController_repository on Repository {\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n\nfragment prDetailView_repository on Repository {\n  id\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n\nfragment issueDetailView_issue_3D8CP9 on Issue {\n  id\n  __typename\n  url\n  state\n  number\n  title\n  bodyHTML\n  author {\n    __typename\n    login\n    avatarUrl\n    url\n    ... on Node {\n      id\n    }\n  }\n  ...issueTimelineController_issue_3D8CP9\n  ...emojiReactionsView_reactable\n}\n\nfragment prCheckoutController_pullRequest on PullRequest {\n  number\n  headRefName\n  headRepository {\n    name\n    url\n    sshUrl\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment prDetailView_pullRequest_1TnD8A on PullRequest {\n  id\n  __typename\n  url\n  isCrossRepository\n  changedFiles\n  state\n  number\n  title\n  bodyHTML\n  baseRefName\n  headRefName\n  countedCommits: commits {\n    totalCount\n  }\n  author {\n    __typename\n    login\n    avatarUrl\n    url\n    ... on Node {\n      id\n    }\n  }\n  ...prCommitsView_pullRequest_38TpXw\n  ...prStatusesView_pullRequest\n  ...prTimelineController_pullRequest_3D8CP9\n  ...emojiReactionsController_reactable\n}\n\nfragment prCommitsView_pullRequest_38TpXw on PullRequest {\n  url\n  commits(first: $commitCount, after: $commitCursor) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        commit {\n          id\n          ...prCommitView_item\n        }\n        id\n        __typename\n      }\n    }\n  }\n}\n\nfragment prStatusesView_pullRequest on PullRequest {\n  id\n  recentCommits: commits(last: 1) {\n    edges {\n      node {\n        commit {\n          status {\n            state\n            contexts {\n              id\n              state\n              ...prStatusContextView_context\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment prTimelineController_pullRequest_3D8CP9 on PullRequest {\n  url\n  ...headRefForcePushedEventView_issueish\n  timeline(first: $timelineCount, after: $timelineCursor) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        __typename\n        ...commitsView_nodes\n        ...issueCommentView_item\n        ...mergedEventView_item\n        ...headRefForcePushedEventView_item\n        ...commitCommentThreadView_item\n        ...crossReferencedEventsView_nodes\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n\nfragment headRefForcePushedEventView_issueish on PullRequest {\n  headRefName\n  headRepositoryOwner {\n    __typename\n    login\n    id\n  }\n  repository {\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment commitsView_nodes on Commit {\n  id\n  author {\n    name\n    user {\n      login\n      id\n    }\n  }\n  ...commitView_commit\n}\n\nfragment issueCommentView_item on IssueComment {\n  author {\n    __typename\n    avatarUrl\n    login\n    ... on Node {\n      id\n    }\n  }\n  bodyHTML\n  createdAt\n  url\n}\n\nfragment mergedEventView_item on MergedEvent {\n  actor {\n    __typename\n    avatarUrl\n    login\n    ... on Node {\n      id\n    }\n  }\n  commit {\n    oid\n    id\n  }\n  mergeRefName\n  createdAt\n}\n\nfragment headRefForcePushedEventView_item on HeadRefForcePushedEvent {\n  actor {\n    __typename\n    avatarUrl\n    login\n    ... on Node {\n      id\n    }\n  }\n  beforeCommit {\n    oid\n    id\n  }\n  afterCommit {\n    oid\n    id\n  }\n  createdAt\n}\n\nfragment commitCommentThreadView_item on CommitCommentThread {\n  commit {\n    oid\n    id\n  }\n  comments(first: 100) {\n    edges {\n      node {\n        id\n        ...commitCommentView_item\n      }\n    }\n  }\n}\n\nfragment crossReferencedEventsView_nodes on CrossReferencedEvent {\n  id\n  referencedAt\n  isCrossRepository\n  actor {\n    __typename\n    login\n    avatarUrl\n    ... on Node {\n      id\n    }\n  }\n  source {\n    __typename\n    ... on RepositoryNode {\n      repository {\n        name\n        owner {\n          __typename\n          login\n          id\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...crossReferencedEventView_item\n}\n\nfragment crossReferencedEventView_item on CrossReferencedEvent {\n  id\n  isCrossRepository\n  source {\n    __typename\n    ... on Issue {\n      number\n      title\n      url\n      issueState: state\n    }\n    ... on PullRequest {\n      number\n      title\n      url\n      prState: state\n    }\n    ... on RepositoryNode {\n      repository {\n        name\n        isPrivate\n        owner {\n          __typename\n          login\n          id\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment commitCommentView_item on CommitComment {\n  author {\n    __typename\n    login\n    avatarUrl\n    ... on Node {\n      id\n    }\n  }\n  commit {\n    oid\n    id\n  }\n  bodyHTML\n  createdAt\n  path\n  position\n}\n\nfragment commitView_commit on Commit {\n  author {\n    name\n    avatarUrl\n    user {\n      login\n      id\n    }\n  }\n  committer {\n    name\n    avatarUrl\n    user {\n      login\n      id\n    }\n  }\n  authoredByCommitter\n  sha: oid\n  message\n  messageHeadlineHTML\n  commitUrl\n}\n\nfragment prStatusContextView_context on StatusContext {\n  context\n  description\n  state\n  targetUrl\n}\n\nfragment prCommitView_item on Commit {\n  committer {\n    avatarUrl\n    name\n    date\n  }\n  messageHeadline\n  messageBody\n  shortSha: abbreviatedOid\n  sha: oid\n  url\n}\n\nfragment issueTimelineController_issue_3D8CP9 on Issue {\n  url\n  timeline(first: $timelineCount, after: $timelineCursor) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        __typename\n        ...commitsView_nodes\n        ...issueCommentView_item\n        ...crossReferencedEventsView_nodes\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n",
+    "text": "query issueishDetailContainerQuery(\n  $repoOwner: String!\n  $repoName: String!\n  $issueishNumber: Int!\n  $timelineCount: Int!\n  $timelineCursor: String\n  $commitCount: Int!\n  $commitCursor: String\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  repository(owner: $repoOwner, name: $repoName) {\n    issueish: issueOrPullRequest(number: $issueishNumber) {\n      __typename\n      ... on PullRequest {\n        ...aggregatedReviewsContainer_pullRequest_qdneZ\n      }\n      ... on Node {\n        id\n      }\n    }\n    ...issueishDetailController_repository_1mXVvq\n    id\n  }\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment issueishDetailController_repository_1mXVvq on Repository {\n  ...issueDetailView_repository\n  ...prCheckoutController_repository\n  ...prDetailView_repository\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n  issue: issueOrPullRequest(number: $issueishNumber) {\n    __typename\n    ... on Issue {\n      title\n      number\n      ...issueDetailView_issue_3D8CP9\n    }\n    ... on Node {\n      id\n    }\n  }\n  pullRequest: issueOrPullRequest(number: $issueishNumber) {\n    __typename\n    ... on PullRequest {\n      title\n      number\n      ...prCheckoutController_pullRequest\n      ...prDetailView_pullRequest_1TnD8A\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment issueDetailView_repository on Repository {\n  id\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n\nfragment prCheckoutController_repository on Repository {\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n\nfragment prDetailView_repository on Repository {\n  id\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n\nfragment issueDetailView_issue_3D8CP9 on Issue {\n  id\n  __typename\n  url\n  state\n  number\n  title\n  bodyHTML\n  author {\n    __typename\n    login\n    avatarUrl\n    url\n    ... on Node {\n      id\n    }\n  }\n  ...issueTimelineController_issue_3D8CP9\n  ...emojiReactionsView_reactable\n}\n\nfragment prCheckoutController_pullRequest on PullRequest {\n  number\n  headRefName\n  headRepository {\n    name\n    url\n    sshUrl\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment prDetailView_pullRequest_1TnD8A on PullRequest {\n  id\n  __typename\n  url\n  isCrossRepository\n  changedFiles\n  state\n  number\n  title\n  bodyHTML\n  baseRefName\n  headRefName\n  countedCommits: commits {\n    totalCount\n  }\n  author {\n    __typename\n    login\n    avatarUrl\n    url\n    ... on Node {\n      id\n    }\n  }\n  ...prCommitsView_pullRequest_38TpXw\n  ...prStatusesView_pullRequest\n  ...prTimelineController_pullRequest_3D8CP9\n  ...emojiReactionsController_reactable\n}\n\nfragment prCommitsView_pullRequest_38TpXw on PullRequest {\n  url\n  commits(first: $commitCount, after: $commitCursor) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        commit {\n          id\n          ...prCommitView_item\n        }\n        id\n        __typename\n      }\n    }\n  }\n}\n\nfragment prStatusesView_pullRequest on PullRequest {\n  id\n  recentCommits: commits(last: 1) {\n    edges {\n      node {\n        commit {\n          status {\n            state\n            contexts {\n              id\n              state\n              ...prStatusContextView_context\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment prTimelineController_pullRequest_3D8CP9 on PullRequest {\n  url\n  ...headRefForcePushedEventView_issueish\n  timeline(first: $timelineCount, after: $timelineCursor) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        __typename\n        ...commitsView_nodes\n        ...issueCommentView_item\n        ...mergedEventView_item\n        ...headRefForcePushedEventView_item\n        ...commitCommentThreadView_item\n        ...crossReferencedEventsView_nodes\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n\nfragment headRefForcePushedEventView_issueish on PullRequest {\n  headRefName\n  headRepositoryOwner {\n    __typename\n    login\n    id\n  }\n  repository {\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment commitsView_nodes on Commit {\n  id\n  author {\n    name\n    user {\n      login\n      id\n    }\n  }\n  ...commitView_commit\n}\n\nfragment issueCommentView_item on IssueComment {\n  author {\n    __typename\n    avatarUrl\n    login\n    ... on Node {\n      id\n    }\n  }\n  bodyHTML\n  createdAt\n  url\n}\n\nfragment mergedEventView_item on MergedEvent {\n  actor {\n    __typename\n    avatarUrl\n    login\n    ... on Node {\n      id\n    }\n  }\n  commit {\n    oid\n    id\n  }\n  mergeRefName\n  createdAt\n}\n\nfragment headRefForcePushedEventView_item on HeadRefForcePushedEvent {\n  actor {\n    __typename\n    avatarUrl\n    login\n    ... on Node {\n      id\n    }\n  }\n  beforeCommit {\n    oid\n    id\n  }\n  afterCommit {\n    oid\n    id\n  }\n  createdAt\n}\n\nfragment commitCommentThreadView_item on CommitCommentThread {\n  commit {\n    oid\n    id\n  }\n  comments(first: 100) {\n    edges {\n      node {\n        id\n        ...commitCommentView_item\n      }\n    }\n  }\n}\n\nfragment crossReferencedEventsView_nodes on CrossReferencedEvent {\n  id\n  referencedAt\n  isCrossRepository\n  actor {\n    __typename\n    login\n    avatarUrl\n    ... on Node {\n      id\n    }\n  }\n  source {\n    __typename\n    ... on RepositoryNode {\n      repository {\n        name\n        owner {\n          __typename\n          login\n          id\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n  ...crossReferencedEventView_item\n}\n\nfragment crossReferencedEventView_item on CrossReferencedEvent {\n  id\n  isCrossRepository\n  source {\n    __typename\n    ... on Issue {\n      number\n      title\n      url\n      issueState: state\n    }\n    ... on PullRequest {\n      number\n      title\n      url\n      prState: state\n    }\n    ... on RepositoryNode {\n      repository {\n        name\n        isPrivate\n        owner {\n          __typename\n          login\n          id\n        }\n        id\n      }\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment commitCommentView_item on CommitComment {\n  author {\n    __typename\n    login\n    avatarUrl\n    ... on Node {\n      id\n    }\n  }\n  commit {\n    oid\n    id\n  }\n  bodyHTML\n  createdAt\n  path\n  position\n}\n\nfragment commitView_commit on Commit {\n  author {\n    name\n    avatarUrl\n    user {\n      login\n      id\n    }\n  }\n  committer {\n    name\n    avatarUrl\n    user {\n      login\n      id\n    }\n  }\n  authoredByCommitter\n  sha: oid\n  message\n  messageHeadlineHTML\n  commitUrl\n}\n\nfragment prStatusContextView_context on StatusContext {\n  context\n  description\n  state\n  targetUrl\n}\n\nfragment prCommitView_item on Commit {\n  committer {\n    avatarUrl\n    name\n    date\n  }\n  messageHeadline\n  messageBody\n  shortSha: abbreviatedOid\n  sha: oid\n  url\n}\n\nfragment issueTimelineController_issue_3D8CP9 on Issue {\n  url\n  timeline(first: $timelineCount, after: $timelineCursor) {\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        __typename\n        ...commitsView_nodes\n        ...issueCommentView_item\n        ...crossReferencedEventsView_nodes\n        ... on Node {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/lib/containers/__generated__/reviewsContainerQuery.graphql.js
+++ b/lib/containers/__generated__/reviewsContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 9609f121bebbad92fd33c103f79e13d9
+ * @relayHash 8a10abb173ca5d7a2e814cc2e5f7a392
  */
 
 /* eslint-disable */
@@ -132,6 +132,7 @@ fragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {
             id
           }
         }
+        authorAssociation
         ...emojiReactionsController_reactable
         __typename
       }
@@ -411,21 +412,21 @@ v12 = {
 v13 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "bodyHTML",
+  "name": "state",
   "args": null,
   "storageKey": null
 },
 v14 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "state",
+  "name": "lastEditedAt",
   "args": null,
   "storageKey": null
 },
 v15 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "lastEditedAt",
+  "name": "bodyHTML",
   "args": null,
   "storageKey": null
 },
@@ -437,6 +438,13 @@ v16 = {
   "storageKey": null
 },
 v17 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "authorAssociation",
+  "args": null,
+  "storageKey": null
+},
+v18 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "reactionGroups",
@@ -479,14 +487,14 @@ v17 = {
     }
   ]
 },
-v18 = {
+v19 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "viewerCanReact",
   "args": null,
   "storageKey": null
 },
-v19 = [
+v20 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -500,7 +508,7 @@ v19 = [
     "type": "Int"
   }
 ],
-v20 = [
+v21 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -673,9 +681,9 @@ return {
                         "concreteType": "PullRequestReview",
                         "plural": false,
                         "selections": [
+                          (v9/*: any*/),
                           (v7/*: any*/),
                           (v13/*: any*/),
-                          (v14/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -683,8 +691,8 @@ return {
                             "args": null,
                             "storageKey": null
                           },
+                          (v14/*: any*/),
                           (v15/*: any*/),
-                          (v9/*: any*/),
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -702,6 +710,7 @@ return {
                           },
                           (v17/*: any*/),
                           (v18/*: any*/),
+                          (v19/*: any*/),
                           (v5/*: any*/)
                         ]
                       }
@@ -723,7 +732,7 @@ return {
                 "alias": null,
                 "name": "reviewThreads",
                 "storageKey": null,
-                "args": (v19/*: any*/),
+                "args": (v20/*: any*/),
                 "concreteType": "PullRequestReviewThreadConnection",
                 "plural": false,
                 "selections": [
@@ -787,7 +796,7 @@ return {
                             "alias": null,
                             "name": "comments",
                             "storageKey": null,
-                            "args": (v20/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "PullRequestReviewCommentConnection",
                             "plural": false,
                             "selections": [
@@ -819,7 +828,7 @@ return {
                                         "storageKey": null
                                       },
                                       (v7/*: any*/),
-                                      (v13/*: any*/),
+                                      (v15/*: any*/),
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
@@ -827,8 +836,8 @@ return {
                                         "args": null,
                                         "storageKey": null
                                       },
-                                      (v14/*: any*/),
-                                      (v18/*: any*/),
+                                      (v13/*: any*/),
+                                      (v19/*: any*/),
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
@@ -858,16 +867,10 @@ return {
                                         "args": null,
                                         "storageKey": null
                                       },
-                                      (v15/*: any*/),
+                                      (v14/*: any*/),
                                       (v9/*: any*/),
-                                      {
-                                        "kind": "ScalarField",
-                                        "alias": null,
-                                        "name": "authorAssociation",
-                                        "args": null,
-                                        "storageKey": null
-                                      },
                                       (v17/*: any*/),
+                                      (v18/*: any*/),
                                       (v5/*: any*/)
                                     ]
                                   }
@@ -879,7 +882,7 @@ return {
                             "kind": "LinkedHandle",
                             "alias": null,
                             "name": "comments",
-                            "args": (v20/*: any*/),
+                            "args": (v21/*: any*/),
                             "handle": "connection",
                             "key": "ReviewCommentsAccumulator_comments",
                             "filters": null
@@ -895,7 +898,7 @@ return {
                 "kind": "LinkedHandle",
                 "alias": null,
                 "name": "reviewThreads",
-                "args": (v19/*: any*/),
+                "args": (v20/*: any*/),
                 "handle": "connection",
                 "key": "ReviewThreadsAccumulator_reviewThreads",
                 "filters": null
@@ -961,7 +964,7 @@ return {
     "operationKind": "query",
     "name": "reviewsContainerQuery",
     "id": null,
-    "text": "query reviewsContainerQuery(\n  $repoOwner: String!\n  $repoName: String!\n  $prNumber: Int!\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  repository(owner: $repoOwner, name: $repoName) {\n    ...reviewsController_repository\n    pullRequest(number: $prNumber) {\n      headRefOid\n      ...aggregatedReviewsContainer_pullRequest_qdneZ\n      ...reviewsController_pullRequest\n      id\n    }\n    id\n  }\n  viewer {\n    ...reviewsController_viewer\n    id\n  }\n}\n\nfragment reviewsController_repository on Repository {\n  ...prCheckoutController_repository\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment reviewsController_pullRequest on PullRequest {\n  id\n  ...prCheckoutController_pullRequest\n}\n\nfragment reviewsController_viewer on User {\n  id\n  login\n  avatarUrl\n}\n\nfragment prCheckoutController_pullRequest on PullRequest {\n  number\n  headRefName\n  headRepository {\n    name\n    url\n    sshUrl\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n\nfragment prCheckoutController_repository on Repository {\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n",
+    "text": "query reviewsContainerQuery(\n  $repoOwner: String!\n  $repoName: String!\n  $prNumber: Int!\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  repository(owner: $repoOwner, name: $repoName) {\n    ...reviewsController_repository\n    pullRequest(number: $prNumber) {\n      headRefOid\n      ...aggregatedReviewsContainer_pullRequest_qdneZ\n      ...reviewsController_pullRequest\n      id\n    }\n    id\n  }\n  viewer {\n    ...reviewsController_viewer\n    id\n  }\n}\n\nfragment reviewsController_repository on Repository {\n  ...prCheckoutController_repository\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment reviewsController_pullRequest on PullRequest {\n  id\n  ...prCheckoutController_pullRequest\n}\n\nfragment reviewsController_viewer on User {\n  id\n  login\n  avatarUrl\n}\n\nfragment prCheckoutController_pullRequest on PullRequest {\n  number\n  headRefName\n  headRepository {\n    name\n    url\n    sshUrl\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n\nfragment prCheckoutController_repository on Repository {\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/lib/containers/__generated__/reviewsContainerQuery.graphql.js
+++ b/lib/containers/__generated__/reviewsContainerQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 5cd00052ea5dd9b378ca9864c9d5a7fb
+ * @relayHash 9609f121bebbad92fd33c103f79e13d9
  */
 
 /* eslint-disable */
@@ -192,6 +192,7 @@ fragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThrea
         createdAt
         lastEditedAt
         url
+        authorAssociation
         ...emojiReactionsController_reactable
         __typename
       }
@@ -813,7 +814,7 @@ return {
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
-                                        "name": "path",
+                                        "name": "position",
                                         "args": null,
                                         "storageKey": null
                                       },
@@ -828,6 +829,13 @@ return {
                                       },
                                       (v14/*: any*/),
                                       (v18/*: any*/),
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "path",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
                                       {
                                         "kind": "LinkedField",
                                         "alias": null,
@@ -846,19 +854,19 @@ return {
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
-                                        "name": "position",
-                                        "args": null,
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "kind": "ScalarField",
-                                        "alias": null,
                                         "name": "createdAt",
                                         "args": null,
                                         "storageKey": null
                                       },
                                       (v15/*: any*/),
                                       (v9/*: any*/),
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "authorAssociation",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
                                       (v17/*: any*/),
                                       (v5/*: any*/)
                                     ]
@@ -953,7 +961,7 @@ return {
     "operationKind": "query",
     "name": "reviewsContainerQuery",
     "id": null,
-    "text": "query reviewsContainerQuery(\n  $repoOwner: String!\n  $repoName: String!\n  $prNumber: Int!\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  repository(owner: $repoOwner, name: $repoName) {\n    ...reviewsController_repository\n    pullRequest(number: $prNumber) {\n      headRefOid\n      ...aggregatedReviewsContainer_pullRequest_qdneZ\n      ...reviewsController_pullRequest\n      id\n    }\n    id\n  }\n  viewer {\n    ...reviewsController_viewer\n    id\n  }\n}\n\nfragment reviewsController_repository on Repository {\n  ...prCheckoutController_repository\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment reviewsController_pullRequest on PullRequest {\n  id\n  ...prCheckoutController_pullRequest\n}\n\nfragment reviewsController_viewer on User {\n  id\n  login\n  avatarUrl\n}\n\nfragment prCheckoutController_pullRequest on PullRequest {\n  number\n  headRefName\n  headRepository {\n    name\n    url\n    sshUrl\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n\nfragment prCheckoutController_repository on Repository {\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n",
+    "text": "query reviewsContainerQuery(\n  $repoOwner: String!\n  $repoName: String!\n  $prNumber: Int!\n  $reviewCount: Int!\n  $reviewCursor: String\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  repository(owner: $repoOwner, name: $repoName) {\n    ...reviewsController_repository\n    pullRequest(number: $prNumber) {\n      headRefOid\n      ...aggregatedReviewsContainer_pullRequest_qdneZ\n      ...reviewsController_pullRequest\n      id\n    }\n    id\n  }\n  viewer {\n    ...reviewsController_viewer\n    id\n  }\n}\n\nfragment reviewsController_repository on Repository {\n  ...prCheckoutController_repository\n}\n\nfragment aggregatedReviewsContainer_pullRequest_qdneZ on PullRequest {\n  id\n  ...reviewSummariesAccumulator_pullRequest_2zzc96\n  ...reviewThreadsAccumulator_pullRequest_CKDvj\n}\n\nfragment reviewsController_pullRequest on PullRequest {\n  id\n  ...prCheckoutController_pullRequest\n}\n\nfragment reviewsController_viewer on User {\n  id\n  login\n  avatarUrl\n}\n\nfragment prCheckoutController_pullRequest on PullRequest {\n  number\n  headRefName\n  headRepository {\n    name\n    url\n    sshUrl\n    owner {\n      __typename\n      login\n      id\n    }\n    id\n  }\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_CKDvj on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1VbUmL\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n\nfragment prCheckoutController_repository on Repository {\n  name\n  owner {\n    __typename\n    login\n    id\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/lib/containers/accumulators/__generated__/reviewCommentsAccumulatorQuery.graphql.js
+++ b/lib/containers/accumulators/__generated__/reviewCommentsAccumulatorQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash cbea83eed5e8044de14e1a883429921c
+ * @relayHash 46a9d8c02a82e693290bcde9566ba3f9
  */
 
 /* eslint-disable */
@@ -70,6 +70,7 @@ fragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThrea
         createdAt
         lastEditedAt
         url
+        authorAssociation
         ...emojiReactionsController_reactable
         __typename
       }
@@ -280,7 +281,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "path",
+                            "name": "position",
                             "args": null,
                             "storageKey": null
                           },
@@ -314,6 +315,13 @@ return {
                             "storageKey": null
                           },
                           {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "path",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
                             "kind": "LinkedField",
                             "alias": null,
                             "name": "author",
@@ -343,13 +351,6 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "position",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
                             "name": "createdAt",
                             "args": null,
                             "storageKey": null
@@ -365,6 +366,13 @@ return {
                             "kind": "ScalarField",
                             "alias": null,
                             "name": "url",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "authorAssociation",
                             "args": null,
                             "storageKey": null
                           },
@@ -437,7 +445,7 @@ return {
     "operationKind": "query",
     "name": "reviewCommentsAccumulatorQuery",
     "id": null,
-    "text": "query reviewCommentsAccumulatorQuery(\n  $id: ID!\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  node(id: $id) {\n    __typename\n    ... on PullRequestReviewThread {\n      ...reviewCommentsAccumulator_reviewThread_1VbUmL\n    }\n    id\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
+    "text": "query reviewCommentsAccumulatorQuery(\n  $id: ID!\n  $commentCount: Int!\n  $commentCursor: String\n) {\n  node(id: $id) {\n    __typename\n    ... on PullRequestReviewThread {\n      ...reviewCommentsAccumulator_reviewThread_1VbUmL\n    }\n    id\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1VbUmL on PullRequestReviewThread {\n  id\n  comments(first: $commentCount, after: $commentCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
     "metadata": {}
   }
 };

--- a/lib/containers/accumulators/__generated__/reviewCommentsAccumulator_reviewThread.graphql.js
+++ b/lib/containers/accumulators/__generated__/reviewCommentsAccumulator_reviewThread.graphql.js
@@ -9,6 +9,7 @@
 /*::
 import type { ReaderFragment } from 'relay-runtime';
 type emojiReactionsController_reactable$ref = any;
+export type CommentAuthorAssociation = "COLLABORATOR" | "CONTRIBUTOR" | "FIRST_TIMER" | "FIRST_TIME_CONTRIBUTOR" | "MEMBER" | "NONE" | "OWNER" | "%future added value";
 export type PullRequestReviewCommentState = "PENDING" | "SUBMITTED" | "%future added value";
 import type { FragmentReference } from "relay-runtime";
 declare export opaque type reviewCommentsAccumulator_reviewThread$ref: FragmentReference;
@@ -36,6 +37,7 @@ export type reviewCommentsAccumulator_reviewThread = {|
         +createdAt: any,
         +lastEditedAt: ?any,
         +url: any,
+        +authorAssociation: CommentAuthorAssociation,
         +$fragmentRefs: emojiReactionsController_reactable$ref,
       |},
     |}>,
@@ -147,7 +149,7 @@ return {
                 {
                   "kind": "ScalarField",
                   "alias": null,
-                  "name": "path",
+                  "name": "position",
                   "args": null,
                   "storageKey": null
                 },
@@ -181,6 +183,13 @@ return {
                   "storageKey": null
                 },
                 {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "path",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
                   "kind": "LinkedField",
                   "alias": null,
                   "name": "author",
@@ -208,13 +217,6 @@ return {
                 {
                   "kind": "ScalarField",
                   "alias": null,
-                  "name": "position",
-                  "args": null,
-                  "storageKey": null
-                },
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
                   "name": "createdAt",
                   "args": null,
                   "storageKey": null
@@ -230,6 +232,13 @@ return {
                   "kind": "ScalarField",
                   "alias": null,
                   "name": "url",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "authorAssociation",
                   "args": null,
                   "storageKey": null
                 },
@@ -255,5 +264,5 @@ return {
 };
 })();
 // prettier-ignore
-(node/*: any*/).hash = 'e6db5422c3f3469415e9508b3db26c50';
+(node/*: any*/).hash = 'd93fe966cd2799dfc28b6c5cd5869b9a';
 module.exports = node;

--- a/lib/containers/accumulators/__generated__/reviewSummariesAccumulatorQuery.graphql.js
+++ b/lib/containers/accumulators/__generated__/reviewSummariesAccumulatorQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 343297dc87b3ae95d77e805a5098c02e
+ * @relayHash c72e0b3ed1b1eb09d79808c2da6a8d56
  */
 
 /* eslint-disable */
@@ -68,6 +68,7 @@ fragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {
             id
           }
         }
+        authorAssociation
         ...emojiReactionsController_reactable
         __typename
       }
@@ -283,14 +284,8 @@ return {
                         "concreteType": "PullRequestReview",
                         "plural": false,
                         "selections": [
+                          (v4/*: any*/),
                           (v3/*: any*/),
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "bodyHTML",
-                            "args": null,
-                            "storageKey": null
-                          },
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -312,7 +307,13 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v4/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "bodyHTML",
+                            "args": null,
+                            "storageKey": null
+                          },
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -339,6 +340,13 @@ return {
                               },
                               (v3/*: any*/)
                             ]
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "authorAssociation",
+                            "args": null,
+                            "storageKey": null
                           },
                           {
                             "kind": "LinkedField",
@@ -416,7 +424,7 @@ return {
     "operationKind": "query",
     "name": "reviewSummariesAccumulatorQuery",
     "id": null,
-    "text": "query reviewSummariesAccumulatorQuery(\n  $url: URI!\n  $reviewCount: Int!\n  $reviewCursor: String\n) {\n  resource(url: $url) {\n    __typename\n    ... on PullRequest {\n      ...reviewSummariesAccumulator_pullRequest_2zzc96\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
+    "text": "query reviewSummariesAccumulatorQuery(\n  $url: URI!\n  $reviewCount: Int!\n  $reviewCursor: String\n) {\n  resource(url: $url) {\n    __typename\n    ... on PullRequest {\n      ...reviewSummariesAccumulator_pullRequest_2zzc96\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment reviewSummariesAccumulator_pullRequest_2zzc96 on PullRequest {\n  url\n  reviews(first: $reviewCount, after: $reviewCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        bodyHTML\n        state\n        submittedAt\n        lastEditedAt\n        url\n        author {\n          __typename\n          login\n          avatarUrl\n          ... on Node {\n            id\n          }\n        }\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
     "metadata": {}
   }
 };

--- a/lib/containers/accumulators/__generated__/reviewSummariesAccumulator_pullRequest.graphql.js
+++ b/lib/containers/accumulators/__generated__/reviewSummariesAccumulator_pullRequest.graphql.js
@@ -9,6 +9,7 @@
 /*::
 import type { ReaderFragment } from 'relay-runtime';
 type emojiReactionsController_reactable$ref = any;
+export type CommentAuthorAssociation = "COLLABORATOR" | "CONTRIBUTOR" | "FIRST_TIMER" | "FIRST_TIME_CONTRIBUTOR" | "MEMBER" | "NONE" | "OWNER" | "%future added value";
 export type PullRequestReviewState = "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED" | "PENDING" | "%future added value";
 import type { FragmentReference } from "relay-runtime";
 declare export opaque type reviewSummariesAccumulator_pullRequest$ref: FragmentReference;
@@ -32,6 +33,7 @@ export type reviewSummariesAccumulator_pullRequest = {|
           +login: string,
           +avatarUrl: any,
         |},
+        +authorAssociation: CommentAuthorAssociation,
         +$fragmentRefs: emojiReactionsController_reactable$ref,
       |},
     |}>,
@@ -202,6 +204,13 @@ return {
                   ]
                 },
                 {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "authorAssociation",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
                   "kind": "FragmentSpread",
                   "name": "emojiReactionsController_reactable",
                   "args": null
@@ -223,5 +232,5 @@ return {
 };
 })();
 // prettier-ignore
-(node/*: any*/).hash = '1e0ba0b2a960b9606a55b7d058ec12d1';
+(node/*: any*/).hash = '1ec93a745279a7a0915ab910e111830b';
 module.exports = node;

--- a/lib/containers/accumulators/__generated__/reviewThreadsAccumulatorQuery.graphql.js
+++ b/lib/containers/accumulators/__generated__/reviewThreadsAccumulatorQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 761c6f217743b5ff38c3b6489afd87bd
+ * @relayHash da375fdf673990d0765dc29484de0292
  */
 
 /* eslint-disable */
@@ -99,6 +99,7 @@ fragment reviewCommentsAccumulator_reviewThread_1UlnwR on PullRequestReviewThrea
         createdAt
         lastEditedAt
         url
+        authorAssociation
         ...emojiReactionsController_reactable
         __typename
       }
@@ -410,7 +411,7 @@ return {
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
-                                        "name": "path",
+                                        "name": "position",
                                         "args": null,
                                         "storageKey": null
                                       },
@@ -444,6 +445,13 @@ return {
                                         "storageKey": null
                                       },
                                       {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "path",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
                                         "kind": "LinkedField",
                                         "alias": null,
                                         "name": "author",
@@ -467,13 +475,6 @@ return {
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
-                                        "name": "position",
-                                        "args": null,
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "kind": "ScalarField",
-                                        "alias": null,
                                         "name": "createdAt",
                                         "args": null,
                                         "storageKey": null
@@ -486,6 +487,13 @@ return {
                                         "storageKey": null
                                       },
                                       (v4/*: any*/),
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "authorAssociation",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
                                       {
                                         "kind": "LinkedField",
                                         "alias": null,
@@ -571,7 +579,7 @@ return {
     "operationKind": "query",
     "name": "reviewThreadsAccumulatorQuery",
     "id": null,
-    "text": "query reviewThreadsAccumulatorQuery(\n  $url: URI!\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n) {\n  resource(url: $url) {\n    __typename\n    ... on PullRequest {\n      ...reviewThreadsAccumulator_pullRequest_3dVVow\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_3dVVow on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1UlnwR\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1UlnwR on PullRequestReviewThread {\n  id\n  comments(first: $commentCount) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
+    "text": "query reviewThreadsAccumulatorQuery(\n  $url: URI!\n  $threadCount: Int!\n  $threadCursor: String\n  $commentCount: Int!\n) {\n  resource(url: $url) {\n    __typename\n    ... on PullRequest {\n      ...reviewThreadsAccumulator_pullRequest_3dVVow\n    }\n    ... on Node {\n      id\n    }\n  }\n}\n\nfragment reviewThreadsAccumulator_pullRequest_3dVVow on PullRequest {\n  url\n  reviewThreads(first: $threadCount, after: $threadCursor) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        isResolved\n        resolvedBy {\n          login\n          id\n        }\n        viewerCanResolve\n        viewerCanUnresolve\n        ...reviewCommentsAccumulator_reviewThread_1UlnwR\n        __typename\n      }\n    }\n  }\n}\n\nfragment reviewCommentsAccumulator_reviewThread_1UlnwR on PullRequestReviewThread {\n  id\n  comments(first: $commentCount) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        state\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n        __typename\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
     "metadata": {}
   }
 };

--- a/lib/containers/accumulators/review-comments-accumulator.js
+++ b/lib/containers/accumulators/review-comments-accumulator.js
@@ -77,6 +77,7 @@ export default createPaginationContainer(BareReviewCommentsAccumulator, {
             createdAt
             lastEditedAt
             url
+            authorAssociation
             ...emojiReactionsController_reactable
           }
         }

--- a/lib/containers/accumulators/review-summaries-accumulator.js
+++ b/lib/containers/accumulators/review-summaries-accumulator.js
@@ -79,6 +79,7 @@ export default createPaginationContainer(BareReviewSummariesAccumulator, {
               login
               avatarUrl
             }
+            authorAssociation
             ...emojiReactionsController_reactable
           }
         }

--- a/lib/mutations/__generated__/addPrReviewCommentMutation.graphql.js
+++ b/lib/mutations/__generated__/addPrReviewCommentMutation.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 02c4f7e8379153b1311c7882780e1970
+ * @relayHash 5665661d41495c80bd3a332f2b4c92f7
  */
 
 /* eslint-disable */
@@ -10,6 +10,7 @@
 /*::
 import type { ConcreteRequest } from 'relay-runtime';
 type emojiReactionsController_reactable$ref = any;
+export type CommentAuthorAssociation = "COLLABORATOR" | "CONTRIBUTOR" | "FIRST_TIMER" | "FIRST_TIME_CONTRIBUTOR" | "MEMBER" | "NONE" | "OWNER" | "%future added value";
 export type AddPullRequestReviewCommentInput = {|
   pullRequestReviewId: string,
   commitOID?: ?any,
@@ -39,6 +40,7 @@ export type addPrReviewCommentMutationResponse = {|
         +createdAt: any,
         +lastEditedAt: ?any,
         +url: any,
+        +authorAssociation: CommentAuthorAssociation,
         +$fragmentRefs: emojiReactionsController_reactable$ref,
       |}
     |}
@@ -75,6 +77,7 @@ mutation addPrReviewCommentMutation(
         createdAt
         lastEditedAt
         url
+        authorAssociation
         ...emojiReactionsController_reactable
       }
     }
@@ -119,7 +122,7 @@ v1 = [
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "path",
+  "name": "position",
   "args": null,
   "storageKey": null
 },
@@ -154,21 +157,21 @@ v6 = {
 v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "avatarUrl",
+  "name": "path",
   "args": null,
   "storageKey": null
 },
 v8 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "login",
+  "name": "avatarUrl",
   "args": null,
   "storageKey": null
 },
 v9 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "position",
+  "name": "login",
   "args": null,
   "storageKey": null
 },
@@ -190,6 +193,13 @@ v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "url",
+  "args": null,
+  "storageKey": null
+},
+v13 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "authorAssociation",
   "args": null,
   "storageKey": null
 };
@@ -234,6 +244,7 @@ return {
                   (v4/*: any*/),
                   (v5/*: any*/),
                   (v6/*: any*/),
+                  (v7/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -243,14 +254,14 @@ return {
                     "concreteType": null,
                     "plural": false,
                     "selections": [
-                      (v7/*: any*/),
-                      (v8/*: any*/)
+                      (v8/*: any*/),
+                      (v9/*: any*/)
                     ]
                   },
-                  (v9/*: any*/),
                   (v10/*: any*/),
                   (v11/*: any*/),
                   (v12/*: any*/),
+                  (v13/*: any*/),
                   {
                     "kind": "FragmentSpread",
                     "name": "emojiReactionsController_reactable",
@@ -301,6 +312,7 @@ return {
                   (v4/*: any*/),
                   (v5/*: any*/),
                   (v6/*: any*/),
+                  (v7/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -317,15 +329,15 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v7/*: any*/),
                       (v8/*: any*/),
+                      (v9/*: any*/),
                       (v3/*: any*/)
                     ]
                   },
-                  (v9/*: any*/),
                   (v10/*: any*/),
                   (v11/*: any*/),
                   (v12/*: any*/),
+                  (v13/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -381,11 +393,11 @@ return {
     "operationKind": "mutation",
     "name": "addPrReviewCommentMutation",
     "id": null,
-    "text": "mutation addPrReviewCommentMutation(\n  $input: AddPullRequestReviewCommentInput!\n) {\n  addPullRequestReviewComment(input: $input) {\n    commentEdge {\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        ...emojiReactionsController_reactable\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
+    "text": "mutation addPrReviewCommentMutation(\n  $input: AddPullRequestReviewCommentInput!\n) {\n  addPullRequestReviewComment(input: $input) {\n    commentEdge {\n      node {\n        id\n        author {\n          __typename\n          avatarUrl\n          login\n          ... on Node {\n            id\n          }\n        }\n        bodyHTML\n        isMinimized\n        viewerCanReact\n        path\n        position\n        createdAt\n        lastEditedAt\n        url\n        authorAssociation\n        ...emojiReactionsController_reactable\n      }\n    }\n  }\n}\n\nfragment emojiReactionsController_reactable on Reactable {\n  id\n  ...emojiReactionsView_reactable\n}\n\nfragment emojiReactionsView_reactable on Reactable {\n  id\n  reactionGroups {\n    content\n    viewerHasReacted\n    users {\n      totalCount\n    }\n  }\n  viewerCanReact\n}\n",
     "metadata": {}
   }
 };
 })();
 // prettier-ignore
-(node/*: any*/).hash = '0da3e8cff62cf69dcbb7d5c461616030';
+(node/*: any*/).hash = '75ec864a015eb9def27a9f6fcd181c83';
 module.exports = node;

--- a/lib/mutations/add-pr-review-comment.js
+++ b/lib/mutations/add-pr-review-comment.js
@@ -22,6 +22,7 @@ const mutation = graphql`
           createdAt
           lastEditedAt
           url
+          authorAssociation
           ...emojiReactionsController_reactable
         }
       }
@@ -62,6 +63,7 @@ export default (environment, {body, inReplyTo, reviewID, threadID, viewerID, pat
     comment.setValue(false, 'viewerCanReact');
     comment.setValue(moment().toISOString(), 'createdAt');
     comment.setValue(null, 'lastEditedAt');
+    comment.setValue('NONE', 'authorAssociation');
     comment.setValue('https://github.com', 'url');
     comment.setValue(path, 'path');
     comment.setValue(position, 'position');

--- a/lib/views/reviews-view.js
+++ b/lib/views/reviews-view.js
@@ -281,6 +281,7 @@ export default class ReviewsView extends React.Component {
           <a className="github-ReviewSummary-username" href={`https://github.com/${reviewAuthor.login}`}>{reviewAuthor.login}</a>
           <span className="github-ReviewSummary-type">{copy}</span>
           {this.renderEditedLink(review)}
+          {this.renderAuthorAssociation(review)}
           <Timeago className="github-ReviewSummary-timeAgo" time={review.submittedAt} displayStyle="short" />
         </header>
         <main className="github-ReviewSummary-comment">

--- a/lib/views/reviews-view.js
+++ b/lib/views/reviews-view.js
@@ -522,15 +522,11 @@ export default class ReviewsView extends React.Component {
   }
 
   renderAuthorAssociation(entity) {
-    if (!entity.authorAssociation) {
-      return null;
-    } else {
-      const text = authorAssociationText[entity.authorAssociation];
-      if (!text) { return null; }
-      return (
-        <span className="github-Review-authorAssociationBadge badge">{text}</span>
-      );
-    }
+    const text = authorAssociationText[entity.authorAssociation];
+    if (!text) { return null; }
+    return (
+      <span className="github-Review-authorAssociationBadge badge">{text}</span>
+    );
   }
 
   renderComment = comment => {

--- a/lib/views/reviews-view.js
+++ b/lib/views/reviews-view.js
@@ -20,6 +20,16 @@ import RefHolder from '../models/ref-holder';
 import {toNativePathSep} from '../helpers';
 import {addEvent} from '../reporter-proxy';
 
+const authorAssociationText = {
+  MEMBER: 'Member',
+  OWNER: 'Owner',
+  COLLABORATOR: 'Collaborator',
+  CONTRIBUTOR: 'Contributor',
+  FIRST_TIME_CONTRIBUTOR: 'First-time contributor',
+  FIRST_TIMER: 'First-timer',
+  NONE: null,
+};
+
 export default class ReviewsView extends React.Component {
   static propTypes = {
     // Relay results
@@ -510,6 +520,18 @@ export default class ReviewsView extends React.Component {
     }
   }
 
+  renderAuthorAssociation(entity) {
+    if (!entity.authorAssociation) {
+      return null;
+    } else {
+      const text = authorAssociationText[entity.authorAssociation];
+      if (!text) { return null; }
+      return (
+        <span className="github-Review-authorAssociationBadge badge">{text}</span>
+      );
+    }
+  }
+
   renderComment = comment => {
     if (comment.isMinimized) {
       return (
@@ -536,6 +558,7 @@ export default class ReviewsView extends React.Component {
               <Timeago displayStyle="long" time={comment.createdAt} />
             </a>
             {this.renderEditedLink(comment)}
+            {this.renderAuthorAssociation(comment)}
             {comment.state === 'PENDING' && (
               <span className="github-Review-pendingBadge badge badge-warning">pending</span>
             )}

--- a/lib/views/reviews-view.js
+++ b/lib/views/reviews-view.js
@@ -273,15 +273,17 @@ export default class ReviewsView extends React.Component {
     const reviewAuthor = {avatarUrl: '', login: '', ...review.author};
     return (
       <div className="github-ReviewSummary" key={review.id}>
-        <header className="github-ReviewSummary-header">
-          <span className={`github-ReviewSummary-icon icon ${icon}`} />
-          <img className="github-ReviewSummary-avatar"
-            src={reviewAuthor.avatarUrl} alt={reviewAuthor.login}
-          />
-          <a className="github-ReviewSummary-username" href={`https://github.com/${reviewAuthor.login}`}>{reviewAuthor.login}</a>
-          <span className="github-ReviewSummary-type">{copy}</span>
-          {this.renderEditedLink(review)}
-          {this.renderAuthorAssociation(review)}
+        <header className="github-Review-header">
+          <div className="github-Review-header-authorData">
+            <span className={`github-ReviewSummary-icon icon ${icon}`} />
+            <img className="github-ReviewSummary-avatar"
+              src={reviewAuthor.avatarUrl} alt={reviewAuthor.login}
+            />
+            <a className="github-ReviewSummary-username" href={`https://github.com/${reviewAuthor.login}`}>{reviewAuthor.login}</a>
+            <span className="github-ReviewSummary-type">{copy}</span>
+            {this.renderEditedLink(review)}
+            {this.renderAuthorAssociation(review)}
+          </div>
           <Timeago className="github-ReviewSummary-timeAgo" time={review.submittedAt} displayStyle="short" />
         </header>
         <main className="github-ReviewSummary-comment">

--- a/styles/review.less
+++ b/styles/review.less
@@ -406,6 +406,10 @@
     margin-left: @component-padding;
   }
 
+  &-authorAssociationBadge {
+    margin-left: @component-padding;
+  }
+
   &-text  {
     font-size: @font-size-body;
 

--- a/test/builder/graphql/pr.js
+++ b/test/builder/graphql/pr.js
@@ -41,6 +41,7 @@ export const CommentBuilder = createSpecBuilderClass('PullRequestReviewComment',
   state: {default: 'SUBMITTED'},
   viewerCanReact: {default: true},
   viewerCanMinimize: {default: true},
+  authorAssociation: {default: 'NONE'},
 }, 'Node & Comment & Deletable & Updatable & UpdatableComment & Reactable & RepositoryNode');
 
 export const CommentConnectionBuilder = createConnectionBuilderClass('PullRequestReviewComment', CommentBuilder);
@@ -67,6 +68,7 @@ export const ReviewBuilder = createSpecBuilderClass('PullRequestReview', {
   comments: {linked: CommentConnectionBuilder},
   viewerCanReact: {default: true},
   reactionGroups: {linked: ReactionGroupBuilder, plural: true, singularName: 'reactionGroup'},
+  authorAssociation: {default: 'NONE'},
 }, 'Node & Comment & Deletable & Updatable & UpdatableComment & Reactable & RepositoryNode');
 
 export const CommitConnectionBuilder = createConnectionBuilderClass('PullRequestCommit', CommentBuilder);

--- a/test/views/reviews-view.test.js
+++ b/test/views/reviews-view.test.js
@@ -138,6 +138,34 @@ describe('ReviewsView', function() {
     assert.isFalse(reviews.at(6).exists('.github-Review-authorAssociationBadge'));
   });
 
+  it('displays an author association badge for review thread comments', function() {
+    const {summaries, commentThreads} = aggregatedReviewsBuilder()
+      .addReviewSummary(r => r.id(0))
+      .addReviewThread(t => {
+        t.thread(t0 => t0.id('abcd'));
+        t.addComment(c => c.id(0).authorAssociation('MEMBER'));
+        t.addComment(c => c.id(1).authorAssociation('OWNER'));
+        t.addComment(c => c.id(2).authorAssociation('COLLABORATOR'));
+        t.addComment(c => c.id(3).authorAssociation('CONTRIBUTOR'));
+        t.addComment(c => c.id(4).authorAssociation('FIRST_TIME_CONTRIBUTOR'));
+        t.addComment(c => c.id(5).authorAssociation('FIRST_TIMER'));
+        t.addComment(c => c.id(6).authorAssociation('NONE'));
+      })
+      .build();
+
+    const wrapper = shallow(buildApp({summaries, commentThreads}));
+
+    const comments = wrapper.find('.github-Review-comment');
+    assert.lengthOf(comments, 7);
+    assert.strictEqual(comments.at(0).find('.github-Review-authorAssociationBadge').text(), 'Member');
+    assert.strictEqual(comments.at(1).find('.github-Review-authorAssociationBadge').text(), 'Owner');
+    assert.strictEqual(comments.at(2).find('.github-Review-authorAssociationBadge').text(), 'Collaborator');
+    assert.strictEqual(comments.at(3).find('.github-Review-authorAssociationBadge').text(), 'Contributor');
+    assert.strictEqual(comments.at(4).find('.github-Review-authorAssociationBadge').text(), 'First-time contributor');
+    assert.strictEqual(comments.at(5).find('.github-Review-authorAssociationBadge').text(), 'First-timer');
+    assert.isFalse(comments.at(6).exists('.github-Review-authorAssociationBadge'));
+  });
+
   it('calls openIssueish when clicking on an issueish link in a review summary', function() {
     const openIssueish = sinon.spy();
 

--- a/test/views/reviews-view.test.js
+++ b/test/views/reviews-view.test.js
@@ -113,6 +113,31 @@ describe('ReviewsView', function() {
     assert.lengthOf(wrapper.find('details.github-Review'), 2);
   });
 
+  it('displays an author association badge for review summaries', function() {
+    const {summaries, commentThreads} = aggregatedReviewsBuilder()
+      .addReviewSummary(r => r.id(0).authorAssociation('MEMBER'))
+      .addReviewSummary(r => r.id(1).authorAssociation('OWNER'))
+      .addReviewSummary(r => r.id(2).authorAssociation('COLLABORATOR'))
+      .addReviewSummary(r => r.id(3).authorAssociation('CONTRIBUTOR'))
+      .addReviewSummary(r => r.id(4).authorAssociation('FIRST_TIME_CONTRIBUTOR'))
+      .addReviewSummary(r => r.id(5).authorAssociation('FIRST_TIMER'))
+      .addReviewSummary(r => r.id(6).authorAssociation('NONE'))
+      .build();
+
+    const wrapper = shallow(buildApp({summaries, commentThreads}));
+
+
+    const reviews = wrapper.find('.github-ReviewSummary');
+    assert.lengthOf(reviews, 7);
+    assert.strictEqual(reviews.at(0).find('.github-Review-authorAssociationBadge').text(), 'Member');
+    assert.strictEqual(reviews.at(1).find('.github-Review-authorAssociationBadge').text(), 'Owner');
+    assert.strictEqual(reviews.at(2).find('.github-Review-authorAssociationBadge').text(), 'Collaborator');
+    assert.strictEqual(reviews.at(3).find('.github-Review-authorAssociationBadge').text(), 'Contributor');
+    assert.strictEqual(reviews.at(4).find('.github-Review-authorAssociationBadge').text(), 'First-time contributor');
+    assert.strictEqual(reviews.at(5).find('.github-Review-authorAssociationBadge').text(), 'First-timer');
+    assert.isFalse(reviews.at(6).exists('.github-Review-authorAssociationBadge'));
+  });
+
   it('calls openIssueish when clicking on an issueish link in a review summary', function() {
     const openIssueish = sinon.spy();
 
@@ -286,7 +311,6 @@ describe('ReviewsView', function() {
         assert.strictEqual(editedWrapper.prop('href'), commentUrl);
       });
     });
-
 
     describe('each thread', function() {
       it('displays correct data', function() {

--- a/test/views/reviews-view.test.js
+++ b/test/views/reviews-view.test.js
@@ -238,52 +238,55 @@ describe('ReviewsView', function() {
       assert.strictEqual(comment.find('em').text(), 'This comment was hidden');
     });
 
-    it('indicates that a review summary comment has been edited', function() {
-      const summary = wrapper.find('.github-ReviewSummary').at(0);
+    describe('indication that a comment has been edited', function() {
+      it('indicates that a review summary comment has been edited', function() {
+        const summary = wrapper.find('.github-ReviewSummary').at(0);
 
-      assert.isFalse(summary.exists('.github-Review-edited'));
+        assert.isFalse(summary.exists('.github-Review-edited'));
 
-      const commentUrl = 'https://github.com/atom/github/pull/1995#discussion_r272475592';
-      const updatedProps = aggregatedReviewsBuilder()
-        .addReviewSummary(r => r.id(0).lastEditedAt('2018-12-27T17:51:17Z').url(commentUrl))
-        .build();
+        const commentUrl = 'https://github.com/atom/github/pull/1995#discussion_r272475592';
+        const updatedProps = aggregatedReviewsBuilder()
+          .addReviewSummary(r => r.id(0).lastEditedAt('2018-12-27T17:51:17Z').url(commentUrl))
+          .build();
 
-      wrapper.setProps({...updatedProps});
+        wrapper.setProps({...updatedProps});
 
-      const updatedSummary = wrapper.find('.github-ReviewSummary').at(0);
-      assert.isTrue(updatedSummary.exists('.github-Review-edited'));
-      const editedWrapper = updatedSummary.find('a.github-Review-edited');
-      assert.strictEqual(editedWrapper.text(), 'edited');
-      assert.strictEqual(editedWrapper.prop('href'), commentUrl);
+        const updatedSummary = wrapper.find('.github-ReviewSummary').at(0);
+        assert.isTrue(updatedSummary.exists('.github-Review-edited'));
+        const editedWrapper = updatedSummary.find('a.github-Review-edited');
+        assert.strictEqual(editedWrapper.text(), 'edited');
+        assert.strictEqual(editedWrapper.prop('href'), commentUrl);
+      });
+
+      it('indicates that a thread comment has been edited', function() {
+        const comment = wrapper.find('details.github-Review').at(0).find('.github-Review-comment').at(0);
+        assert.isFalse(comment.exists('.github-Review-edited'));
+
+        const commentUrl = 'https://github.com/atom/github/pull/1995#discussion_r272475592';
+        const updatedProps = aggregatedReviewsBuilder()
+          .addReviewSummary(r => r.id(0))
+          .addReviewThread(t => {
+            t.thread(t0 => t0.id('abcd'));
+            t.addComment(c =>
+              c.id(0).path('dir/file0').position(10).bodyHTML('i have opinions.').author(a => a.login('user0').avatarUrl('user0.jpg'))
+                .lastEditedAt('2018-12-27T17:51:17Z').url(commentUrl),
+            );
+            t.addComment(c =>
+              c.id(1).path('file0').position(10).bodyHTML('i disagree.').author(a => a.login('user1').avatarUrl('user1.jpg')).isMinimized(true),
+            );
+          })
+          .build();
+
+        wrapper.setProps({...updatedProps});
+
+        const updatedComment = wrapper.find('details.github-Review').at(0).find('.github-Review-comment').at(0);
+        assert.isTrue(updatedComment.exists('.github-Review-edited'));
+        const editedWrapper = updatedComment.find('a.github-Review-edited');
+        assert.strictEqual(editedWrapper.text(), 'edited');
+        assert.strictEqual(editedWrapper.prop('href'), commentUrl);
+      });
     });
 
-    it('indicates that a thread comment has been edited', function() {
-      const comment = wrapper.find('details.github-Review').at(0).find('.github-Review-comment').at(0);
-      assert.isFalse(comment.exists('.github-Review-edited'));
-
-      const commentUrl = 'https://github.com/atom/github/pull/1995#discussion_r272475592';
-      const updatedProps = aggregatedReviewsBuilder()
-        .addReviewSummary(r => r.id(0))
-        .addReviewThread(t => {
-          t.thread(t0 => t0.id('abcd'));
-          t.addComment(c =>
-            c.id(0).path('dir/file0').position(10).bodyHTML('i have opinions.').author(a => a.login('user0').avatarUrl('user0.jpg'))
-              .lastEditedAt('2018-12-27T17:51:17Z').url(commentUrl),
-          );
-          t.addComment(c =>
-            c.id(1).path('file0').position(10).bodyHTML('i disagree.').author(a => a.login('user1').avatarUrl('user1.jpg')).isMinimized(true),
-          );
-        })
-        .build();
-
-      wrapper.setProps({...updatedProps});
-
-      const updatedComment = wrapper.find('details.github-Review').at(0).find('.github-Review-comment').at(0);
-      assert.isTrue(updatedComment.exists('.github-Review-edited'));
-      const editedWrapper = updatedComment.find('a.github-Review-edited');
-      assert.strictEqual(editedWrapper.text(), 'edited');
-      assert.strictEqual(editedWrapper.prop('href'), commentUrl);
-    });
 
     describe('each thread', function() {
       it('displays correct data', function() {


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Our trusty Community and Safety team pointed out that displaying "first time contributor" badges encourages people to be kind to new folks, etc. 

This PR introduces `authorAssociation` information provided by the GitHub GraphQL API to indicate the author's relationship to the repository (member, owner, collaborator, contributor, first-time contributor, first-timer, none). See [API docs](https://developer.github.com/v4/enum/commentauthorassociation/) for more information.

Badges for author association are displayed on review summary comments as well as review thread comments.

See #2056 for reference.

### Screenshot/Gif

<!-- If the changes are visual, add a screenshot or record a Gif. This doesn't have to be updated during implementation, but after a PR is merged, a final screenshot/gif should be added. It might get used for blog posts, documentation etc. Write "N/A" if not applicable. -->

Summaries:

<img width="404" alt="Reviews__5_—___src_trepo" src="https://user-images.githubusercontent.com/7910250/56397269-d0d5ce00-61f7-11e9-9011-9a3d6f4dbeb1.png">

Review threads:

<img width="414" alt="Reviews__5_—___src_trepo_and_Comparing_master___ku-add-author-association_·_atom_github" src="https://user-images.githubusercontent.com/7910250/56397309-fa8ef500-61f7-11e9-8a3a-06f5f5254593.png">

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None were considered.

### Benefits

<!-- What benefits will be realized by the code change? -->

Folks have more context about the author of the comments and can therefore adjust their responses accordingly. For example, responses to comments made by "First-time contributors" warrant extra thought and attention, to ensure that we are welcoming new contributors and effectively growing our communities -- https://github.blog/2017-07-25-making-it-easier-to-grow-communities-on-github/

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

There is limited space in comment headers. An additional badge adds some visual noise, and if the panel width isn't large enough, the badge appears on a separate line:

<img width="290" alt="Reviews__5_—___src_trepo" src="https://user-images.githubusercontent.com/7910250/56397337-27dba300-61f8-11e9-88f0-e4c1782b415e.png">

### Applicable Issues

<!-- Enter any applicable Issues here -->
#2056

### Metrics

<!-- What metrics are associated with this code change and what questions can they help us answer? Write "N/A" if not applicable. -->
N/A

### Tests

<!-- 

How did you verify that your change has the desired effects?
- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

What unit or integration tests were (or will be) added to help protect against future regressions? 
For manual testing, be sure to describe in detail the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and the results you observed.
If you chose not to include a specific test, please explain why. 

Write "N/A" if not applicable. 

-->

Added unit tests to ensure that text shows up correctly for each author association value (member, owner, collaborator, contributor, first-time contributor, first-timer, none). Did this for both review summary comments and thread comments.

### Documentation

<!-- Describe the documentation added or improved. Write "N/A" if not applicable. -->

N/A

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where the merge message did not show up in the commit message box.
- Increased the performance of rendering diffs.

-->

> Add author association badges to GitHub review comments.

### User Experience Research (Optional)

<!-- If this change would benefit from UXR, please state assumptions or hypotheses and specify if they are to be validated before or after releasing. Examples include investigating discoverability, verifying performance improvements, tracking metrics, etc. -->

N/A

TODO: make summary badges drop to new line (as is the case for thread comments)

<img width="269" alt="Reviews__5_—___src_trepo" src="https://user-images.githubusercontent.com/7910250/56397363-43df4480-61f8-11e9-855a-eac822eb04b1.png">
