### PR TITLE
Simplify CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
     condition: succeededOrFailed()
   - bash: |
       env
-      bash <(curl -s https://codecov.io/bash) -n "Linux $(atom_channel)"
+      bash <(curl -s https://codecov.io/bash) -n "Linux $(atom_channel)" -v
     displayName: publish code coverage to CodeCov
     env:
       CODECOV_TOKEN: $(codecov.token)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,12 +17,6 @@ jobs:
       dev:
         atom_channel: dev
         atom_name: atom-dev
-      beta:
-        atom_channel: beta
-        atom_name: atom-beta
-      stable:
-        atom_channel: stable
-        atom_name: atom
   variables:
     display: ":99"
   steps:
@@ -73,12 +67,6 @@ jobs:
       dev:
         atom_channel: dev
         atom_app: Atom Dev.app
-      beta:
-        atom_channel: beta
-        atom_app: Atom Beta.app
-      stable:
-        atom_channel: stable
-        atom_app: Atom.app
   steps:
   - template: script/azure-pipelines/macos-install.yml
     parameters:
@@ -127,12 +115,6 @@ jobs:
       dev:
         atom_channel: dev
         atom_directory: Atom Dev
-      beta:
-        atom_channel: beta
-        atom_directory: Atom Beta
-      stable:
-        atom_channel: stable
-        atom_directory: Atom
   steps:
   - template: script/azure-pipelines/windows-install.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,13 +12,10 @@ jobs:
 - job: Linux
   pool:
     vmImage: ubuntu-16.04
-  strategy:
-    matrix:
-      dev:
-        atom_channel: dev
-        atom_name: atom-dev
   variables:
     display: ":99"
+    atom_channel: dev
+    atom_name: atom-dev
   steps:
   - template: script/azure-pipelines/linux-install.yml
     parameters:
@@ -61,11 +58,9 @@ jobs:
 - job: MacOS
   pool:
     vmImage: macos-10.13
-  strategy:
-    matrix:
-      dev:
-        atom_channel: dev
-        atom_app: Atom Dev.app
+  variables:
+    atom_channel: dev
+    atom_app: Atom Dev.app
   steps:
   - template: script/azure-pipelines/macos-install.yml
     parameters:
@@ -106,11 +101,9 @@ jobs:
 - job: Windows
   pool:
     vmImage: vs2015-win2012r2
-  strategy:
-    matrix:
-      dev:
-        atom_channel: dev
-        atom_directory: Atom Dev
+  variables:
+    atom_channel: dev
+    atom_directory: Atom Dev
   steps:
   - template: script/azure-pipelines/windows-install.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
     condition: succeededOrFailed()
   - bash: |
       env
-      bash <(curl -s https://codecov.io/bash) -n "Linux $(atom_channel)" -p "${VCS_PULL_REQUEST}" -B "${VCS_BRANCH_NAME}"
+      bash <(curl -s https://codecov.io/bash) -n "Linux $(atom_channel)" -P "${VCS_PULL_REQUEST}" -B "${VCS_BRANCH_NAME}"
     displayName: publish code coverage to CodeCov
     env:
       CODECOV_TOKEN: $(codecov.token)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
   branches:
     include:
     - master
-    - *-releases
+    - '*-releases'
 pr:
   branches:
     include:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,15 +44,12 @@ jobs:
     condition: succeededOrFailed()
   - bash: |
       env
-      bash <(curl -s https://codecov.io/bash) -n "Linux $(atom_channel)" -v
+      bash <(curl -s https://codecov.io/bash) -n "Linux $(atom_channel)" -p "${VCS_PULL_REQUEST}" -B "${VCS_BRANCH_NAME}"
     displayName: publish code coverage to CodeCov
     env:
       CODECOV_TOKEN: $(codecov.token)
-      VCS_COMMIT_ID: $(Build.SourceVersion)
       VCS_BRANCH_NAME: $[coalesce(variables.System.PullRequest.SourceBranch, variables.Build.SourceBranch)]
       VCS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
-      CI_JOB_ID: $(Agent.JobName)
-      CI_BUILD_ID: $(Build.BuildID)
     condition: succeededOrFailed()
   - task: PublishCodeCoverageResults@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,9 @@ jobs:
   - bash: npm run report:coverage
     displayName: generate code coverage reports
     condition: succeededOrFailed()
-  - bash: bash <(curl -s https://codecov.io/bash) -n "Linux $(atom_channel)" -v
+  - bash: |
+      env
+      bash <(curl -s https://codecov.io/bash) -n "Linux $(atom_channel)"
     displayName: publish code coverage to CodeCov
     env:
       CODECOV_TOKEN: $(codecov.token)
@@ -90,7 +92,7 @@ jobs:
   - bash: npm run report:coverage
     displayName: generate code coverage reports
     condition: succeededOrFailed()
-  - bash: bash <(curl -s https://codecov.io/bash) -n "MacOS $(atom_channel)" -v
+  - bash: bash <(curl -s https://codecov.io/bash) -n "MacOS $(atom_channel)"
     displayName: publish code coverage to CodeCov
     env:
       CODECOV_TOKEN: $(codecov.token)
@@ -158,7 +160,7 @@ jobs:
   - powershell: npm run report:coverage
     displayName: generate code coverage reports
     condition: succeededOrFailed()
-  - bash: bash <(curl -s https://codecov.io/bash) -n "Windows $(atom_channel)" -v
+  - bash: bash <(curl -s https://codecov.io/bash) -n "Windows $(atom_channel)"
     displayName: publish code coverage to CodeCov
     env:
       CODECOV_TOKEN: $(codecov.token)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,13 @@
+trigger:
+  branches:
+    include:
+    - master
+    - *-releases
+pr:
+  branches:
+    include:
+    - '*'
+
 jobs:
 - job: Linux
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,10 +48,15 @@ jobs:
   - bash: npm run report:coverage
     displayName: generate code coverage reports
     condition: succeededOrFailed()
-  - bash: npm run codecov -- --build="Linux $(atom_channel)"
+  - bash: bash <(curl -s https://codecov.io/bash) -n "Linux $(atom_channel)" -v
     displayName: publish code coverage to CodeCov
     env:
       CODECOV_TOKEN: $(codecov.token)
+      VCS_COMMIT_ID: $(Build.SourceVersion)
+      VCS_BRANCH_NAME: $[coalesce(variables.System.PullRequest.SourceBranch, variables.Build.SourceBranch)]
+      VCS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
+      CI_JOB_ID: $(Agent.JobName)
+      CI_BUILD_ID: $(Build.BuildID)
     condition: succeededOrFailed()
   - task: PublishCodeCoverageResults@1
     inputs:
@@ -97,10 +102,15 @@ jobs:
   - bash: npm run report:coverage
     displayName: generate code coverage reports
     condition: succeededOrFailed()
-  - bash: npm run codecov -- --build="MacOS $(atom_channel)"
+  - bash: bash <(curl -s https://codecov.io/bash) -n "MacOS $(atom_channel)" -v
     displayName: publish code coverage to CodeCov
     env:
       CODECOV_TOKEN: $(codecov.token)
+      VCS_COMMIT_ID: $(Build.SourceVersion)
+      VCS_BRANCH_NAME: $[coalesce(variables.System.PullRequest.SourceBranch, variables.Build.SourceBranch)]
+      VCS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
+      CI_JOB_ID: $(Agent.JobName)
+      CI_BUILD_ID: $(Build.BuildID)
     condition: succeededOrFailed()
   - task: PublishCodeCoverageResults@1
     inputs:
@@ -166,10 +176,15 @@ jobs:
   - powershell: npm run report:coverage
     displayName: generate code coverage reports
     condition: succeededOrFailed()
-  - powershell: npm run codecov -- --build="Windows $(atom_channel)"
+  - bash: bash <(curl -s https://codecov.io/bash) -n "Windows $(atom_channel)" -v
     displayName: publish code coverage to CodeCov
     env:
       CODECOV_TOKEN: $(codecov.token)
+      VCS_COMMIT_ID: $(Build.SourceVersion)
+      VCS_BRANCH_NAME: $[coalesce(variables.System.PullRequest.SourceBranch, variables.Build.SourceBranch)]
+      VCS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
+      CI_JOB_ID: $(Agent.JobName)
+      CI_BUILD_ID: $(Build.BuildID)
     condition: succeededOrFailed()
   - task: PublishCodeCoverageResults@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,15 +89,12 @@ jobs:
   - bash: npm run report:coverage
     displayName: generate code coverage reports
     condition: succeededOrFailed()
-  - bash: bash <(curl -s https://codecov.io/bash) -n "MacOS $(atom_channel)"
+  - bash: bash <(curl -s https://codecov.io/bash) -n "MacOS $(atom_channel)" -P "${VCS_PULL_REQUEST}" -B "${VCS_BRANCH_NAME}"
     displayName: publish code coverage to CodeCov
     env:
       CODECOV_TOKEN: $(codecov.token)
-      VCS_COMMIT_ID: $(Build.SourceVersion)
       VCS_BRANCH_NAME: $[coalesce(variables.System.PullRequest.SourceBranch, variables.Build.SourceBranch)]
       VCS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
-      CI_JOB_ID: $(Agent.JobName)
-      CI_BUILD_ID: $(Build.BuildID)
     condition: succeededOrFailed()
   - task: PublishCodeCoverageResults@1
     inputs:
@@ -157,15 +154,12 @@ jobs:
   - powershell: npm run report:coverage
     displayName: generate code coverage reports
     condition: succeededOrFailed()
-  - bash: bash <(curl -s https://codecov.io/bash) -n "Windows $(atom_channel)"
+  - bash: bash <(curl -s https://codecov.io/bash) -n "Windows $(atom_channel)"  -P "${VCS_PULL_REQUEST}" -B "${VCS_BRANCH_NAME}"
     displayName: publish code coverage to CodeCov
     env:
       CODECOV_TOKEN: $(codecov.token)
-      VCS_COMMIT_ID: $(Build.SourceVersion)
       VCS_BRANCH_NAME: $[coalesce(variables.System.PullRequest.SourceBranch, variables.Build.SourceBranch)]
       VCS_PULL_REQUEST: $(System.PullRequest.PullRequestNumber)
-      CI_JOB_ID: $(Agent.JobName)
-      CI_BUILD_ID: $(Build.BuildID)
     condition: succeededOrFailed()
   - task: PublishCodeCoverageResults@1
     inputs:

--- a/test/models/endpoint.test.js
+++ b/test/models/endpoint.test.js
@@ -1,6 +1,6 @@
 import {getEndpoint} from '../../lib/models/endpoint';
 
-describe.only('Endpoint', function() {
+describe('Endpoint', function() {
   describe('on dotcom', function() {
     let dotcom;
 

--- a/test/models/endpoint.test.js
+++ b/test/models/endpoint.test.js
@@ -1,6 +1,6 @@
 import {getEndpoint} from '../../lib/models/endpoint';
 
-describe('Endpoint', function() {
+describe.only('Endpoint', function() {
   describe('on dotcom', function() {
     let dotcom;
 


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

We're running both push and PR builds for every PR because it's the only way I found to get CodeCov to correctly associate and display reports correctly, but that means we're running a _lot_ of builds (22 per push!) This is increasing the likelihood that we hit things like misbehaving build agents in any given job.

I'm going to see if I can keep CodeCov happy with a single set of builds if I change us over to [codecov-bash](https://github.com/codecov/codecov-bash/blob/master/codecov) with manual tweaking.

I'm also considering the removal of the stable and beta channel builds. It'd substantially reduce our build matrix, and I can't recall a legit failure that it's caught for us.

### Screenshot/Gif

_TODO_

### Alternate Designs

_N/A_

### Benefits

Faster CI.

### Possible Drawbacks

If I do trim out beta and stable, we would risk shipping a backported version to an Atom hotfix with a regression. I'm pretty sure Atom CI will catch those though.

### Applicable Issues

_N/A_

### Metrics

_N/A_

### Tests

By committing and pushing a lot?

### Documentation

_N/A_

### Release Notes

_N/A_

### User Experience Research (Optional)

_N/A_