### PR TITLE
Avoid stalls caused by large diffs fetched from GitHub

### DIFF
--- a/lib/containers/comment-decorations-container.js
+++ b/lib/containers/comment-decorations-container.js
@@ -189,7 +189,8 @@ export default class CommentDecorationsContainer extends React.Component {
         repo={repo}
         number={currentPullRequest.number}
         endpoint={endpoint}
-        token={token}>
+        token={token}
+        largeDiffThreshold={Infinity}>
         {(patchError, patch) => this.renderWithPatch(
           {error: patchError, patch},
           {summaries, commentThreads, currentPullRequest, repoResult, endpoint, owner, repo, repoData, token},

--- a/lib/containers/comment-decorations-container.js
+++ b/lib/containers/comment-decorations-container.js
@@ -126,7 +126,7 @@ export default class CommentDecorationsContainer extends React.Component {
           environment={environment}
           query={query}
           variables={variables}
-          render={queryResult => this.renderWithGraphQLData({
+          render={queryResult => this.renderWithPullRequest({
             endpoint,
             owner: variables.headOwner,
             repo: variables.headName,
@@ -137,7 +137,7 @@ export default class CommentDecorationsContainer extends React.Component {
     );
   }
 
-  renderWithGraphQLData({error, props, endpoint, owner, repo}, {repoData, token}) {
+  renderWithPullRequest({error, props, endpoint, owner, repo}, {repoData, token}) {
     if (error) {
       // eslint-disable-next-line no-console
       console.warn(`error fetching CommentDecorationsContainer data: ${error}`);
@@ -154,7 +154,34 @@ export default class CommentDecorationsContainer extends React.Component {
     }
 
     const currentPullRequest = props.repository.ref.associatedPullRequests.nodes[0];
-    const queryProps = {currentPullRequest, ...props};
+
+    return (
+      <AggregatedReviewsContainer
+        pullRequest={currentPullRequest}
+        reportRelayError={this.props.reportRelayError}>
+        {({errors, summaries, commentThreads}) => {
+          return this.renderWithReviews(
+            {errors, summaries, commentThreads},
+            {currentPullRequest, repoResult: props, endpoint, owner, repo, repoData, token},
+          );
+        }}
+      </AggregatedReviewsContainer>
+    );
+  }
+
+  renderWithReviews(
+    {errors, summaries, commentThreads},
+    {currentPullRequest, repoResult, endpoint, owner, repo, repoData, token},
+  ) {
+    if (errors && errors.length > 0) {
+      // eslint-disable-next-line no-console
+      console.warn('Errors aggregating reviews and comments for current pull request', ...errors);
+      return null;
+    }
+
+    if (commentThreads.length === 0) {
+      return null;
+    }
 
     return (
       <PullRequestPatchContainer
@@ -165,40 +192,22 @@ export default class CommentDecorationsContainer extends React.Component {
         token={token}>
         {(patchError, patch) => this.renderWithPatch(
           {error: patchError, patch},
-          {queryProps, endpoint, owner, repo, repoData},
+          {summaries, commentThreads, currentPullRequest, repoResult, endpoint, owner, repo, repoData, token},
         )}
       </PullRequestPatchContainer>
     );
   }
 
-  renderWithPatch({error, patch}, {queryProps, endpoint, owner, repo, repoData}) {
+  renderWithPatch(
+    {error, patch},
+    {summaries, commentThreads, currentPullRequest, repoResult, endpoint, owner, repo, repoData, token},
+  ) {
     if (error) {
       // eslint-disable-next-line no-console
       console.warn('Error fetching patch for current pull request', error);
       return null;
     }
 
-    return (
-      <AggregatedReviewsContainer
-        pullRequest={queryProps.currentPullRequest}
-        reportRelayError={this.props.reportRelayError}>
-        {({errors, summaries, commentThreads}) => {
-          if (errors && errors.length > 0) {
-            // eslint-disable-next-line no-console
-            console.warn('Errors aggregating reviews and comments for current pull request', ...errors);
-            return null;
-          }
-
-          const aggregationResult = {summaries, commentThreads};
-          return this.renderWithResult(aggregationResult, {
-            queryProps, endpoint, owner, repo, repoData, patch,
-          });
-        }}
-      </AggregatedReviewsContainer>
-    );
-  }
-
-  renderWithResult(aggregationResult, {queryProps, endpoint, owner, repo, repoData, patch}) {
     if (!patch) {
       return null;
     }
@@ -206,8 +215,8 @@ export default class CommentDecorationsContainer extends React.Component {
     return (
       <CommentPositioningContainer
         multiFilePatch={patch}
-        commentThreads={aggregationResult.commentThreads}
-        prCommitSha={queryProps.currentPullRequest.headRefOid}
+        commentThreads={commentThreads}
+        prCommitSha={currentPullRequest.headRefOid}
         localRepository={this.props.localRepository}
         workdir={repoData.workingDirectoryPath}>
         {commentTranslations => {
@@ -223,9 +232,9 @@ export default class CommentDecorationsContainer extends React.Component {
               workspace={this.props.workspace}
               commands={this.props.commands}
               repoData={repoData}
-              commentThreads={aggregationResult.commentThreads}
+              commentThreads={commentThreads}
               commentTranslations={commentTranslations}
-              pullRequests={queryProps.repository.ref.associatedPullRequests.nodes}
+              pullRequests={repoResult.repository.ref.associatedPullRequests.nodes}
             />
           );
         }}

--- a/lib/containers/comment-positioning-container.js
+++ b/lib/containers/comment-positioning-container.js
@@ -148,7 +148,7 @@ class FileTranslation {
   update({multiFilePatch, diffs, diffPositionFn, translatePositionFn}) {
     const filePatch = multiFilePatch.getPatchForPath(this.nativeRelPath);
     // if there's a comment on a file that used to exist in a pr but does not exist,
-    // the filePatch won't exist.  Don't even try.
+    // or that was too large to parse, the filePatch won't exist.  Don't even try.
     if (!filePatch) {
       return;
     }

--- a/lib/containers/comment-positioning-container.js
+++ b/lib/containers/comment-positioning-container.js
@@ -121,6 +121,7 @@ class FileTranslation {
 
     this.rawPositions = new Set();
     this.diffToFilePosition = new Map();
+    this.removed = false;
     this.fileTranslations = null;
     this.digest = null;
 
@@ -147,16 +148,26 @@ class FileTranslation {
 
   update({multiFilePatch, diffs, diffPositionFn, translatePositionFn}) {
     const filePatch = multiFilePatch.getPatchForPath(this.nativeRelPath);
-    // if there's a comment on a file that used to exist in a pr but does not exist,
-    // or that was too large to parse, the filePatch won't exist.  Don't even try.
+    // Comment on a file that used to exist in a PR but no longer does. Skip silently.
     if (!filePatch) {
+      this.diffToFilePosition = new Map();
+      this.removed = false;
+      this.fileTranslations = null;
+
       return;
     }
+
+    // This comment was left on a file that was too large to parse.
     if (!filePatch.getRenderStatus().isVisible()) {
+      this.diffToFilePosition = new Map();
+      this.removed = true;
+      this.fileTranslations = null;
+
       return;
     }
 
     this.diffToFilePosition = diffPositionFn(this.rawPositions, filePatch.getRawContentPatch());
+    this.removed = false;
 
     let contentChangeDiff;
     if (diffs.length === 1) {

--- a/lib/containers/comment-positioning-container.js
+++ b/lib/containers/comment-positioning-container.js
@@ -152,6 +152,10 @@ class FileTranslation {
     if (!filePatch) {
       return;
     }
+    if (!filePatch.getRenderStatus().isVisible()) {
+      return;
+    }
+
     this.diffToFilePosition = diffPositionFn(this.rawPositions, filePatch.getRawContentPatch());
 
     let contentChangeDiff;

--- a/lib/containers/pr-patch-container.js
+++ b/lib/containers/pr-patch-container.js
@@ -26,20 +26,27 @@ export default class PullRequestPatchContainer extends React.Component {
 
   state = {
     multiFilePatch: null,
-    patchURL: null,
-    etag: null,
     error: null,
+    last: {url: null, patch: null, etag: null},
   }
 
   componentDidMount() {
     this.mounted = true;
-    this.fetchDiff();
+    this.fetchDiff(this.state.last);
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.refetch && !prevProps.refetch) {
-      this.setState({error: null});
-      this.fetchDiff();
+    const explicitRefetch = this.props.refetch && !prevProps.refetch;
+    const requestedURLChange = this.state.last.url !== this.getDiffURL();
+
+    if (explicitRefetch || requestedURLChange) {
+      const {last} = this.state;
+      this.setState({
+        multiFilePatch: null,
+        error: null,
+        last: {url: this.getDiffURL(), patch: null, etag: null},
+      });
+      this.fetchDiff(last);
     }
   }
 
@@ -71,7 +78,7 @@ export default class PullRequestPatchContainer extends React.Component {
     return buildMultiFilePatch(diffs, {preserveOriginal: true});
   }
 
-  async fetchDiff() {
+  async fetchDiff(last) {
     const url = this.getDiffURL();
     let response;
 
@@ -81,8 +88,8 @@ export default class PullRequestPatchContainer extends React.Component {
         Authorization: `bearer ${this.props.token}`,
       };
 
-      if (url === this.state.lastURL && this.state.etag !== null) {
-        headers['If-None-Match'] = this.state.etag;
+      if (url === last.url && last.etag !== null) {
+        headers['If-None-Match'] = last.etag;
       }
 
       response = await fetch(url, {headers});
@@ -92,7 +99,15 @@ export default class PullRequestPatchContainer extends React.Component {
 
     if (response.status === 304) {
       // Not modified.
-      return null;
+      if (!this.mounted) {
+        return null;
+      }
+
+      return new Promise(resolve => this.setState({
+        multiFilePatch: last.patch,
+        error: null,
+        last,
+      }));
     }
 
     if (!response.ok) {
@@ -107,13 +122,21 @@ export default class PullRequestPatchContainer extends React.Component {
       }
 
       const multiFilePatch = this.buildPatch(rawDiff);
-      return new Promise(resolve => this.setState({multiFilePatch, etag, lastURL: url, error: null}, resolve));
+      return new Promise(resolve => this.setState({
+        multiFilePatch,
+        error: null,
+        last: {url, patch: multiFilePatch, etag},
+      }, resolve));
     } catch (err) {
       return this.reportDiffError('Unable to parse the diff for this pull request.', err);
     }
   }
 
   reportDiffError(message, error) {
+    if (!this.mounted) {
+      return null;
+    }
+
     return new Promise(resolve => {
       if (error) {
         // eslint-disable-next-line no-console

--- a/lib/containers/pr-patch-container.js
+++ b/lib/containers/pr-patch-container.js
@@ -18,8 +18,9 @@ export default class PullRequestPatchContainer extends React.Component {
     endpoint: EndpointPropType.isRequired,
     token: PropTypes.string.isRequired,
 
-    // Refetch diff on next component update
+    // Fetching and parsing
     refetch: PropTypes.bool,
+    largeDiffThreshold: PropTypes.number,
 
     // Render prop. Called with (error or null, multiFilePatch or null)
     children: PropTypes.func.isRequired,
@@ -77,7 +78,14 @@ export default class PullRequestPatchContainer extends React.Component {
         oldPath: diff.oldPath ? toNativePathSep(diff.oldPath.replace(/^[a|b]\//, '')) : diff.oldPath,
       };
     });
-    return buildMultiFilePatch(diffs, {preserveOriginal: true});
+    const options = {
+      preserveOriginal: true,
+    };
+    if (this.props.largeDiffThreshold) {
+      options.largeDiffThreshold = this.props.largeDiffThreshold;
+    }
+    const mfp = buildMultiFilePatch(diffs, options);
+    return mfp;
   }
 
   async fetchDiff(last) {

--- a/lib/containers/pr-patch-container.js
+++ b/lib/containers/pr-patch-container.js
@@ -26,6 +26,8 @@ export default class PullRequestPatchContainer extends React.Component {
 
   state = {
     multiFilePatch: null,
+    patchURL: null,
+    etag: null,
     error: null,
   }
 
@@ -36,7 +38,7 @@ export default class PullRequestPatchContainer extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.refetch && !prevProps.refetch) {
-      this.setState({multiFilePatch: null, error: null});
+      this.setState({error: null});
       this.fetchDiff();
     }
   }
@@ -74,14 +76,23 @@ export default class PullRequestPatchContainer extends React.Component {
     let response;
 
     try {
-      response = await fetch(url, {
-        headers: {
-          Accept: 'application/vnd.github.v3.diff',
-          Authorization: `bearer ${this.props.token}`,
-        },
-      });
+      const headers = {
+        Accept: 'application/vnd.github.v3.diff',
+        Authorization: `bearer ${this.props.token}`,
+      };
+
+      if (url === this.state.lastURL && this.state.etag !== null) {
+        headers['If-None-Match'] = this.state.etag;
+      }
+
+      response = await fetch(url, {headers});
     } catch (err) {
       return this.reportDiffError(`Network error encountered fetching the patch: ${err.message}.`, err);
+    }
+
+    if (response.status === 304) {
+      // Not modified.
+      return null;
     }
 
     if (!response.ok) {
@@ -89,13 +100,14 @@ export default class PullRequestPatchContainer extends React.Component {
     }
 
     try {
+      const etag = response.headers.get('ETag');
       const rawDiff = await response.text();
       if (!this.mounted) {
         return null;
       }
 
       const multiFilePatch = this.buildPatch(rawDiff);
-      return new Promise(resolve => this.setState({multiFilePatch}, resolve));
+      return new Promise(resolve => this.setState({multiFilePatch, etag, lastURL: url, error: null}, resolve));
     } catch (err) {
       return this.reportDiffError('Unable to parse the diff for this pull request.', err);
     }

--- a/lib/containers/pr-patch-container.js
+++ b/lib/containers/pr-patch-container.js
@@ -4,6 +4,7 @@ import {parse as parseDiff} from 'what-the-diff';
 
 import {toNativePathSep} from '../helpers';
 import {EndpointPropType} from '../prop-types';
+import {filter as filterDiff} from '../models/patch/filter';
 import {buildMultiFilePatch} from '../models/patch';
 
 export default class PullRequestPatchContainer extends React.Component {
@@ -65,7 +66,8 @@ export default class PullRequestPatchContainer extends React.Component {
   }
 
   buildPatch(rawDiff) {
-    const diffs = parseDiff(rawDiff).map(diff => {
+    const filtered = filterDiff(rawDiff);
+    const diffs = parseDiff(filtered).map(diff => {
     // diff coming from API will have the defaul git diff prefixes a/ and b/ and use *nix-style / path separators.
     // e.g. a/dir/file1.js and b/dir/file2.js
     // see https://git-scm.com/docs/git-diff#_generating_patches_with_p

--- a/lib/containers/pr-patch-container.js
+++ b/lib/containers/pr-patch-container.js
@@ -67,7 +67,7 @@ export default class PullRequestPatchContainer extends React.Component {
   }
 
   buildPatch(rawDiff) {
-    const filtered = filterDiff(rawDiff);
+    const {filtered, removed} = filterDiff(rawDiff);
     const diffs = parseDiff(filtered).map(diff => {
     // diff coming from API will have the defaul git diff prefixes a/ and b/ and use *nix-style / path separators.
     // e.g. a/dir/file1.js and b/dir/file2.js
@@ -80,6 +80,7 @@ export default class PullRequestPatchContainer extends React.Component {
     });
     const options = {
       preserveOriginal: true,
+      removed,
     };
     if (this.props.largeDiffThreshold) {
       options.largeDiffThreshold = this.props.largeDiffThreshold;

--- a/lib/containers/reviews-container.js
+++ b/lib/containers/reviews-container.js
@@ -90,7 +90,8 @@ export default class ReviewsContainer extends React.Component {
         repo={this.props.repo}
         number={this.props.number}
         endpoint={this.props.endpoint}
-        token={token}>
+        token={token}
+        largeDiffThreshold={Infinity}>
         {(error, patch) => this.renderWithPatch(error, {token, patch})}
       </PullRequestPatchContainer>
     );

--- a/lib/controllers/editor-comment-decorations-controller.js
+++ b/lib/controllers/editor-comment-decorations-controller.js
@@ -3,8 +3,11 @@ import PropTypes from 'prop-types';
 import {Range} from 'atom';
 
 import {EndpointPropType} from '../prop-types';
+import {addEvent} from '../reporter-proxy';
 import Marker from '../atom/marker';
 import Decoration from '../atom/decoration';
+import Octicon from '../atom/octicon';
+import ReviewsItem from '../items/reviews-item';
 import CommentGutterDecorationController from '../controllers/comment-gutter-decoration-controller';
 
 export default class EditorCommentDecorationsController extends React.Component {
@@ -29,6 +32,7 @@ export default class EditorCommentDecorationsController extends React.Component 
       fileTranslations: PropTypes.shape({
         get: PropTypes.func.isRequired,
       }),
+      removed: PropTypes.bool.isRequired,
       digest: PropTypes.string,
     }),
   }
@@ -46,6 +50,32 @@ export default class EditorCommentDecorationsController extends React.Component 
   render() {
     if (!this.props.commentTranslationsForPath) {
       return null;
+    }
+
+    if (this.props.commentTranslationsForPath.removed && this.props.threadsForPath.length > 0) {
+      const [firstThread] = this.props.threadsForPath;
+
+      return (
+        <Marker
+          editor={this.props.editor}
+          exclusive={true}
+          invalidate="surround"
+          bufferRange={[[0, 0], [0, 0]]}>
+
+          <Decoration type="block" editor={this.props.editor} className="github-EditorComment-omitted">
+            <p>
+              <Octicon icon="warning" />This file has review comments, but its patch is too large for Atom to load.
+            </p>
+            <p>
+              Review comments may still be viewed within
+              <button
+                className="btn"
+                onClick={() => this.openReviewThread(firstThread.threadID)}>the review tab</button>.
+            </p>
+          </Decoration>
+
+        </Marker>
+      );
     }
 
     return this.props.threadsForPath.map(thread => {
@@ -122,6 +152,19 @@ export default class EditorCommentDecorationsController extends React.Component 
       this.rangesByRootID.set(thread.rootCommentID, localRange);
     }
     return localRange;
+  }
+
+  openReviewThread = async threadId => {
+    const uri = ReviewsItem.buildURI({
+      host: this.props.endpoint.getHost(),
+      owner: this.props.owner,
+      repo: this.props.repo,
+      number: this.props.number,
+      workdir: this.props.workdir,
+    });
+    const reviewsItem = await this.props.workspace.open(uri, {searchAllPanes: true});
+    reviewsItem.jumpToThread(threadId);
+    addEvent('open-review-thread', {package: 'github', from: this.constructor.name});
   }
 }
 

--- a/lib/controllers/editor-comment-decorations-controller.js
+++ b/lib/controllers/editor-comment-decorations-controller.js
@@ -6,7 +6,6 @@ import {EndpointPropType} from '../prop-types';
 import {addEvent} from '../reporter-proxy';
 import Marker from '../atom/marker';
 import Decoration from '../atom/decoration';
-import Octicon from '../atom/octicon';
 import ReviewsItem from '../items/reviews-item';
 import CommentGutterDecorationController from '../controllers/comment-gutter-decoration-controller';
 
@@ -60,11 +59,11 @@ export default class EditorCommentDecorationsController extends React.Component 
           editor={this.props.editor}
           exclusive={true}
           invalidate="surround"
-          bufferRange={[[0, 0], [0, 0]]}>
+          bufferRange={Range.fromObject([[0, 0], [0, 0]])}>
 
           <Decoration type="block" editor={this.props.editor} className="github-EditorComment-omitted">
             <p>
-              <Octicon icon="warning" />This file has review comments, but its patch is too large for Atom to load.
+              This file has review comments, but its patch is too large for Atom to load.
             </p>
             <p>
               Review comments may still be viewed within

--- a/lib/models/patch/builder.js
+++ b/lib/models/patch/builder.js
@@ -1,7 +1,7 @@
 import PatchBuffer from './patch-buffer';
 import Hunk from './hunk';
 import File, {nullFile} from './file';
-import Patch, {DEFERRED, EXPANDED} from './patch';
+import Patch, {DEFERRED, EXPANDED, REMOVED} from './patch';
 import {Unchanged, Addition, Deletion, NoNewline} from './region';
 import FilePatch from './file-patch';
 import MultiFilePatch from './multi-file-patch';
@@ -18,6 +18,9 @@ export const DEFAULT_OPTIONS = {
 
   // Store off what-the-diff file patch
   preserveOriginal: false,
+
+  // Paths of file patches that have been removed from the patch before parsing
+  removed: new Set(),
 };
 
 export function buildFilePatch(diffs, options) {
@@ -88,6 +91,24 @@ export function buildMultiFilePatch(diffs, options) {
 
   // Delete the final trailing newline from the last non-empty patch.
   patchBuffer.deleteLastNewline();
+
+  // Append hidden patches corresponding to each removed file.
+  for (const removedPath of opts.removed) {
+    const removedFile = new File({path: removedPath});
+    const removedMarker = patchBuffer.markPosition(
+      Patch.layerName,
+      patchBuffer.getBuffer().getEndPosition(),
+      {invalidate: 'never', exclusive: false},
+    );
+    filePatches.push(FilePatch.createHiddenFilePatch(
+      removedFile,
+      removedFile,
+      removedMarker,
+      REMOVED,
+      /* istanbul ignore next */
+      () => { throw new Error(`Attempt to expand removed file patch ${removedPath}`); },
+    ));
+  }
 
   return new MultiFilePatch({patchBuffer, filePatches});
 }

--- a/lib/models/patch/builder.js
+++ b/lib/models/patch/builder.js
@@ -1,7 +1,7 @@
 import PatchBuffer from './patch-buffer';
 import Hunk from './hunk';
 import File, {nullFile} from './file';
-import Patch, {TOO_LARGE, EXPANDED} from './patch';
+import Patch, {DEFERRED, EXPANDED} from './patch';
 import {Unchanged, Addition, Deletion, NoNewline} from './region';
 import FilePatch from './file-patch';
 import MultiFilePatch from './multi-file-patch';
@@ -10,7 +10,7 @@ export const DEFAULT_OPTIONS = {
   // Number of lines after which we consider the diff "large"
   largeDiffThreshold: 800,
 
-  // Map of file path (relative to repository root) to Patch render status (EXPANDED, COLLAPSED, TOO_LARGE)
+  // Map of file path (relative to repository root) to Patch render status (EXPANDED, COLLAPSED, DEFERRED)
   renderStatusOverrides: {},
 
   // Existing patch buffer to render onto
@@ -124,7 +124,7 @@ function singleDiffFilePatch(diff, patchBuffer, opts) {
     undefined;
 
   const renderStatus = renderStatusOverride ||
-    (isDiffLarge([diff], opts) && TOO_LARGE) ||
+    (isDiffLarge([diff], opts) && DEFERRED) ||
     EXPANDED;
 
   if (!renderStatus.isVisible()) {
@@ -191,7 +191,7 @@ function dualDiffFilePatch(diff1, diff2, patchBuffer, opts) {
   const newFile = new File({path: filePath, mode: newMode, symlink: newSymlink});
 
   const renderStatus = opts.renderStatusOverrides[filePath] ||
-    (isDiffLarge([contentChangeDiff], opts) && TOO_LARGE) ||
+    (isDiffLarge([contentChangeDiff], opts) && DEFERRED) ||
     EXPANDED;
 
   if (!renderStatus.isVisible()) {

--- a/lib/models/patch/filter.js
+++ b/lib/models/patch/filter.js
@@ -1,29 +1,13 @@
 export const MAX_PATCH_CHARS = 10240;
 
 export function filter(original, fileSet) {
-  const removed = new Set();
   let accumulating = false;
   let accumulated = '';
   let includedChars = 0;
 
   let index = 0;
-  const rx = /\n?diff --git (?:a|b)\/(\S+) (?:a|b)\/(\S+)\b/y;
   while (index !== -1) {
     let include = true;
-
-    // Identify the files in the current patch. Exclude it if neither filename is in the accepted path set.
-    const fileNames = [];
-    rx.lastIndex = index;
-    const m = rx.exec(original);
-    if (m) {
-      fileNames.push(m[1]);
-      fileNames.push(m[2]);
-    }
-
-    if (!fileNames.some(fileName => fileSet.has(fileName))) {
-      // Exclude this patch
-      include = false;
-    }
 
     const result = original.indexOf('\ndiff --git ', index);
     const nextIndex = result !== -1 ? result + 1 : -1;
@@ -47,14 +31,10 @@ export function filter(original, fileSet) {
         accumulating = true;
         accumulated = original.slice(0, index);
       }
-
-      for (const fileName of fileNames) {
-        removed.add(fileName);
-      }
     }
 
     index = nextIndex;
   }
 
-  return {filtered: accumulating ? accumulated : original, removed};
+  return accumulating ? accumulated : original;
 }

--- a/lib/models/patch/filter.js
+++ b/lib/models/patch/filter.js
@@ -1,0 +1,60 @@
+export const MAX_PATCH_CHARS = 10240;
+
+export function filter(original, fileSet) {
+  const removed = new Set();
+  let accumulating = false;
+  let accumulated = '';
+  let includedChars = 0;
+
+  let index = 0;
+  const rx = /\n?diff --git (?:a|b)\/(\S+) (?:a|b)\/(\S+)\b/y;
+  while (index !== -1) {
+    let include = true;
+
+    // Identify the files in the current patch. Exclude it if neither filename is in the accepted path set.
+    const fileNames = [];
+    rx.lastIndex = index;
+    const m = rx.exec(original);
+    if (m) {
+      fileNames.push(m[1]);
+      fileNames.push(m[2]);
+    }
+
+    if (!fileNames.some(fileName => fileSet.has(fileName))) {
+      // Exclude this patch
+      include = false;
+    }
+
+    const result = original.indexOf('\ndiff --git ', index);
+    const nextIndex = result !== -1 ? result + 1 : -1;
+    const patchEnd = nextIndex !== -1 ? nextIndex : original.length;
+
+    // Exclude this patch if its inclusion would cause the patch to become too large.
+    const patchChars = patchEnd - index + 1;
+    if (includedChars + patchChars > MAX_PATCH_CHARS) {
+      include = false;
+    }
+
+    if (include) {
+      // Avoid copying large buffers of text around if we're including everything anyway.
+      if (accumulating) {
+        accumulated += original.slice(index, patchEnd);
+      }
+      includedChars += patchChars;
+    } else {
+      // If this is the first excluded patch, start by copying everything before this into "accumulated."
+      if (!accumulating) {
+        accumulating = true;
+        accumulated = original.slice(0, index);
+      }
+
+      for (const fileName of fileNames) {
+        removed.add(fileName);
+      }
+    }
+
+    index = nextIndex;
+  }
+
+  return {filtered: accumulating ? accumulated : original, removed};
+}

--- a/lib/models/patch/filter.js
+++ b/lib/models/patch/filter.js
@@ -1,4 +1,4 @@
-export const MAX_PATCH_CHARS = 10 * 1024 * 1024;
+export const MAX_PATCH_CHARS = 1024 * 1024;
 
 export function filter(original) {
   let accumulating = false;
@@ -37,7 +37,6 @@ export function filter(original) {
       // Extract the removed filenames from the "diff --git" line.
       pathRx.lastIndex = index;
       const pathMatch = pathRx.exec(original);
-      console.log(pathMatch[1], pathMatch[2]);
       if (pathMatch) {
         removed.add(pathMatch[1]);
         removed.add(pathMatch[2]);

--- a/lib/models/patch/filter.js
+++ b/lib/models/patch/filter.js
@@ -4,6 +4,8 @@ export function filter(original) {
   let accumulating = false;
   let accumulated = '';
   let includedChars = 0;
+  const removed = new Set();
+  const pathRx = /\n?diff --git (?:a|b)\/(\S+) (?:a|b)\/(\S+)/y;
 
   let index = 0;
   while (index !== -1) {
@@ -31,10 +33,19 @@ export function filter(original) {
         accumulating = true;
         accumulated = original.slice(0, index);
       }
+
+      // Extract the removed filenames from the "diff --git" line.
+      pathRx.lastIndex = index;
+      const pathMatch = pathRx.exec(original);
+      console.log(pathMatch[1], pathMatch[2]);
+      if (pathMatch) {
+        removed.add(pathMatch[1]);
+        removed.add(pathMatch[2]);
+      }
     }
 
     index = nextIndex;
   }
 
-  return accumulating ? accumulated : original;
+  return {filtered: accumulating ? accumulated : original, removed};
 }

--- a/lib/models/patch/filter.js
+++ b/lib/models/patch/filter.js
@@ -1,6 +1,6 @@
-export const MAX_PATCH_CHARS = 10240;
+export const MAX_PATCH_CHARS = 10 * 1024 * 1024;
 
-export function filter(original, fileSet) {
+export function filter(original) {
   let accumulating = false;
   let accumulated = '';
   let includedChars = 0;

--- a/lib/models/patch/patch.js
+++ b/lib/models/patch/patch.js
@@ -8,6 +8,8 @@ export const EXPANDED = {
   toString() { return 'RenderStatus(expanded)'; },
 
   isVisible() { return true; },
+
+  isExpandable() { return false; },
 };
 
 export const COLLAPSED = {
@@ -15,6 +17,8 @@ export const COLLAPSED = {
   toString() { return 'RenderStatus(collapsed)'; },
 
   isVisible() { return false; },
+
+  isExpandable() { return true; },
 };
 
 export const DEFERRED = {
@@ -22,6 +26,17 @@ export const DEFERRED = {
   toString() { return 'RenderStatus(deferred)'; },
 
   isVisible() { return false; },
+
+  isExpandable() { return true; },
+};
+
+export const REMOVED = {
+  /* istanbul ignore next */
+  toString() { return 'RenderStatus(removed)'; },
+
+  isVisible() { return false; },
+
+  isExpandable() { return false; },
 };
 
 export default class Patch {

--- a/lib/models/patch/patch.js
+++ b/lib/models/patch/patch.js
@@ -17,9 +17,9 @@ export const COLLAPSED = {
   isVisible() { return false; },
 };
 
-export const TOO_LARGE = {
+export const DEFERRED = {
   /* istanbul ignore next */
-  toString() { return 'RenderStatus(too-large)'; },
+  toString() { return 'RenderStatus(deferred)'; },
 
   isVisible() { return false; },
 };

--- a/lib/views/multi-file-patch-view.js
+++ b/lib/views/multi-file-patch-view.js
@@ -23,7 +23,7 @@ import CommentGutterDecorationController from '../controllers/comment-gutter-dec
 import IssueishDetailItem from '../items/issueish-detail-item';
 import File from '../models/patch/file';
 
-import {TOO_LARGE} from '../models/patch/patch';
+import {DEFERRED} from '../models/patch/patch';
 
 const executableText = {
   [File.modes.NORMAL]: 'non executable',
@@ -498,7 +498,7 @@ export default class MultiFilePatchView extends React.Component {
           </Decoration>
         </Marker>
 
-        {filePatch.getPatch().getRenderStatus() === TOO_LARGE && this.renderDiffGate(filePatch, position, index)}
+        {filePatch.getPatch().getRenderStatus() === DEFERRED && this.renderDiffGate(filePatch, position, index)}
 
         {this.renderHunkHeaders(filePatch, index)}
       </Fragment>

--- a/lib/views/multi-file-patch-view.js
+++ b/lib/views/multi-file-patch-view.js
@@ -23,8 +23,6 @@ import CommentGutterDecorationController from '../controllers/comment-gutter-dec
 import IssueishDetailItem from '../items/issueish-detail-item';
 import File from '../models/patch/file';
 
-import {DEFERRED} from '../models/patch/patch';
-
 const executableText = {
   [File.modes.NORMAL]: 'non executable',
   [File.modes.EXECUTABLE]: 'executable',
@@ -466,6 +464,8 @@ export default class MultiFilePatchView extends React.Component {
   renderFilePatchDecorations = (filePatch, index) => {
     const isCollapsed = !filePatch.getRenderStatus().isVisible();
     const isEmpty = filePatch.getMarker().getRange().isEmpty();
+    const isExpandable = filePatch.getRenderStatus().isExpandable();
+    const isUnavailable = isCollapsed && !isExpandable;
     const atEnd = filePatch.getStartRange().start.isEqual(this.props.multiFilePatch.getBuffer().getEndPosition());
     const position = isEmpty && atEnd ? 'after' : 'before';
 
@@ -498,7 +498,8 @@ export default class MultiFilePatchView extends React.Component {
           </Decoration>
         </Marker>
 
-        {filePatch.getPatch().getRenderStatus() === DEFERRED && this.renderDiffGate(filePatch, position, index)}
+        {isExpandable && this.renderDiffGate(filePatch, position, index)}
+        {isUnavailable && this.renderDiffUnavailable(filePatch, position, index)}
 
         {this.renderHunkHeaders(filePatch, index)}
       </Fragment>
@@ -522,6 +523,24 @@ export default class MultiFilePatchView extends React.Component {
             Large diffs are collapsed by default for performance reasons.
             <br />
             <button className="github-FilePatchView-showDiffButton" onClick={showDiff}> Load Diff</button>
+          </p>
+
+        </Decoration>
+      </Marker>
+    );
+  }
+
+  renderDiffUnavailable(filePatch, position, orderOffset) {
+    return (
+      <Marker invalidate="never" bufferRange={filePatch.getStartRange()}>
+        <Decoration
+          type="block"
+          order={orderOffset + 0.1}
+          position={position}
+          className="github-FilePatchView-controlBlock">
+
+          <p className="github-FilePatchView-message icon icon-warning">
+            This diff is too large to load at all. Use the command-line to view it.
           </p>
 
         </Decoration>

--- a/styles/editor-comment.less
+++ b/styles/editor-comment.less
@@ -36,3 +36,25 @@ atom-text-editor {
     vertical-align: middle;
   }
 }
+
+.github-EditorComment-omitted {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: @tool-panel-background-color;
+  border-radius: @component-border-radius;
+  padding: @component-padding;
+  margin: @component-padding/2 0;
+
+  p {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    margin: @component-padding/4;
+  }
+
+  button {
+    margin-left: @component-padding;
+  }
+}

--- a/test/containers/changed-file-container.test.js
+++ b/test/containers/changed-file-container.test.js
@@ -5,7 +5,7 @@ import {mount} from 'enzyme';
 
 import ChangedFileContainer from '../../lib/containers/changed-file-container';
 import ChangedFileItem from '../../lib/items/changed-file-item';
-import {TOO_LARGE, EXPANDED} from '../../lib/models/patch/patch';
+import {DEFERRED, EXPANDED} from '../../lib/models/patch/patch';
 import {cloneRepository, buildRepository} from '../helpers';
 
 describe('ChangedFileContainer', function() {
@@ -93,7 +93,7 @@ describe('ChangedFileContainer', function() {
     await assert.async.isTrue(wrapper.update().exists('ChangedFileController'));
     const before = wrapper.find('ChangedFileController').prop('multiFilePatch');
     const fp = before.getFilePatches()[0];
-    assert.strictEqual(fp.getRenderStatus(), TOO_LARGE);
+    assert.strictEqual(fp.getRenderStatus(), DEFERRED);
     before.expandFilePatch(fp);
     assert.strictEqual(fp.getRenderStatus(), EXPANDED);
 

--- a/test/containers/comment-decorations-container.test.js
+++ b/test/containers/comment-decorations-container.test.js
@@ -41,6 +41,8 @@ describe('CommentDecorationsContainer', function() {
         localRepository={localRepository}
         loginModel={loginModel}
         reportRelayError={() => {}}
+        commands={atomEnv.commands}
+        children={() => <div />}
         {...overrideProps}
       />
     );
@@ -217,7 +219,7 @@ describe('CommentDecorationsContainer', function() {
       assert.isTrue(resultWrapper.isEmptyRender());
     });
 
-    it('renders the PullRequestPatchContainer if result includes repository and ref', function() {
+    it('renders the AggregatedReviewsContainerContainer if result includes repository and ref', function() {
       const props = queryBuilder(rootQuery)
         .repository(r => {
           r.ref(r0 => {
@@ -233,7 +235,87 @@ describe('CommentDecorationsContainer', function() {
       const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({
         error: null, props, retry: () => {},
       });
-      assert.lengthOf(resultWrapper.find(PullRequestPatchContainer), 1);
+      assert.lengthOf(resultWrapper.find(AggregatedReviewsContainer), 1);
+    });
+
+    it("renders nothing if there's an error aggregating reviews", function() {
+      const props = queryBuilder(rootQuery)
+        .repository(r => {
+          r.ref(r0 => {
+            r0.associatedPullRequests(conn => {
+              conn.totalCount(1);
+              conn.addNode();
+            });
+          });
+        })
+        .build();
+
+      const tokenWrapper = localRepoWrapper.find(ObserveModel).renderProp('children')('1234');
+      const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({
+        error: null, props, retry: () => {},
+      });
+      const reviewsWrapper = resultWrapper.find(AggregatedReviewsContainer).renderProp('children')({
+        errors: [new Error('ahhhh')],
+        summaries: [],
+        commentThreads: [],
+      });
+
+      assert.isTrue(reviewsWrapper.isEmptyRender());
+    });
+
+    it('renders nothing if there are no review comment threads', function() {
+      const props = queryBuilder(rootQuery)
+        .repository(r => {
+          r.ref(r0 => {
+            r0.associatedPullRequests(conn => {
+              conn.totalCount(1);
+              conn.addNode();
+            });
+          });
+        })
+        .build();
+
+      const tokenWrapper = localRepoWrapper.find(ObserveModel).renderProp('children')('1234');
+      const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({
+        error: null, props, retry: () => {},
+      });
+      const reviewsWrapper = resultWrapper.find(AggregatedReviewsContainer).renderProp('children')({
+        errors: [],
+        summaries: [],
+        commentThreads: [],
+      });
+
+      assert.isTrue(reviewsWrapper.isEmptyRender());
+    });
+
+    it('loads the patch once there is at least one loaded review comment thread', function() {
+      const props = queryBuilder(rootQuery)
+        .repository(r => {
+          r.ref(r0 => {
+            r0.associatedPullRequests(conn => {
+              conn.totalCount(1);
+              conn.addNode();
+            });
+          });
+        })
+        .build();
+
+      const tokenWrapper = localRepoWrapper.find(ObserveModel).renderProp('children')('1234');
+      const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({
+        error: null, props, retry: () => {},
+      });
+      const reviewsWrapper = resultWrapper.find(AggregatedReviewsContainer).renderProp('children')({
+        errors: [],
+        summaries: [],
+        commentThreads: [
+          {thread: {id: 'thread0'}, comments: [{id: 'comment0', path: 'a.txt'}, {id: 'comment1', path: 'a.txt'}]},
+        ],
+      });
+      const patchWrapper = reviewsWrapper.find(PullRequestPatchContainer).renderProp('children')(
+        null, null,
+      );
+
+      assert.isTrue(patchWrapper.isEmptyRender());
     });
 
     it('renders nothing if patch cannot be fetched', function() {
@@ -252,65 +334,17 @@ describe('CommentDecorationsContainer', function() {
       const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({
         error: null, props, retry: () => {},
       });
-      const patchWrapper = resultWrapper.find(PullRequestPatchContainer).renderProp('children')(
+      const reviewsWrapper = resultWrapper.find(AggregatedReviewsContainer).renderProp('children')({
+        errors: [],
+        summaries: [],
+        commentThreads: [
+          {thread: {id: 'thread0'}, comments: [{id: 'comment0', path: 'a.txt'}, {id: 'comment1', path: 'a.txt'}]},
+        ],
+      });
+      const patchWrapper = reviewsWrapper.find(PullRequestPatchContainer).renderProp('children')(
         new Error('oops'), null,
       );
       assert.isTrue(patchWrapper.isEmptyRender());
-    });
-
-    it('aggregates reviews while the patch is loading', function() {
-      const props = queryBuilder(rootQuery)
-        .repository(r => {
-          r.ref(r0 => {
-            r0.associatedPullRequests(conn => {
-              conn.totalCount(1);
-              conn.addNode();
-            });
-          });
-        })
-        .build();
-
-      const tokenWrapper = localRepoWrapper.find(ObserveModel).renderProp('children')('1234');
-      const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({
-        error: null, props, retry: () => {},
-      });
-      const patchWrapper = resultWrapper.find(PullRequestPatchContainer).renderProp('children')(
-        null, null,
-      );
-      const reviewsWrapper = patchWrapper.find(AggregatedReviewsContainer).renderProp('children')({
-        errors: [],
-        summaries: [],
-        commentThreads: [],
-      });
-
-      assert.isTrue(reviewsWrapper.isEmptyRender());
-    });
-
-    it("renders nothing if there's an error aggregating reviews", function() {
-      const props = queryBuilder(rootQuery)
-        .repository(r => {
-          r.ref(r0 => {
-            r0.associatedPullRequests(conn => {
-              conn.totalCount(1);
-              conn.addNode();
-            });
-          });
-        })
-        .build();
-      const patch = multiFilePatchBuilder().build();
-
-      const tokenWrapper = localRepoWrapper.find(ObserveModel).renderProp('children')('1234');
-      const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({
-        error: null, props, retry: () => {},
-      });
-      const patchWrapper = resultWrapper.find(PullRequestPatchContainer).renderProp('children')(null, patch);
-      const reviewsWrapper = patchWrapper.find(AggregatedReviewsContainer).renderProp('children')({
-        errors: [new Error('ahhhh')],
-        summaries: [],
-        commentThreads: [],
-      });
-
-      assert.isTrue(reviewsWrapper.isEmptyRender());
     });
 
     it('renders a CommentPositioningContainer when the patch and reviews arrive', function() {
@@ -330,14 +364,16 @@ describe('CommentDecorationsContainer', function() {
       const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({
         error: null, props, retry: () => {},
       });
-      const patchWrapper = resultWrapper.find(PullRequestPatchContainer).renderProp('children')(null, patch);
-      const reviewsWrapper = patchWrapper.find(AggregatedReviewsContainer).renderProp('children')({
+      const reviewsWrapper = resultWrapper.find(AggregatedReviewsContainer).renderProp('children')({
         errors: [],
         summaries: [],
-        commentThreads: [],
+        commentThreads: [
+          {thread: {id: 'thread0'}, comments: [{id: 'comment0', path: 'a.txt'}, {id: 'comment1', path: 'a.txt'}]},
+        ],
       });
+      const patchWrapper = reviewsWrapper.find(PullRequestPatchContainer).renderProp('children')(null, patch);
 
-      assert.isTrue(reviewsWrapper.find(CommentPositioningContainer).exists());
+      assert.isTrue(patchWrapper.find(CommentPositioningContainer).exists());
     });
 
     it('renders nothing while the comment positions are being calculated', function() {
@@ -357,14 +393,16 @@ describe('CommentDecorationsContainer', function() {
       const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({
         error: null, props, retry: () => {},
       });
-      const patchWrapper = resultWrapper.find(PullRequestPatchContainer).renderProp('children')(null, patch);
-      const reviewsWrapper = patchWrapper.find(AggregatedReviewsContainer).renderProp('children')({
+      const reviewsWrapper = resultWrapper.find(AggregatedReviewsContainer).renderProp('children')({
         errors: [],
         summaries: [],
-        commentThreads: [],
+        commentThreads: [
+          {thread: {id: 'thread0'}, comments: [{id: 'comment0', path: 'a.txt'}, {id: 'comment1', path: 'a.txt'}]},
+        ],
       });
+      const patchWrapper = reviewsWrapper.find(PullRequestPatchContainer).renderProp('children')(null, patch);
 
-      const positionedWrapper = reviewsWrapper.find(CommentPositioningContainer).renderProp('children')(null);
+      const positionedWrapper = patchWrapper.find(CommentPositioningContainer).renderProp('children')(null);
       assert.isTrue(positionedWrapper.isEmptyRender());
     });
 
@@ -385,15 +423,17 @@ describe('CommentDecorationsContainer', function() {
       const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({
         error: null, props, retry: () => {},
       });
-      const patchWrapper = resultWrapper.find(PullRequestPatchContainer).renderProp('children')(null, patch);
-      const reviewsWrapper = patchWrapper.find(AggregatedReviewsContainer).renderProp('children')({
+      const reviewsWrapper = resultWrapper.find(AggregatedReviewsContainer).renderProp('children')({
         errors: [],
         summaries: [],
-        commentThreads: [],
+        commentThreads: [
+          {thread: {id: 'thread0'}, comments: [{id: 'comment0', path: 'a.txt'}, {id: 'comment1', path: 'a.txt'}]},
+        ],
       });
+      const patchWrapper = reviewsWrapper.find(PullRequestPatchContainer).renderProp('children')(null, patch);
 
       const translations = new Map();
-      const positionedWrapper = reviewsWrapper.find(CommentPositioningContainer).renderProp('children')(translations);
+      const positionedWrapper = patchWrapper.find(CommentPositioningContainer).renderProp('children')(translations);
 
       const controller = positionedWrapper.find(CommentDecorationsController);
       assert.strictEqual(controller.prop('commentTranslations'), translations);

--- a/test/containers/commit-preview-container.test.js
+++ b/test/containers/commit-preview-container.test.js
@@ -5,7 +5,7 @@ import path from 'path';
 
 import CommitPreviewContainer from '../../lib/containers/commit-preview-container';
 import CommitPreviewItem from '../../lib/items/commit-preview-item';
-import {TOO_LARGE, EXPANDED} from '../../lib/models/patch/patch';
+import {DEFERRED, EXPANDED} from '../../lib/models/patch/patch';
 import {cloneRepository, buildRepository} from '../helpers';
 
 describe('CommitPreviewContainer', function() {
@@ -89,7 +89,7 @@ describe('CommitPreviewContainer', function() {
     await assert.async.isTrue(wrapper.update().exists('CommitPreviewController'));
 
     const before = wrapper.find('CommitPreviewController').prop('multiFilePatch');
-    assert.strictEqual(before.getFilePatches()[0].getRenderStatus(), TOO_LARGE);
+    assert.strictEqual(before.getFilePatches()[0].getRenderStatus(), DEFERRED);
     assert.strictEqual(before.getFilePatches()[1].getRenderStatus(), EXPANDED);
 
     before.expandFilePatch(before.getFilePatches()[0]);

--- a/test/containers/pr-patch-container.test.js
+++ b/test/containers/pr-patch-container.test.js
@@ -220,6 +220,24 @@ describe('PullRequestPatchContainer', function() {
 
       assert.isFalse(setStateSpy.called);
     });
+
+    it('respects a custom largeDiffThreshold', async function() {
+      setDiffResponse(rawDiff);
+
+      const children = createChildrenCallback();
+      shallow(buildApp({
+        largeDiffThreshold: 1,
+        children,
+      }));
+
+      await children.nextCall();
+      const {error, mfp} = await children.nextCall();
+
+      assert.isNull(error);
+      assert.lengthOf(mfp.getFilePatches(), 1);
+      const [fp] = mfp.getFilePatches();
+      assert.isFalse(fp.getRenderStatus().isVisible());
+    });
   });
 
   describe('when there has been an error', function() {

--- a/test/containers/pr-patch-container.test.js
+++ b/test/containers/pr-patch-container.test.js
@@ -73,12 +73,12 @@ describe('PullRequestPatchContainer', function() {
     const fn = function(error, mfp) {
       if (waitingCallbacks.length > 0) {
         waitingCallbacks.shift()({error, mfp});
-        return;
+        return null;
       }
 
       calls.push({error, mfp});
       return null;
-    }
+    };
 
     fn.nextCall = function() {
       if (calls.length > 0) {
@@ -86,7 +86,7 @@ describe('PullRequestPatchContainer', function() {
       }
 
       return new Promise(resolve => waitingCallbacks.push(resolve));
-    }
+    };
 
     return fn;
   }
@@ -311,11 +311,15 @@ describe('PullRequestPatchContainer', function() {
         token: 'swordfish',
         children,
       }));
-      await children.nextCall();
+
+      assert.deepEqual(await children.nextCall(), {error: null, mfp: null});
       const {error: error0, mfp: mfp0} = await children.nextCall();
       assert.isNull(error0);
 
       wrapper.setProps({refetch: true});
+
+      assert.deepEqual(await children.nextCall(), {error: null, mfp: mfp0});
+      assert.deepEqual(await children.nextCall(), {error: null, mfp: null});
       const {error: error1, mfp: mfp1} = await children.nextCall();
       assert.isNull(error1);
       assert.strictEqual(mfp1, mfp0);

--- a/test/models/patch/builder.test.js
+++ b/test/models/patch/builder.test.js
@@ -1,5 +1,5 @@
 import {buildFilePatch, buildMultiFilePatch} from '../../../lib/models/patch';
-import {TOO_LARGE, EXPANDED} from '../../../lib/models/patch/patch';
+import {DEFERRED, EXPANDED} from '../../../lib/models/patch/patch';
 import {multiFilePatchBuilder} from '../../builder/patch';
 import {assertInPatch, assertInFilePatch} from '../../helpers';
 
@@ -854,7 +854,7 @@ describe('buildFilePatch', function() {
       assert.lengthOf(mfp.getFilePatches(), 2);
       const [fp0, fp1] = mfp.getFilePatches();
 
-      assert.strictEqual(fp0.getRenderStatus(), TOO_LARGE);
+      assert.strictEqual(fp0.getRenderStatus(), DEFERRED);
       assert.strictEqual(fp0.getOldPath(), 'first');
       assert.strictEqual(fp0.getNewPath(), 'first');
       assert.deepEqual(fp0.getStartRange().serialize(), [[0, 0], [0, 0]]);
@@ -904,7 +904,7 @@ describe('buildFilePatch', function() {
       assert.lengthOf(mfp.getFilePatches(), 2);
       const [fp0, fp1] = mfp.getFilePatches();
 
-      assert.strictEqual(fp0.getRenderStatus(), TOO_LARGE);
+      assert.strictEqual(fp0.getRenderStatus(), DEFERRED);
       assert.strictEqual(fp0.getOldPath(), 'big');
       assert.strictEqual(fp0.getNewPath(), 'big');
       assert.deepEqual(fp0.getMarker().getRange().serialize(), [[0, 0], [0, 0]]);
@@ -939,7 +939,7 @@ describe('buildFilePatch', function() {
       assert.lengthOf(mfp.getFilePatches(), 1);
       const [fp] = mfp.getFilePatches();
 
-      assert.strictEqual(fp.getRenderStatus(), TOO_LARGE);
+      assert.strictEqual(fp.getRenderStatus(), DEFERRED);
       assert.strictEqual(fp.getOldPath(), 'first');
       assert.strictEqual(fp.getNewPath(), 'first');
       assert.deepEqual(fp.getStartRange().serialize(), [[0, 0], [0, 0]]);
@@ -980,7 +980,7 @@ describe('buildFilePatch', function() {
       assert.lengthOf(mfp.getFilePatches(), 1);
       const [fp] = mfp.getFilePatches();
 
-      assert.strictEqual(fp.getRenderStatus(), TOO_LARGE);
+      assert.strictEqual(fp.getRenderStatus(), DEFERRED);
       assert.strictEqual(fp.getOldPath(), 'big');
       assert.strictEqual(fp.getNewPath(), 'big');
       assert.deepEqual(fp.getStartRange().serialize(), [[0, 0], [0, 0]]);
@@ -1044,7 +1044,7 @@ describe('buildFilePatch', function() {
         },
       );
 
-      assert.strictEqual(fp1.getRenderStatus(), TOO_LARGE);
+      assert.strictEqual(fp1.getRenderStatus(), DEFERRED);
       assert.deepEqual(fp1.getPatch().getMarker().getRange().serialize(), [[4, 0], [4, 0]]);
       assertInFilePatch(fp1, mfp.getBuffer()).hunks();
 

--- a/test/models/patch/file-patch.test.js
+++ b/test/models/patch/file-patch.test.js
@@ -2,7 +2,7 @@ import {TextBuffer} from 'atom';
 
 import FilePatch from '../../../lib/models/patch/file-patch';
 import File, {nullFile} from '../../../lib/models/patch/file';
-import Patch, {TOO_LARGE, COLLAPSED, EXPANDED} from '../../../lib/models/patch/patch';
+import Patch, {DEFERRED, COLLAPSED, EXPANDED} from '../../../lib/models/patch/patch';
 import PatchBuffer from '../../../lib/models/patch/patch-buffer';
 import Hunk from '../../../lib/models/patch/hunk';
 import {Unchanged, Addition, Deletion, NoNewline} from '../../../lib/models/patch/region';
@@ -700,7 +700,7 @@ describe('FilePatch', function() {
     it('triggerCollapseIn returns false if patch is not visible', function() {
       const {multiFilePatch} = multiFilePatchBuilder()
         .addFilePatch(fp => {
-          fp.renderStatus(TOO_LARGE);
+          fp.renderStatus(DEFERRED);
         }).build();
       const filePatch = multiFilePatch.getFilePatches()[0];
       assert.isFalse(filePatch.triggerCollapseIn(new PatchBuffer(), {before: [], after: []}));

--- a/test/models/patch/filter.test.js
+++ b/test/models/patch/filter.test.js
@@ -1,0 +1,75 @@
+import {filter, MAX_PATCH_CHARS} from '../../../lib/models/patch/filter';
+
+describe('patch filter', function() {
+  it('passes through small patches as-is', function() {
+    const original = new PatchBuilder()
+      .addSmallPatch('path-a.txt')
+      .addSmallPatch('path-b.txt')
+      .toString();
+
+    const {filtered, removed} = filter(original, new Set(['path-a.txt', 'path-b.txt']));
+    assert.lengthOf(Array.from(removed), 0);
+    assert.strictEqual(filtered, original);
+  });
+
+  it('retains only files matching requested paths', function() {
+    const original = new PatchBuilder()
+      .addSmallPatch('path-a.txt')
+      .addSmallPatch('path-b.txt')
+      .toString();
+
+    const expected = new PatchBuilder()
+      .addSmallPatch('path-b.txt')
+      .toString();
+
+    const {filtered, removed} = filter(original, new Set(['path-b.txt', 'path-c.txt']));
+    assert.deepEqual(Array.from(removed), ['path-a.txt']);
+    assert.strictEqual(filtered, expected);
+  });
+
+  it('removes files from the patch that exceed the size threshold', function() {
+    const original = new PatchBuilder()
+      .addLargePatch('path-a.txt')
+      .addSmallPatch('path-b.txt')
+      .toString();
+
+    const expected = new PatchBuilder()
+      .addSmallPatch('path-b.txt')
+      .toString();
+
+    const {filtered, removed} = filter(original, new Set(['path-a.txt', 'path-b.txt']));
+    assert.deepEqual(Array.from(removed), ['path-a.txt']);
+    assert.strictEqual(filtered, expected);
+  });
+});
+
+class PatchBuilder {
+  constructor() {
+    this.text = '';
+  }
+
+  addSmallPatch(fileName) {
+    this.text += `diff --git a/${fileName} b/${fileName}\n`;
+    this.text += '+aaaa\n';
+    this.text += '+bbbb\n';
+    this.text += '+cccc\n';
+    this.text += '+dddd\n';
+    this.text += '+eeee\n';
+    return this;
+  }
+
+  addLargePatch(fileName) {
+    this.text += `diff --git a/${fileName} b/${fileName}\n`;
+    const line = '+yyyy\n';
+    let totalSize = 0;
+    while (totalSize < MAX_PATCH_CHARS) {
+      this.text += line;
+      totalSize += line.length;
+    }
+    return this;
+  }
+
+  toString() {
+    return this.text;
+  }
+}

--- a/test/models/patch/filter.test.js
+++ b/test/models/patch/filter.test.js
@@ -7,8 +7,9 @@ describe('patch filter', function() {
       .addSmallPatch('path-b.txt')
       .toString();
 
-    const filtered = filter(original);
+    const {filtered, removed} = filter(original);
     assert.strictEqual(filtered, original);
+    assert.sameMembers(Array.from(removed), []);
   });
 
   it('removes files from the patch that exceed the size threshold', function() {
@@ -21,8 +22,9 @@ describe('patch filter', function() {
       .addSmallPatch('path-b.txt')
       .toString();
 
-    const filtered = filter(original);
+    const {filtered, removed} = filter(original);
     assert.strictEqual(filtered, expected);
+    assert.sameMembers(Array.from(removed), ['path-a.txt']);
   });
 });
 

--- a/test/models/patch/filter.test.js
+++ b/test/models/patch/filter.test.js
@@ -7,24 +7,8 @@ describe('patch filter', function() {
       .addSmallPatch('path-b.txt')
       .toString();
 
-    const {filtered, removed} = filter(original, new Set(['path-a.txt', 'path-b.txt']));
-    assert.lengthOf(Array.from(removed), 0);
+    const filtered = filter(original);
     assert.strictEqual(filtered, original);
-  });
-
-  it('retains only files matching requested paths', function() {
-    const original = new PatchBuilder()
-      .addSmallPatch('path-a.txt')
-      .addSmallPatch('path-b.txt')
-      .toString();
-
-    const expected = new PatchBuilder()
-      .addSmallPatch('path-b.txt')
-      .toString();
-
-    const {filtered, removed} = filter(original, new Set(['path-b.txt', 'path-c.txt']));
-    assert.deepEqual(Array.from(removed), ['path-a.txt']);
-    assert.strictEqual(filtered, expected);
   });
 
   it('removes files from the patch that exceed the size threshold', function() {
@@ -37,8 +21,7 @@ describe('patch filter', function() {
       .addSmallPatch('path-b.txt')
       .toString();
 
-    const {filtered, removed} = filter(original, new Set(['path-a.txt', 'path-b.txt']));
-    assert.deepEqual(Array.from(removed), ['path-a.txt']);
+    const filtered = filter(original);
     assert.strictEqual(filtered, expected);
   });
 });

--- a/test/models/patch/multi-file-patch.test.js
+++ b/test/models/patch/multi-file-patch.test.js
@@ -2,7 +2,7 @@ import dedent from 'dedent-js';
 
 import {multiFilePatchBuilder, filePatchBuilder} from '../../builder/patch';
 
-import {TOO_LARGE, COLLAPSED, EXPANDED} from '../../../lib/models/patch/patch';
+import {DEFERRED, COLLAPSED, EXPANDED} from '../../../lib/models/patch/patch';
 import MultiFilePatch from '../../../lib/models/patch/multi-file-patch';
 import PatchBuffer from '../../../lib/models/patch/patch-buffer';
 
@@ -646,7 +646,7 @@ describe('MultiFilePatch', function() {
       const multiFilePatch = multiFilePatchBuilder()
         .addFilePatch(fp => {
           fp.setOldFile(f => f.path('file-0'));
-          fp.renderStatus(TOO_LARGE);
+          fp.renderStatus(DEFERRED);
         })
         .build()
         .multiFilePatch;
@@ -683,7 +683,7 @@ describe('MultiFilePatch', function() {
         })
         .addFilePatch(fp => {
           fp.setOldFile(f => f.path('too-large-file'));
-          fp.renderStatus(TOO_LARGE);
+          fp.renderStatus(DEFERRED);
         })
         .addFilePatch(fp => {
           fp.setOldFile(f => f.path('collapsed-file'));
@@ -885,7 +885,7 @@ describe('MultiFilePatch', function() {
           fp.addHunk(h => h.unchanged('0 (1)').added('1 (2)', '2 (3)').deleted('3 (4)').unchanged('4 (5)'));
           fp.addHunk(h => h.unchanged('5 (7)').added('6 (8)', '7 (9)', '8 (10)').unchanged('9 (11)'));
           fp.addHunk(h => h.unchanged('10 (13)').deleted('11 (14)').unchanged('12 (15)'));
-          fp.renderStatus(TOO_LARGE);
+          fp.renderStatus(DEFERRED);
         })
         .build();
       assert.isTrue(multiFilePatch.isDiffRowOffsetIndexEmpty('1.txt'));

--- a/test/views/multi-file-patch-view.test.js
+++ b/test/views/multi-file-patch-view.test.js
@@ -4,7 +4,7 @@ import {shallow, mount} from 'enzyme';
 import * as reporterProxy from '../../lib/reporter-proxy';
 
 import {cloneRepository, buildRepository} from '../helpers';
-import {EXPANDED, COLLAPSED, DEFERRED} from '../../lib/models/patch/patch';
+import {EXPANDED, COLLAPSED, DEFERRED, REMOVED} from '../../lib/models/patch/patch';
 import MultiFilePatchView from '../../lib/views/multi-file-patch-view';
 import {multiFilePatchBuilder} from '../builder/patch';
 import {aggregatedReviewsBuilder} from '../builder/graphql/aggregated-reviews-builder';
@@ -1915,6 +1915,28 @@ describe('MultiFilePatchView', function() {
       wrapper = mount(buildApp({multiFilePatch: mfp}));
       assert.isFalse(wrapper.find('.github-FilePatchView-showDiffButton').exists());
       assert.isTrue(wrapper.find('.github-HunkHeaderView').exists());
+    });
+  });
+
+  describe('removed diff message', function() {
+    let wrapper, mfp;
+
+    beforeEach(function() {
+      const {multiFilePatch} = multiFilePatchBuilder()
+        .addFilePatch(fp => {
+          fp.renderStatus(REMOVED);
+        }).build();
+      mfp = multiFilePatch;
+      wrapper = mount(buildApp({multiFilePatch: mfp}));
+    });
+
+    it('displays the message when a file has been removed', function() {
+      assert.include(
+        wrapper.find('.github-FilePatchView-controlBlock .github-FilePatchView-message').first().text(),
+        'This diff is too large to load at all.',
+      );
+      assert.isFalse(wrapper.find('.github-FilePatchView-showDiffButton').exists());
+      assert.isFalse(wrapper.find('.github-HunkHeaderView').exists());
     });
   });
 });

--- a/test/views/multi-file-patch-view.test.js
+++ b/test/views/multi-file-patch-view.test.js
@@ -4,7 +4,7 @@ import {shallow, mount} from 'enzyme';
 import * as reporterProxy from '../../lib/reporter-proxy';
 
 import {cloneRepository, buildRepository} from '../helpers';
-import {EXPANDED, COLLAPSED, TOO_LARGE} from '../../lib/models/patch/patch';
+import {EXPANDED, COLLAPSED, DEFERRED} from '../../lib/models/patch/patch';
 import MultiFilePatchView from '../../lib/views/multi-file-patch-view';
 import {multiFilePatchBuilder} from '../builder/patch';
 import {aggregatedReviewsBuilder} from '../builder/graphql/aggregated-reviews-builder';
@@ -1878,7 +1878,7 @@ describe('MultiFilePatchView', function() {
     beforeEach(function() {
       const {multiFilePatch} = multiFilePatchBuilder()
         .addFilePatch(fp => {
-          fp.renderStatus(TOO_LARGE);
+          fp.renderStatus(DEFERRED);
         }).build();
       mfp = multiFilePatch;
       wrapper = mount(buildApp({multiFilePatch: mfp}));


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Our `PullRequestPatchContainer` component fetches and parses diffs from GitHub's REST API, then makes this available to child components as a MultiFilePatch. Unfortunately, it seems that pull requests with many or large files -- such as atom/flight-manual.atom.io#541 -- can cause stalls of a full minute (😱) while these are being parsed.

Interestingly, the stalls seem to be in what-the-diff's PEG parser rather than our own `buildMultiFilePatch()` function; in the past, `buildMultiFilePatch()` was the bottleneck. As a consequence our "large diff detection" logic isn't helping.

To mitigate this:

- [x] I'm using [conditional requests](https://developer.github.com/v3/#conditional-requests) to avoid fetching and re-parsing the _same_ large diff from dotcom more than once.
- [x] We don't need the patch at all in `CommentDecorationsContainer` if the current PR has no review comments. Let's find review comments first and bail if there are none (which is the common case anyway).
- [x] Finally, I'll investigate setting an upper size bound on which diffs we attempt to parse from dotcom.
  - [x] It would be good to offer some notification of degraded functionality when we _do_ have to drop comments.
  - [x] When the patch is large enough to trigger the MultiFilePatch "large diff" gate, but not the raw diff filter, comments are unavailable, but only until the diff is expanded. Let's show a notification with a control that allows users to opt in to parsing the diff when it does have comments.
  - [x] We'll need to make sure that the `PullRequestDetailView` can gracefully handle a missing diff. Or at least not crash horribly.
  - [x] Settling on an appropriate size limit will take some experimentation.

### Screenshot/Gif

Here's what I'm doing if you open an editor on a file that has review comments, but whose patch has been omitted for size:

<img width="812" alt="too-large" src="https://user-images.githubusercontent.com/17565/61322537-e731fc80-a7db-11e9-9776-c22d86ccd9f4.png">

### Alternate Designs

_N/A_

### Benefits

Using Atom to edit files on branches corresponding to pull requests with "large" diffs will no longer cause periodic stalls.

### Possible Drawbacks

The review comment and patch fetches can happen in parallel presently because they're independent operations. By making the patch fetch depend on the result of the review comment aggregation, it'll take longer to load all of the data and display the first review comment decoration or populate the reviews tab.

### Applicable Issues

_N/A_

### Metrics

_N/A_

### Tests

* [x] Normal case: small patch, review comments.
  * [x] Ensure comment decorations are rendered appropriately.
  * [x] Ensure that the ETag and 304 response are used to prevent re-parsing the patch.
* [x] On a PR with no review comments, ensure the patch is not fetched at all.
* [x] On a PR with a large file patch and a small patch that contains review comments:
  * [x] Ensure the large file patch is filtered out and does not cause a performance stall.
  * [x] Ensure the review comments on the file with the small patch are rendered appropriately.
* [x] On a PR with a large file patch that contains review comments:
  * [x] Ensure the large file patch is filtered out and does not cause a performance stall.
  * [x] Ensure a block decoration is rendered at the front of the editor of the file with the large patch.
  * [x] Ensure that opening the ReviewsItem on the PR does not crash as a result of the missing patch.

### Documentation

_N/A_

### Release Notes

* Improved the performance of the GitHub package when working on checked-out pull request with a large diff.

### User Experience Research (Optional)

_N/A_