### PR TITLE
swap button colors to emphasize `Comment` more than `Resolve Conversa…

### DIFF
--- a/lib/views/reviews-view.js
+++ b/lib/views/reviews-view.js
@@ -477,7 +477,7 @@ export default class ReviewsView extends React.Component {
         </div>}
         <footer className="github-Review-footer">
           <button
-            className="github-Review-replyButton btn"
+            className="github-Review-replyButton btn btn-primary"
             title="Add your comment"
             disabled={isPosting}
             onClick={() => this.submitReply(replyHolder, thread, lastComment)}>
@@ -493,7 +493,7 @@ export default class ReviewsView extends React.Component {
     if (thread.isResolved) {
       return (
         <button
-          className="github-Review-resolveButton btn btn-primary icon icon-check"
+          className="github-Review-resolveButton btn icon icon-check"
           title="Unresolve conversation"
           onClick={() => this.props.unresolveThread(thread)}>
           Unresolve conversation
@@ -502,7 +502,7 @@ export default class ReviewsView extends React.Component {
     } else {
       return (
         <button
-          className="github-Review-resolveButton btn btn-primary icon icon-check"
+          className="github-Review-resolveButton btn icon icon-check"
           title="Resolve conversation"
           onClick={() => this.props.resolveThread(thread)}>
           Resolve conversation


### PR DESCRIPTION
I kept clicking "Resolve conversation" instead of "Comment" by accident, because the bright color of `btn-primary` called to me. This PR swaps the colors of those two buttons, since "Comment" is more likely to be the button a user means to click.