### PR TITLE
Always create a pull request for schema changes

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,6 +1,6 @@
 workflow "GraphQL schema update" {
-  // Every Wednesday at 1am.
-  on = "schedule(0 1 * * 3)"
+  // Every Thursday at 1am.
+  on = "schedule(0 1 * * 4)"
   resolves = "Update schema"
 }
 

--- a/actions/schema-up/index.js
+++ b/actions/schema-up/index.js
@@ -69,7 +69,7 @@ Toolkit.run(async tools => {
 
   tools.log.info('Creating a pull request.');
 
-  let body = `:robot: _This automated pull request brought to you by [a GitHub action](/actions/schema-up)_ :robot:
+  let body = `:robot: _This automated pull request brought to you by [a GitHub action](https://github.com/atom/github/tree/master/actions/schema-up)_ :robot:
 
 The GraphQL schema has been automatically updated and \`relay-compiler\` has been re-run on the package source.`;
 

--- a/actions/schema-up/index.js
+++ b/actions/schema-up/index.js
@@ -71,15 +71,20 @@ Toolkit.run(async tools => {
 
   let body = `:robot: _This automated pull request brought to you by [a GitHub action](https://github.com/atom/github/tree/master/actions/schema-up)_ :robot:
 
-The GraphQL schema has been automatically updated and \`relay-compiler\` has been re-run on the package source.`;
+The GraphQL schema has been updated and \`relay-compiler\` has been re-run on the package source. `;
 
   if (!relayFailed) {
-    body += ' The modified files have been committed to this branch and pushed. ';
-    body += 'If all of the tests pass in CI, merge with confidence :zap:';
+    if (hasRelayChanges !== 0) {
+      body += 'The modified files have been committed to this branch and pushed. ';
+      body += 'If all of the tests pass in CI, merge with confidence :zap:';
+    } else {
+      body += 'The new schema has been committed to this branch and pushed. None of the ';
+      body += 'generated Relay source has changed as a result, so this should be a trivial merge :shipit: :rocket:';
+    }
   } else {
     body += ' `relay-compiler` failed with the following output:\n\n```\n';
     body += relayOutput;
-    body += '\n```\n\nCheck out this branch to fix things so we don\'t break.';
+    body += '\n```\n\n:rotating_light: Check out this branch to fix things so we don\'t break. :rotating_light:';
   }
 
   const createPullRequestMutation = await tools.github.graphql(`


### PR DESCRIPTION
The less-intrusive "push schema changes directly to master" flow I was hoping to support is now failing because it can't bypass the branch protections to push:

[Check run](https://github.com/atom/github/runs/121586307)

```
ℹ  info      Fetching the latest GraphQL schema changes.
ℹ  info      Committing schema changes.
ℹ  info      Re-running relay compiler.
ℹ  info      Relay output:

Writing js
Unchanged: 62 files
ℹ  info      Generated relay files are unchanged.
✖  fatal     Error: Command failed: git push origin HEAD:refs/heads/master 
remote: error: GH006: Protected branch update failed for refs/heads/master.        
remote: error: 12 of 12 required status checks are expected.        
To https://github.com/atom/github.git
 ! [remote rejected]   HEAD -> master (protected branch hook declined)
error: failed to push some refs to 'https://github.com/atom/github.git'


    at makeError (/node_modules/execa/index.js:174:9)
    at Promise.all.then.arr (/node_modules/execa/index.js:278:16)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
```

I'm modifying the Action to _always_ create a pull request, even if relay-compiler didn't change everything. One autogenerated PR per week shouldn't be too bad.