### PR TITLE
Removed jump to file from options when viewing past commits

### DIFF
--- a/menus/git.cson
+++ b/menus/git.cson
@@ -46,16 +46,6 @@
       'command': 'github:jump-to-file'
     }
   ]
-  '.github-FilePatchView': [
-    {
-      'type': 'separator'
-    }
-    {
-      'label': 'Jump to File'
-      'command': 'github:jump-to-file'
-      'after': ['core:confirm']
-    }
-  ]
   '.github-FilePatchView--staged': [
     {
       'type': 'separator'


### PR DESCRIPTION
### Description of the Change
Removed jump to file from the list of options when viewing a past commit or a diff.

### Possible Drawbacks

None.
### Applicable Issues

Fixes https://github.com/atom/github/issues/2310
