### PR TITLE
Get author info tooltips working again

### DIFF
--- a/lib/containers/__generated__/userMentionTooltipContainer_repositoryOwner.graphql.js
+++ b/lib/containers/__generated__/userMentionTooltipContainer_repositoryOwner.graphql.js
@@ -17,7 +17,7 @@ export type userMentionTooltipContainer_repositoryOwner = {|
     +totalCount: number
   |},
   +company?: ?string,
-  +members?: {|
+  +membersWithRole?: {|
     +totalCount: number
   |},
   +$refType: userMentionTooltipContainer_repositoryOwner$ref,
@@ -73,10 +73,10 @@ return {
         {
           "kind": "LinkedField",
           "alias": null,
-          "name": "members",
+          "name": "membersWithRole",
           "storageKey": null,
           "args": null,
-          "concreteType": "UserConnection",
+          "concreteType": "OrganizationMemberConnection",
           "plural": false,
           "selections": (v0/*: any*/)
         }
@@ -99,5 +99,5 @@ return {
 };
 })();
 // prettier-ignore
-(node/*: any*/).hash = 'e59070cd60b11e3732403a074496e66c';
+(node/*: any*/).hash = '3ee858460adcfbee1dfc27cf8dc46332';
 module.exports = node;

--- a/lib/containers/user-mention-tooltip-container.js
+++ b/lib/containers/user-mention-tooltip-container.js
@@ -17,7 +17,7 @@ class UserMentionTooltip extends React.Component {
       company: PropTypes.string,
 
       // Organizations
-      members: PropTypes.shape({
+      membersWithRole: PropTypes.shape({
         totalCount: PropTypes.number.isRequired,
       }),
     }).isRequired,
@@ -48,9 +48,17 @@ class UserMentionTooltip extends React.Component {
 export default createFragmentContainer(UserMentionTooltip, {
   repositoryOwner: graphql`
     fragment userMentionTooltipContainer_repositoryOwner on RepositoryOwner {
-      login avatarUrl repositories { totalCount }
-      ... on User { company }
-      ... on Organization { members { totalCount } }
+      login
+      avatarUrl
+      repositories { totalCount }
+      ... on User {
+        company
+      }
+      ... on Organization {
+        membersWithRole {
+          totalCount
+        }
+      }
     }
   `,
 });

--- a/lib/containers/user-mention-tooltip-container.js
+++ b/lib/containers/user-mention-tooltip-container.js
@@ -25,7 +25,7 @@ class UserMentionTooltip extends React.Component {
 
   render() {
     const owner = this.props.repositoryOwner;
-    const {login, company, repositories, members} = owner;
+    const {login, company, repositories, membersWithRole} = owner;
     return (
       <div className="github-UserMentionTooltip">
         <div className="github-UserMentionTooltip-avatar">
@@ -36,7 +36,9 @@ class UserMentionTooltip extends React.Component {
             <Octicon icon="mention" /><strong>{login}</strong>
           </div>
           {company && <div><Octicon icon="briefcase" /><span>{company}</span></div>}
-          {members && <div><Octicon icon="organization" /><span>{members.totalCount} members</span></div>}
+          {membersWithRole && (
+            <div><Octicon icon="organization" /><span>{membersWithRole.totalCount} members</span></div>
+          )}
           <div><Octicon icon="repo" /><span>{repositories.totalCount} repositories</span></div>
         </div>
         <div style={{clear: 'both'}} />

--- a/lib/containers/user-mention-tooltip-container.js
+++ b/lib/containers/user-mention-tooltip-container.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import Octicon from '../atom/octicon';
 
-class UserMentionTooltip extends React.Component {
+export class BareUserMentionTooltipContainer extends React.Component {
   static propTypes = {
     repositoryOwner: PropTypes.shape({
       login: PropTypes.string.isRequired,
@@ -47,7 +47,7 @@ class UserMentionTooltip extends React.Component {
   }
 }
 
-export default createFragmentContainer(UserMentionTooltip, {
+export default createFragmentContainer(BareUserMentionTooltipContainer, {
   repositoryOwner: graphql`
     fragment userMentionTooltipContainer_repositoryOwner on RepositoryOwner {
       login

--- a/lib/items/__generated__/userMentionTooltipItemQuery.graphql.js
+++ b/lib/items/__generated__/userMentionTooltipItemQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash cbae41158b2bedaa2322e49d0f1da45d
+ * @relayHash ef326a01ce14bb3be20ff2572872ce35
  */
 
 /* eslint-disable */
@@ -46,7 +46,7 @@ fragment userMentionTooltipContainer_repositoryOwner on RepositoryOwner {
     company
   }
   ... on Organization {
-    members {
+    membersWithRole {
       totalCount
     }
   }
@@ -165,10 +165,10 @@ return {
               {
                 "kind": "LinkedField",
                 "alias": null,
-                "name": "members",
+                "name": "membersWithRole",
                 "storageKey": null,
                 "args": null,
-                "concreteType": "UserConnection",
+                "concreteType": "OrganizationMemberConnection",
                 "plural": false,
                 "selections": (v2/*: any*/)
               }
@@ -195,7 +195,7 @@ return {
     "operationKind": "query",
     "name": "userMentionTooltipItemQuery",
     "id": null,
-    "text": "query userMentionTooltipItemQuery(\n  $username: String!\n) {\n  repositoryOwner(login: $username) {\n    __typename\n    ...userMentionTooltipContainer_repositoryOwner\n    id\n  }\n}\n\nfragment userMentionTooltipContainer_repositoryOwner on RepositoryOwner {\n  login\n  avatarUrl\n  repositories {\n    totalCount\n  }\n  ... on User {\n    company\n  }\n  ... on Organization {\n    members {\n      totalCount\n    }\n  }\n}\n",
+    "text": "query userMentionTooltipItemQuery(\n  $username: String!\n) {\n  repositoryOwner(login: $username) {\n    __typename\n    ...userMentionTooltipContainer_repositoryOwner\n    id\n  }\n}\n\nfragment userMentionTooltipContainer_repositoryOwner on RepositoryOwner {\n  login\n  avatarUrl\n  repositories {\n    totalCount\n  }\n  ... on User {\n    company\n  }\n  ... on Organization {\n    membersWithRole {\n      totalCount\n    }\n  }\n}\n",
     "metadata": {}
   }
 };

--- a/test/builder/graphql/base/spec.js
+++ b/test/builder/graphql/base/spec.js
@@ -52,7 +52,7 @@ export class FragmentSpec extends Spec {
         );
         throw new Error(`Unrecognized node kind ${node.kind}`);
       } else {
-        return fn(node);
+        return fn({...node});
       }
     });
 
@@ -62,7 +62,6 @@ export class FragmentSpec extends Spec {
       for (let i = selections.length - 1; i >= 0; i--) {
         if (selections[i].kind === 'InlineFragment') {
           // Replace inline fragments in-place with their selected fields *if* the GraphQL type name matches.
-
           if (!typeNameSet.has(selections[i].type)) {
             continue;
           }
@@ -77,6 +76,7 @@ export class FragmentSpec extends Spec {
     };
 
     for (const node of this.nodes) {
+      node.selections = node.selections.slice();
       flattenFragments(node.selections);
     }
   }

--- a/test/builder/graphql/user.js
+++ b/test/builder/graphql/user.js
@@ -1,5 +1,9 @@
-import {createSpecBuilderClass} from './base';
+import {createSpecBuilderClass, createConnectionBuilderClass, createUnionBuilderClass, defer} from './base';
 import {nextID} from '../id-sequence';
+
+const RepositoryBuilder = defer('../repository', 'RepositoryBuilder');
+
+export const RepositoryConnectionBuilder = createConnectionBuilderClass('Repository', RepositoryBuilder);
 
 export const UserBuilder = createSpecBuilderClass('User', {
   __typename: {default: 'User'},
@@ -10,8 +14,35 @@ export const UserBuilder = createSpecBuilderClass('User', {
     const login = f.login || 'login';
     return `https://github.com/${login}`;
   }},
+  company: {default: 'GitHub'},
+  repositories: {linked: RepositoryConnectionBuilder},
+},
+'Node & Actor & RegistryPackageOwner & RegistryPackageSearch & ProjectOwner ' +
+  '& RepositoryOwner & UniformResourceLocatable',
+);
+
+export const OrganizationMemberConnectionBuilder = createConnectionBuilderClass('OrganizationMember', UserBuilder);
+
+export const OrganizationBuilder = createSpecBuilderClass('Organization', {
+  login: {default: 'someone'},
+  avatarUrl: {default: 'https://avatars3.githubusercontent.com/u/17565?s=32&v=4'},
+  repositories: {linked: RepositoryConnectionBuilder},
+  membersWithRole: {linked: OrganizationMemberConnectionBuilder},
+},
+'Node & Actor & RegistryPackageOwner & RegistryPackageSearch & ProjectOwner ' +
+  '& RepositoryOwner & UniformResourceLocatable & MemberStatusable',
+);
+
+export const RepositoryOwnerBuilder = createUnionBuilderClass('RepositoryOwner', {
+  beUser: UserBuilder,
+  beOrganization: OrganizationBuilder,
+  default: 'beUser',
 });
 
 export function userBuilder(...nodes) {
   return UserBuilder.onFragmentQuery(nodes);
+}
+
+export function organizationBuilder(...nodes) {
+  return OrganizationBuilder.onFragmentQuery(nodes);
 }

--- a/test/containers/user-mention-tooltip-container.test.js
+++ b/test/containers/user-mention-tooltip-container.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import {BareUserMentionTooltipContainer} from '../../lib/containers/user-mention-tooltip-container';
+import {userBuilder, organizationBuilder} from '../builder/graphql/user';
+
+import ownerQuery from '../../lib/containers/__generated__/userMentionTooltipContainer_repositoryOwner.graphql';
+
+describe('UserMentionTooltipContainer', function() {
+  function buildApp(override = {}) {
+    const props = {
+      ...override,
+    };
+
+    return <BareUserMentionTooltipContainer {...props} />;
+  }
+
+  it('renders information about a User', function() {
+    const wrapper = shallow(buildApp({
+      repositoryOwner: userBuilder(ownerQuery)
+        .login('someone')
+        .avatarUrl('https://i.redd.it/03xcogvbr6v21.jpg')
+        .company('Infinity, Ltd.')
+        .repositories(conn => conn.totalCount(5))
+        .build(),
+    }));
+
+    assert.strictEqual(wrapper.find('img').prop('src'), 'https://i.redd.it/03xcogvbr6v21.jpg');
+    assert.isTrue(wrapper.find('span').someWhere(s => s.text() === 'Infinity, Ltd.'));
+    assert.isTrue(wrapper.find('span').someWhere(s => s.text() === '5 repositories'));
+  });
+
+  it('renders information about an Organization', function() {
+    const wrapper = shallow(buildApp({
+      repositoryOwner: organizationBuilder(ownerQuery)
+        .login('acme')
+        .avatarUrl('https://i.redd.it/eekf8onik0v21.jpg')
+        .membersWithRole(conn => conn.totalCount(10))
+        .repositories(conn => conn.totalCount(5))
+        .build(),
+    }));
+
+    assert.strictEqual(wrapper.find('img').prop('src'), 'https://i.redd.it/eekf8onik0v21.jpg');
+    assert.isTrue(wrapper.find('span').someWhere(s => s.text() === '10 members'));
+    assert.isTrue(wrapper.find('span').someWhere(s => s.text() === '5 repositories'));
+  });
+});


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Fixes #2094 by updating the GraphQL query and component props to reflect the renaming of `Organization#membersWithRole` to `Organization#members`.

### Screenshot

_N/A_

### Alternate Designs

UserMentionTooltipItem is one of the old-style tooltips. I could modernize it, but I opted for a surgical fix here.

### Benefits

User mention tooltips will work again.

### Possible Drawbacks

_N/A_

### Applicable Issues

Fixes #2094

### Metrics

_N/A_

### Tests

I tested it out with the PR in the issue screenshot :smile:

### Documentation

_N/A_

### Release Notes

* User mention tooltips correctly fetch data again.

### User Experience Research (Optional)

_N/A_