### PR TITLE
tab styling refactor

### DIFF
--- a/lib/views/pr-detail-view.js
+++ b/lib/views/pr-detail-view.js
@@ -136,25 +136,27 @@ export class BarePullRequestDetailView extends React.Component {
 
     return (
       <Tabs selectedIndex={this.props.selectedTab} onSelect={this.onTabSelected}>
-        <TabList className="github-IssueishDetailView-tablist">
-          <Tab className="github-IssueishDetailView-tab">
-            <Octicon icon="info" className="github-IssueishDetailView-tab-icon" />Overview</Tab>
-          <Tab className="github-IssueishDetailView-tab">
-            <Octicon icon="checklist" className="github-IssueishDetailView-tab-icon" />
+        <TabList className="github-tablist">
+          <Tab className="github-tab">
+            <Octicon icon="info" className="github-tab-icon github-IssueishDetailView-tab-icon" />Overview</Tab>
+          <Tab className="github-tab">
+            <Octicon icon="checklist" className="github-tab-icon github-IssueishDetailView-tab-icon" />
             Build Status
           </Tab>
-          <Tab className="github-IssueishDetailView-tab">
+          <Tab className="github-tab">
             <Octicon icon="git-commit"
-              className="github-IssueishDetailView-tab-icon"
+              className="github-tab-icon github-IssueishDetailView-tab-icon"
             />
               Commits
-            <span className="github-IssueishDetailView-tab-count">{pullRequest.countedCommits.totalCount}</span>
+            <span className="github-tab-count github-IssueishDetailView-tab-count">
+              {pullRequest.countedCommits.totalCount}
+            </span>
           </Tab>
-          <Tab className="github-IssueishDetailView-tab">
+          <Tab className="github-tab">
             <Octicon icon="diff"
-              className="github-IssueishDetailView-tab-icon"
-            />
-              Files<span className="github-IssueishDetailView-tab-count">{pullRequest.changedFiles}</span>
+              className="github-tab-icon github-IssueishDetailView-tab-icon"
+            />Files
+            <span className="github-tab-count github-IssueishDetailView-tab-count">{pullRequest.changedFiles}</span>
           </Tab>
         </TabList>
         {/* 'Reviews' tab to be added in the future. */}

--- a/lib/views/pr-detail-view.js
+++ b/lib/views/pr-detail-view.js
@@ -138,25 +138,25 @@ export class BarePullRequestDetailView extends React.Component {
       <Tabs selectedIndex={this.props.selectedTab} onSelect={this.onTabSelected}>
         <TabList className="github-tablist">
           <Tab className="github-tab">
-            <Octicon icon="info" className="github-tab-icon github-IssueishDetailView-tab-icon" />Overview</Tab>
+            <Octicon icon="info" className="github-tab-icon" />Overview</Tab>
           <Tab className="github-tab">
-            <Octicon icon="checklist" className="github-tab-icon github-IssueishDetailView-tab-icon" />
+            <Octicon icon="checklist" className="github-tab-icon" />
             Build Status
           </Tab>
           <Tab className="github-tab">
             <Octicon icon="git-commit"
-              className="github-tab-icon github-IssueishDetailView-tab-icon"
+              className="github-tab-icon"
             />
               Commits
-            <span className="github-tab-count github-IssueishDetailView-tab-count">
+            <span className="github-tab-count">
               {pullRequest.countedCommits.totalCount}
             </span>
           </Tab>
           <Tab className="github-tab">
             <Octicon icon="diff"
-              className="github-tab-icon github-IssueishDetailView-tab-icon"
+              className="github-tab-icon"
             />Files
-            <span className="github-tab-count github-IssueishDetailView-tab-count">{pullRequest.changedFiles}</span>
+            <span className="github-tab-count">{pullRequest.changedFiles}</span>
           </Tab>
         </TabList>
         {/* 'Reviews' tab to be added in the future. */}

--- a/styles/issueish-detail-view.less
+++ b/styles/issueish-detail-view.less
@@ -17,18 +17,6 @@
     height: 100%;
   }
 
-  .react-tabs {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .react-tabs__tab-panel--selected {
-    flex: 1;
-    overflow: auto;
-  }
-
-
   // Header ------------------------
 
   &-header {
@@ -136,55 +124,6 @@
     }
   }
 
-
-  // Tabs ------------------------
-
-  &-tablist {
-    flex: none;
-    display: flex;
-    justify-content: center;
-    padding: 0;
-    margin: 0;
-    list-style: none;
-    border-bottom: 1px solid @base-border-color;
-    background-color: @app-background-color;
-  }
-
-  &-tab {
-    padding: @component-padding/2 @component-padding*1.5;
-    text-align: center;
-    font-weight: 600;
-    color: mix(@text-color, @app-background-color, 75%);
-    cursor: default;
-    user-select: none;
-  }
-
-  &-tab-icon {
-    color: mix(@text-color, @app-background-color, 33%);
-    vertical-align: middle;
-    &:before {
-      margin-right: .4em;
-    }
-  }
-
-  &-tab-count {
-    display: inline-block;
-    background-color: mix(@text-color-subtle, @app-background-color, 20%);
-    border-radius: @component-border-radius;
-    padding: 0 .25em;
-    margin-left: @component-padding/2;
-  }
-
-
-  // Selected tab
-  &-tab.react-tabs__tab--selected {
-    color: @text-color-selected;
-    box-shadow: 0 1px 0 @button-background-color-selected;
-
-    .github-IssueishDetailView-tab-icon {
-      color: @text-color;
-    }
-  }
 
   // Footer ------------------------
 

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -1,0 +1,59 @@
+@import 'variables';
+
+.react-tabs {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.react-tabs__tab-panel--selected {
+  flex: 1;
+  overflow: auto;
+}
+
+.github-tab {
+  padding: @component-padding/2 @component-padding*1.5;
+  text-align: center;
+  font-weight: 600;
+  color: mix(@text-color, @app-background-color, 75%);
+  cursor: default;
+  user-select: none;
+
+  &list {
+    flex: none;
+    display: flex;
+    justify-content: center;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    border-bottom: 1px solid @base-border-color;
+    background-color: @app-background-color;
+  }
+
+  &-icon {
+    color: mix(@text-color, @app-background-color, 33%);
+    vertical-align: middle;
+    &:before {
+      margin-right: .4em;
+    }
+  }
+
+  &-count {
+    display: inline-block;
+    background-color: mix(@text-color-subtle, @app-background-color, 20%);
+    border-radius: @component-border-radius;
+    padding: 0 .25em;
+    margin-left: @component-padding/2;
+  }
+
+
+  // Selected tab
+  &.react-tabs__tab--selected {
+    color: @text-color-selected;
+    box-shadow: 0 1px 0 @button-background-color-selected;
+
+    .github-tab-icon {
+      color: @text-color;
+    }
+  }
+}

--- a/test/views/pr-detail-view.test.js
+++ b/test/views/pr-detail-view.test.js
@@ -182,22 +182,22 @@ describe('PullRequestDetailView', function() {
     assert.lengthOf(tabs, 4);
 
     const tab0Children = tabs[0].props.children;
-    assert.deepEqual(tab0Children[0].props, {icon: 'info', className: 'github-IssueishDetailView-tab-icon'});
+    assert.deepEqual(tab0Children[0].props, {icon: 'info', className: 'github-tab-icon'});
     assert.deepEqual(tab0Children[1], 'Overview');
 
     const tab1Children = tabs[1].props.children;
-    assert.deepEqual(tab1Children[0].props, {icon: 'checklist', className: 'github-IssueishDetailView-tab-icon'});
+    assert.deepEqual(tab1Children[0].props, {icon: 'checklist', className: 'github-tab-icon'});
     assert.deepEqual(tab1Children[1], 'Build Status');
 
     const tab2Children = tabs[2].props.children;
-    assert.deepEqual(tab2Children[0].props, {icon: 'git-commit', className: 'github-IssueishDetailView-tab-icon'});
+    assert.deepEqual(tab2Children[0].props, {icon: 'git-commit', className: 'github-tab-icon'});
     assert.deepEqual(tab2Children[1], 'Commits');
 
     const tab3Children = tabs[3].props.children;
-    assert.deepEqual(tab3Children[0].props, {icon: 'diff', className: 'github-IssueishDetailView-tab-icon'});
+    assert.deepEqual(tab3Children[0].props, {icon: 'diff', className: 'github-tab-icon'});
     assert.deepEqual(tab3Children[1], 'Files');
 
-    const tabCounts = wrapper.find('.github-IssueishDetailView-tab-count');
+    const tabCounts = wrapper.find('.github-tab-count');
     assert.lengthOf(tabCounts, 2);
     assert.strictEqual(tabCounts.at(0).text(), '11');
     assert.strictEqual(tabCounts.at(1).text(), '22');


### PR DESCRIPTION
This is a small styling refactor + rename that will make the css classnames more appropriate when they are later re-used in the review dock. Doing this in a separate PR to keep the review authoring PR smaller and scoped.