### PR TITLE
Improve performance of isCommitPushed

### DIFF
--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -985,6 +985,9 @@ export default class GitShellOutStrategy {
     } else if (option.showRemote) {
       args.splice(1, 0, '--remotes');
     }
+    if (option.pattern) {
+      args.push(option.pattern);
+    }
     return (await this.exec(args)).trim().split(LINE_ENDING_REGEX);
   }
 

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -781,7 +781,7 @@ export default class Present extends State {
       showRemote: true,
       pattern: upstream.getShortRef(),
     });
-    return contained.length > 0;
+    return contained.some(ref => ref.length > 0);
   }
 
   // Author information

--- a/lib/models/repository-states/present.js
+++ b/lib/models/repository-states/present.js
@@ -770,9 +770,18 @@ export default class Present extends State {
   }
 
   async isCommitPushed(sha) {
-    const remoteBranchesWithCommit = await this.git().getBranchesWithCommit(sha, {showLocal: false, showRemote: true});
-    const currentRemote = (await this.repository.getCurrentBranch()).getUpstream();
-    return remoteBranchesWithCommit.includes(currentRemote.getFullRef());
+    const currentBranch = await this.repository.getCurrentBranch();
+    const upstream = currentBranch.getPush();
+    if (!upstream.isPresent()) {
+      return false;
+    }
+
+    const contained = await this.git().getBranchesWithCommit(sha, {
+      showLocal: false,
+      showRemote: true,
+      pattern: upstream.getShortRef(),
+    });
+    return contained.length > 0;
   }
 
   // Author information

--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -1080,6 +1080,13 @@ import * as reporterProxy from '../lib/reporter-proxy';
           ['refs/remotes/origin/HEAD', 'refs/remotes/origin/master'],
         );
       });
+
+      it('includes only refs matching a pattern', async function() {
+        assert.sameMembers(
+          await git.getBranchesWithCommit(SHA, {showLocal: true, showRemote: true, pattern: 'origin/master'}),
+          ['refs/remotes/origin/master'],
+        );
+      });
     });
 
     describe('getRemotes()', function() {


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Rework `Present#isCommitPushed(sha)` to only consider the push upstream of the current branch when listing remote refs that contain `sha`. This brings a considerable performance boost when opening `CommitDetailItems` in repositories that have a large number of remote refs, without actually changing any behavior because we were checking for the upstream ref in the `--contains` output anyway.

cc @vanessayuenn who noticed this :eyes:

### Screenshot/Gif

_N/A_

### Alternate Designs

_N/A_

### Benefits

Performance gains when opening a `CommitDetailItem` in large repositories.

### Possible Drawbacks

`isCommitPushed` will still return `false` if you open a commit that's pushed to a _different_ remote tracking branch. This could cause surprising behavior if you use the `github:open-commit` action from the command palette to look at a commit from a different branch - specifically, the dotcom link won't show up even if the commit _is_ pushed.

### Applicable Issues

_N/A_

### Metrics

_N/A_

### Tests

I tested this out in dev mode with `github/github`.

### Documentation

_N/A_

### Release Notes

* Fixed a performance issue when opening commit items in repositories with large numbers of remote refs.

### User Experience Research (Optional)

_N/A_