### PR TITLE
Fix branch menu on unborn branch

### DIFF
--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -177,7 +177,7 @@ export default class Repository {
     }
 
     const description = await this.getHeadDescription();
-    return Branch.createDetached(description);
+    return Branch.createDetached(description || 'no branch');
   }
 
   async getUnstagedChanges() {

--- a/lib/views/branch-menu-view.js
+++ b/lib/views/branch-menu-view.js
@@ -26,7 +26,7 @@ export default class BranchMenuView extends React.Component {
   }
 
   render() {
-    const branchNames = this.props.branches.getNames();
+    const branchNames = this.props.branches.getNames().filter(Boolean);
     let currentBranchName = this.props.currentBranch.isDetached() ? 'detached' : this.props.currentBranch.getName();
     if (this.state.checkedOutBranch) {
       currentBranchName = this.state.checkedOutBranch;
@@ -71,7 +71,7 @@ export default class BranchMenuView extends React.Component {
           <option key="detached" value="detached" disabled>{this.props.currentBranch.getName()}</option>
         }
         {branchNames.map(branchName => {
-          return <option key={branchName} value={branchName}>{branchName}</option>;
+          return <option key={`branch-${branchName}`} value={branchName}>{branchName}</option>;
         })}
       </select>
     );

--- a/lib/views/branch-menu-view.js
+++ b/lib/views/branch-menu-view.js
@@ -5,31 +5,24 @@ import cx from 'classnames';
 import Commands, {Command} from '../atom/commands';
 import {BranchPropType, BranchSetPropType} from '../prop-types';
 import {GitError} from '../git-shell-out-strategy';
-import {autobind} from '../helpers';
 
 export default class BranchMenuView extends React.Component {
   static propTypes = {
+    // Atom environment
     workspace: PropTypes.object.isRequired,
     commandRegistry: PropTypes.object.isRequired,
     notificationManager: PropTypes.object.isRequired,
+
+    // Model
     repository: PropTypes.object,
     branches: BranchSetPropType.isRequired,
     currentBranch: BranchPropType.isRequired,
     checkout: PropTypes.func,
   }
 
-  static defaultProps = {
-    checkout: () => Promise.resolve(),
-  }
-
-  constructor(props, context) {
-    super(props, context);
-    autobind(this, 'didSelectItem', 'createBranch', 'checkout', 'cancelCreateNewBranch');
-
-    this.state = {
-      createNew: false,
-      checkedOutBranch: null,
-    };
+  state = {
+    createNew: false,
+    checkedOutBranch: null,
   }
 
   render() {
@@ -101,12 +94,12 @@ export default class BranchMenuView extends React.Component {
     );
   }
 
-  async didSelectItem(event) {
+  didSelectItem = async event => {
     const branchName = event.target.value;
     await this.checkout(branchName);
   }
 
-  async createBranch() {
+  createBranch = async () => {
     if (this.state.createNew) {
       const branchName = this.editorElement.getModel().getText().trim();
       await this.checkout(branchName, {createNew: true});
@@ -120,7 +113,7 @@ export default class BranchMenuView extends React.Component {
     }
   }
 
-  async checkout(branchName, options) {
+  checkout = async (branchName, options) => {
     this.editorElement.classList.remove('is-focused');
     await new Promise(resolve => {
       this.setState({checkedOutBranch: branchName}, resolve);
@@ -142,7 +135,7 @@ export default class BranchMenuView extends React.Component {
     }
   }
 
-  cancelCreateNewBranch() {
+  cancelCreateNewBranch = () => {
     this.setState({createNew: false});
   }
 }

--- a/test/views/branch-menu-view.test.js
+++ b/test/views/branch-menu-view.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import BranchMenuView from '../../lib/views/branch-menu-view';
+import Branch, {nullBranch} from '../../lib/models/branch';
+import BranchSet from '../../lib/models/branch-set';
+import {cloneRepository, buildRepository} from '../helpers';
+
+describe('BranchMenuView', function() {
+  let atomEnv, repository;
+
+  beforeEach(async function() {
+    atomEnv = global.buildAtomEnvironment();
+
+    repository = await buildRepository(await cloneRepository());
+  });
+
+  afterEach(function() {
+    atomEnv.destroy();
+  });
+
+  function buildApp(overrides = {}) {
+    const currentBranch = new Branch('master', nullBranch, nullBranch, true);
+    const branches = new BranchSet([currentBranch]);
+
+    return (
+      <BranchMenuView
+        workspace={atomEnv.workspace}
+        commandRegistry={atomEnv.commands}
+        notificationManager={atomEnv.notifications}
+        repository={repository}
+        branches={branches}
+        currentBranch={currentBranch}
+        checkout={() => {}}
+        {...overrides}
+      />
+    );
+  }
+
+  it('cancels new branch creation', function() {
+    const wrapper = shallow(buildApp());
+    wrapper.find('.github-BranchMenuView-button').simulate('click');
+    wrapper.find('Command[command="core:cancel"]').prop('callback')();
+
+    assert.isTrue(wrapper.find('.github-BranchMenuView-editor').hasClass('hidden'));
+    assert.isFalse(wrapper.find('.github-BranchMenuView-select').hasClass('hidden'));
+  });
+});


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

If you open Atom in a repository after you run `git init .` but before you make your first commit, the "branch menu" selector is blank, which looks wrong and is difficult to interact with. I've changed it to show "no branch" instead.

### Screenshot/Gif

| Before | After |
| -- | -- |
|  <img width="379" alt="before-status-bar" src="https://user-images.githubusercontent.com/17565/61561077-0cbd4100-aa3c-11e9-915d-b132bc656546.png"> | <img width="445" alt="after-status-bar" src="https://user-images.githubusercontent.com/17565/61561166-39715880-aa3c-11e9-9d06-fb5d84ead9b6.png"> |
| <img width="434" alt="before-menu" src="https://user-images.githubusercontent.com/17565/61561085-0fb83180-aa3c-11e9-8228-d7f209933ca2.png"> | <img width="571" alt="after-menu" src="https://user-images.githubusercontent.com/17565/61561170-3fffd000-aa3c-11e9-82c3-919b6ecc1ea2.png"> |

### Alternate Designs

_N/A_

### Benefits

Users who initialize a repo from Atom will be less confused.

### Possible Drawbacks

_N/A_

### Applicable Issues

_N/A_

### Metrics

_N/A_

### Tests

I opened Atom on a repo I'd just initialized.

### Documentation

_N/A_

### Release Notes

* The branch menu displays "no branch" on a repository that's just been initialized.

### User Experience Research (Optional)

_N/A_