### PR TITLE
Push using GITHUB_ACTOR and GITHUB_TOKEN

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-  - cron: 0 1 * * 4
+  - cron: 0 1 * * 5
 name: GraphQL schema update
 jobs:
   updateSchema:

--- a/actions/schema-up/index.js
+++ b/actions/schema-up/index.js
@@ -65,7 +65,12 @@ Toolkit.run(async tools => {
   if (hasRelayChanges !== 0 && !relayFailed) {
     await tools.runInWorkspace('git', ['commit', '--all', '--message', ':gear: relay-compiler changes']);
   }
-  await tools.runInWorkspace('git', ['push', 'origin', branchName]);
+
+  const actor = process.env.GITHUB_ACTOR;
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+
+  await tools.runInWorkspace('git', ['push', `https://${actor}:${token}@github.com/${repository}.git`, branchName]);
 
   tools.log.info('Creating a pull request.');
 


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Attempt to fix the automatic GraphQL schema workflow by explicitly using `${GITHUB_ACTOR}` and `${GITHUB_TOKEN}` as push credentials.

### Screenshot/Gif

_N/A_

### Alternate Designs

_N/A_

### Benefits

Our local copy of the GraphQL schema will be kept up to date automatically, and we'll have early warnings about any deprecations that may impact the GitHub package.

### Possible Drawbacks

_N/A_

### Applicable Issues

_N/A_

### Metrics

_N/A_

### Tests

Unfortunately we can't _really_ test this out until the next time the scheduled job fires. I'm going to change it to run tonight to give it a shot.

### Documentation

_N/A_

### Release Notes

_N/A_

### User Experience Research (Optional)

_N/A_