### PR TITLE
move the the Jump to file from the generic FilePatchView menu to the …

### DIFF
--- a/menus/git.cson
+++ b/menus/git.cson
@@ -51,6 +51,11 @@
       'type': 'separator'
     }
     {
+      'label': 'Jump to File'
+      'command': 'github:jump-to-file'
+      'after': ['core:confirm']
+    }
+    {
       'label': 'Unstage Selection'
       'command': 'core:confirm'
       'beforeGroupContaining': ['core:undo']
@@ -59,6 +64,11 @@
   '.github-FilePatchView--unstaged': [
     {
       'type': 'separator'
+    }
+    {
+      'label': 'Jump to File'
+      'command': 'github:jump-to-file'
+      'after': ['core:confirm']
     }
     {
       'label': 'Stage Selection'


### PR DESCRIPTION
### Description of the Change

The context menu, should not show the `jump to file` item on diffs for committed files.

### Possible Drawbacks

Users won't be able to use the `jump to file` for committed files for now, but any requests for this feature is welcome.

### Applicable Issues

Fixes #2310 
