### PR TITLE
Make it easier to copy the commit SHA and subject

### DIFF
--- a/lib/controllers/recent-commits-controller.js
+++ b/lib/controllers/recent-commits-controller.js
@@ -63,6 +63,7 @@ export default class RecentCommitsController extends React.Component {
         selectPreviousCommit={this.selectPreviousCommit}
         selectedCommitSha={this.state.selectedCommitSha}
         commands={this.props.commands}
+        clipboard={atom.clipboard}
       />
     );
   }

--- a/lib/views/recent-commits-view.js
+++ b/lib/views/recent-commits-view.js
@@ -12,6 +12,8 @@ import Timeago from './timeago';
 
 class RecentCommitView extends React.Component {
   static propTypes = {
+    commands: PropTypes.object.isRequired,
+    clipboard: PropTypes.object.isRequired,
     commit: PropTypes.object.isRequired,
     undoLastCommit: PropTypes.func.isRequired,
     isMostRecent: PropTypes.bool.isRequired,
@@ -49,6 +51,10 @@ class RecentCommitView extends React.Component {
           'is-selected': this.props.isSelected,
         })}
         onClick={this.props.openCommit}>
+        <Commands registry={this.props.commands} target={this.refRoot}>
+          <Command command="github:copy-commit-sha" callback={this.copyCommitSha} />
+          <Command command="github:copy-commit-subject" callback={this.copyCommitSubject} />
+        </Commands>
         {this.renderAuthors()}
         <span
           className="github-RecentCommit-message"
@@ -104,6 +110,18 @@ class RecentCommitView extends React.Component {
     );
   }
 
