### PR TITLE
Exclude deprecated fields from the fetched schema

### DIFF
--- a/script/fetch-schema
+++ b/script/fetch-schema
@@ -3,12 +3,99 @@ const fs = require('fs');
 const path = require('path');
 
 const fetch = require('node-fetch');
-const {
-  buildClientSchema,
-  introspectionQuery,
-  printSchema,
-} = require('graphql/utilities');
+const {buildClientSchema, printSchema} = require('graphql/utilities');
 const schemaPath = path.resolve(__dirname, '..', 'graphql', 'schema');
+
+const introspectionQuery = `
+  query IntrospectionQuery {
+    __schema {
+      queryType { name }
+      mutationType { name }
+      subscriptionType { name }
+      types {
+        ...FullType
+      }
+      directives {
+        name
+        description
+        locations
+        args {
+          ...InputValue
+        }
+      }
+    }
+  }
+  fragment FullType on __Type {
+    kind
+    name
+    description
+    fields(includeDeprecated: false) {
+      name
+      description
+      args {
+        ...InputValue
+      }
+      type {
+        ...TypeRef
+      }
+      isDeprecated
+      deprecationReason
+    }
+    inputFields {
+      ...InputValue
+    }
+    interfaces {
+      ...TypeRef
+    }
+    enumValues(includeDeprecated: false) {
+      name
+      description
+      isDeprecated
+      deprecationReason
+    }
+    possibleTypes {
+      ...TypeRef
+    }
+  }
+  fragment InputValue on __InputValue {
+    name
+    description
+    type { ...TypeRef }
+    defaultValue
+  }
+  fragment TypeRef on __Type {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
 
 const token = process.env.GITHUB_TOKEN;
 if (!token) {


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Inline the introspectionQuery from [the graphql package](https://github.com/graphql/graphql-js/blob/master/src/utilities/introspectionQuery.js#L20) and change the `includeDeprecation:` arguments to `false`. This will exclude deprecated fields from the schema we give to `relay-compiler`, which will in turn give us early notice of us depending on fields which are due to be removed.

### Screenshot/Gif

_N/A_

### Alternate Designs

It might be worth making a pull request to the GraphQL package itself to give `getIntrospectionQuery()` an option to include deprecated fields or not. We'd need to wait for it to be included in a release and for Relay to catch up before we could take advantage of it, though.

### Benefits

Early notice of GraphQL schema changes that will affect us. This would help prevent regressions like #2094 from occurring.

### Possible Drawbacks

Well... we can't actually merge the schema changes until #2104 is merged 🙃 

### Applicable Issues

#2094, #2104.

### Metrics

_N/A_

### Tests

_N/A_

### Documentation

_N/A_

### Release Notes

_N/A_

### User Experience Research (Optional)

_N/A_