### PR TITLE
Schema-up action, iteration N+1

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,6 +1,6 @@
 workflow "GraphQL schema update" {
-  // Every Tuesday at 1am.
-  on = "schedule(0 1 * * 2)"
+  // Every Wednesday at 1am.
+  on = "schedule(0 1 * * 3)"
   resolves = "Update schema"
 }
 

--- a/actions/schema-up/index.js
+++ b/actions/schema-up/index.js
@@ -42,7 +42,7 @@ Toolkit.run(async tools => {
 
   if (hasRelayChanges === 0 && !relayFailed) {
     tools.log.info('Generated relay files are unchanged.');
-    const upstream = tools.context.ref || 'master';
+    const upstream = tools.context.ref || 'HEAD:refs/heads/master';
     await tools.runInWorkspace('git', ['push', 'origin', upstream]);
     tools.exit.success('Schema is up to date on master.');
   }


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

The command `git push origin master` is failing in our nightly action, because the local repository available from a schedule trigger has no master ref:

[check run](https://github.com/atom/github/runs/120477890)

```
ℹ  info      Fetching the latest GraphQL schema changes.
ℹ  info      Committing schema changes.
ℹ  info      Re-running relay compiler.
ℹ  info      Relay output:

Writing js
Unchanged: 62 files
ℹ  info      Generated relay files are unchanged.
✖  fatal     Error: Command failed: git push origin master 
error: src refspec master does not match any.
error: failed to push some refs to 'https://github.com/atom/github.git'


    at makeError (/node_modules/execa/index.js:174:9)
    at Promise.all.then.arr (/node_modules/execa/index.js:278:16)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
```

I've changed it to default to a full refspec that should work as long as we have a repo:

```
git push origin HEAD:refs/heads/master
```

I've also bumped the schedule to try again tonight.

### Screenshot/Gif

_N/A_

### Alternate Designs

_N/A_

### Benefits

Another iteration closer to the GitHub action introduced in #2108 working properly.

### Possible Drawbacks

_N/A_

### Applicable Issues

_N/A_

### Metrics

_N/A_

### Tests

![image](https://user-images.githubusercontent.com/17565/57305924-d95f4d00-70af-11e9-8500-4bfede57bbb3.png)

### Documentation

_N/A_

### Release Notes

_N/A_

### User Experience Research (Optional)

_N/A_
