### PR TITLE
Default upstream refspec to master

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,6 +1,6 @@
 workflow "GraphQL schema update" {
   // Every Tuesday at 1am.
-  on = "schedule(0 2 * * 1)"
+  on = "schedule(0 1 * * 2)"
   resolves = "Update schema"
 }
 

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,6 +1,6 @@
 workflow "GraphQL schema update" {
-  // Every Monday at 1am.
-  on = "schedule(0 1 * * 1)"
+  // Every Tuesday at 1am.
+  on = "schedule(0 2 * * 1)"
   resolves = "Update schema"
 }
 

--- a/actions/schema-up/index.js
+++ b/actions/schema-up/index.js
@@ -42,7 +42,7 @@ Toolkit.run(async tools => {
 
   if (hasRelayChanges === 0 && !relayFailed) {
     tools.log.info('Generated relay files are unchanged.');
-    const upstream = tools.context.ref.replace(/^refs\/heads\//, '');
+    const upstream = tools.context.ref || 'master';
     await tools.runInWorkspace('git', ['push', 'origin', upstream]);
     tools.exit.success('Schema is up to date on master.');
   }


### PR DESCRIPTION
The first scheduled run of our schema-up action [failed on master](https://github.com/atom/github/runs/119452820):

```
ℹ  info      Fetching the latest GraphQL schema changes.
ℹ  info      Committing schema changes.
ℹ  info      Re-running relay compiler.
ℹ  info      Relay output:

Writing js
Unchanged: 62 files
ℹ  info      Generated relay files are unchanged.
✖  fatal     TypeError: Cannot read property 'replace' of undefined 
    at Toolkit.run (/index.js:45:40)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)

### FAILED Update schema 01:01:22Z (21.425s)
```

I'd assumed that `toolkit.context.ref` would be populated with the repository's default branch when run from a schedule trigger, but this is [not the case](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables):

> The branch or tag ref that triggered the workflow. For example, `refs/heads/feature-branch-1`. **If neither a branch or tag is available for the event type, the variable will not exist.**

The easiest fix here is to default to `master`.