### PR TITLE
Fix bad jump to file in reviews controller

### DIFF
--- a/lib/controllers/reviews-controller.js
+++ b/lib/controllers/reviews-controller.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import path from 'path';
 import PropTypes from 'prop-types';
 import {createFragmentContainer, graphql} from 'react-relay';
 
@@ -159,7 +160,7 @@ export class BareReviewsController extends React.Component {
 
   openFile = async (filePath, lineNumber) => {
     await this.props.workspace.open(
-      filePath, {
+      path.join(this.props.workdir, filePath), {
         initialLine: lineNumber - 1,
         initialColumn: 0,
         pending: true,

--- a/lib/controllers/reviews-controller.js
+++ b/lib/controllers/reviews-controller.js
@@ -289,7 +289,7 @@ export class BareReviewsController extends React.Component {
     }
   }
 
-  addSingleComment = async (commentBody, threadID, replyToID, path, position, callbacks = {}) => {
+  addSingleComment = async (commentBody, threadID, replyToID, commentPath, position, callbacks = {}) => {
     let pendingReviewID = null;
     try {
       this.setState({postingToThreadID: threadID});
@@ -307,7 +307,7 @@ export class BareReviewsController extends React.Component {
         reviewID,
         threadID,
         viewerID: this.props.viewer.id,
-        path,
+        path: commentPath,
         position,
       });
       if (callbacks.didSubmitComment) {

--- a/test/controllers/reviews-controller.test.js
+++ b/test/controllers/reviews-controller.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
+import path from 'path';
 
 import {BareReviewsController} from '../../lib/controllers/reviews-controller';
 import PullRequestCheckoutController from '../../lib/controllers/pr-checkout-controller';
@@ -758,7 +759,7 @@ describe('ReviewsController', function() {
     it('opens file on disk', async function() {
       await wrapper.find(ReviewsView).prop('openFile')('filepath', 420);
       assert.isTrue(atomEnv.workspace.open.calledWith(
-        'filepath', {
+        path.join(localRepository.getWorkingDirectoryPath(), 'filepath'), {
           initialLine: 420 - 1,
           initialColumn: 0,
           pending: true,


### PR DESCRIPTION
@smashwilson @lkashef @darangi 

Fixes #2330 

This was *possibly* overlooked during project management #2308, but now jumping to files uses an absolute path rather than a relative. This may have worked before because github's active context (chosen by active pane) and atom were probably assuming the same directory.

- [x] update tests