+  copyCommitSha = event => {
+    event.stopPropagation();
+    const {commit, clipboard} = this.props;
+    clipboard.write(commit.sha);
+  }
+
+  copyCommitSubject = event => {
+    event.stopPropagation();
+    const {commit, clipboard} = this.props;
+    clipboard.write(commit.messageSubject);
+  }
+
   undoLastCommit = event => {
     event.stopPropagation();
     this.props.undoLastCommit();
@@ -118,6 +136,7 @@ export default class RecentCommitsView extends React.Component {
     selectedCommitSha: PropTypes.string.isRequired,
 
     // Atom environment
+    clipboard: PropTypes.object.isRequired,
     commands: PropTypes.object.isRequired,
 
     // Action methods
@@ -192,6 +211,8 @@ export default class RecentCommitsView extends React.Component {
             return (
               <RecentCommitView
                 key={commit.getSha()}
+                commands={this.props.commands}
+                clipboard={this.props.clipboard}
                 isMostRecent={i === 0}
                 commit={commit}
                 undoLastCommit={this.props.undoLastCommit}

--- a/menus/git.cson
+++ b/menus/git.cson
@@ -140,3 +140,13 @@
       'command': 'github:amend-last-commit'
     }
   ]
+  '.github-RecentCommit': [
+    {
+      'label': 'Copy Commit SHA'
+      'command': 'github:copy-commit-sha'
+    }
+    {
+      'label': 'Copy Commit Subject'
+      'command': 'github:copy-commit-subject'
+    }
+  ]

--- a/test/controllers/recent-commits-controller.test.js
+++ b/test/controllers/recent-commits-controller.test.js
@@ -45,6 +45,12 @@ describe('RecentCommitsController', function() {
     assert.isTrue(wrapper.find('RecentCommitsView').prop('isLoading'));
   });
 
+  it('passes the clipboard to the RecentCommitsView', function() {
+    app = React.cloneElement(app);
+    const wrapper = shallow(app);
+    assert.deepEqual(wrapper.find('RecentCommitsView').prop('clipboard'), atom.clipboard);
+  });
+
   describe('openCommit({sha, preserveFocus})', function() {
     it('opens a commit detail item', async function() {
       sinon.stub(atomEnv.workspace, 'open').resolves();

--- a/test/views/recent-commits-view.test.js
+++ b/test/views/recent-commits-view.test.js
@@ -14,6 +14,7 @@ describe('RecentCommitsView', function() {
     app = (
       <RecentCommitsView
         commits={[]}
+        clipboard={{}}
         isLoading={false}
         selectedCommitSha=""
         commands={atomEnv.commands}
@@ -218,6 +219,36 @@ describe('RecentCommitsView', function() {
     it('returns null from unrecognized previous focuses', async function() {
       assert.isNull(await instance.advanceFocusFrom(CommitView.firstFocus));
       assert.isNull(await instance.retreatFocusFrom(CommitView.firstFocus));
+    });
+  });
+
+  describe('copying details of a commit', function() {
+    let wrapper;
+    let clipboard;
+
+    beforeEach(function() {
+      const commits = [
+        commitBuilder().sha('0000').messageSubject('subject 0').build(),
+        commitBuilder().sha('1111').messageSubject('subject 1').build(),
+        commitBuilder().sha('2222').messageSubject('subject 2').build(),
+      ];
+      clipboard = {write: sinon.spy()};
+      app = React.cloneElement(app, {commits, clipboard});
+      wrapper = mount(app);
+    });
+
+    it('copies the commit sha on github:copy-commit-sha', function() {
+      const commitNode = wrapper.find('.github-RecentCommit').at(1).getDOMNode();
+      atomEnv.commands.dispatch(commitNode, 'github:copy-commit-sha');
+      assert.isTrue(clipboard.write.called);
+      assert.isTrue(clipboard.write.calledWith('1111'));
+    });
+
+    it('copies the commit subject on github:copy-commit-subject', function() {
+      const commitNode = wrapper.find('.github-RecentCommit').at(1).getDOMNode();
+      atomEnv.commands.dispatch(commitNode, 'github:copy-commit-subject');
+      assert.isTrue(clipboard.write.called);
+      assert.isTrue(clipboard.write.calledWith('subject 1'));
     });
   });
 });


### PR DESCRIPTION
### Description of the Change

This adds 'Copy Commit SHA' and 'Copy Commit Subject' to the right-click 
menu of the recent commits list.

This was suggested in https://github.com/atom/github/issues/1453 

### Screenshot/Gif

![Screenshot 2019-09-07 at 5 33 58pm](https://user-images.githubusercontent.com/149785/64477902-b1d0dc00-d198-11e9-95f2-8224e0268fdb.png)

### Alternate Designs

I started solving https://github.com/atom/github/issues/1533 instead- I often create 'fixup' and 'squash' commits a lot to be used with auto-squashing. I decided that this could be too niche a use case because auto-squashing is off in git by default and could be confusing to people that haven't used auto-squashing before. I thought that making it easier to copy commit details would go some way to make creating auto-squashing commits from Atom easier and bring other benefits.

### Benefits

This is intended to make it easier to:
+ Copy commit SHAs to use with command line tools
+ Reference commit SHAs or subjects when writing other commits
+ Reference the commit SHA or subject when writing a commit to be [auto-squashed](https://thoughtbot.com/blog/autosquashing-git-commits) in a later rebase.

Currently to copy the commit SHA or subject you have to click on the commit to open it, select the text you want to copy, then copy it, then close the commit.

Note that I find it better to use the commit subjects rather than the SHAs for fixup commits since SHAs may change when performing a non-interactive rebase on a branch (and auto-squash commits only apply during interactive rebases).


### Possible Drawbacks

None that I can think of - it's an isolated change and the ability is in a context menu so doesn't change the layout of the commit view.

### Applicable Issues

+ [Feature Request: Context menu for recent commits with fixup action #1533](https://github.com/atom/github/issues/1533)
+ [Feature request: copy SHA from recent commits #1453](https://github.com/atom/github/issues/1453)
+ [Copy commit SHA from commit detail pane #1876](https://github.com/atom/github/issues/1876) 

### Metrics

N/A

### Tests

Tested on Atom 1.42.0-nightly6 on OSX

+ Can Copy SHA by right-clicking on commit
   + [x] SHA copied matches what is displayed in `git log`
   + [x] Can right-click anywhere on highlighted commit to copy (including author image or timestamp)

+ Can Copy Commit Subject  by right-clicking on commit
   + [x] Subject copied matches to what is displayed in `git log`
   + [x] A copied subject pasted after `fixup! ` in a commit message triggers auto-squashing when rebasing
   + [x] Can right-click anywhere on highlighted commit to copy (including author image or timestamp)

I've added unit tests for the two copy actions in the recent commits view test file.

### Documentation

Please let me know if this should be documented.

### Release Notes

- You can now copy the SHA or subject of recent commits by right-clicking on them