### PR TITLE
Add Switch to Active Pane Working Directory Shortcut

### DIFF
--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -31,7 +31,7 @@ import GitTimingsView from '../views/git-timings-view';
 import Conflict from '../models/conflicts/conflict';
 import {getEndpoint} from '../models/endpoint';
 import Switchboard from '../switchboard';
-import {WorkdirContextPoolPropType} from '../prop-types';
+import {WorkdirContextPoolPropType, WorkdirCachePropType} from '../prop-types';
 import {destroyFilePatchPaneItems, destroyEmptyFilePatchPaneItems, autobind} from '../helpers';
 import {GitError} from '../git-shell-out-strategy';
 import {incrementCounter, addEvent} from '../reporter-proxy';
@@ -54,6 +54,7 @@ export default class RootController extends React.Component {
     // Models
     loginModel: PropTypes.object.isRequired,
     workdirContextPool: WorkdirContextPoolPropType.isRequired,
+    workdirCache: WorkdirCachePropType.isRequired,
     repository: PropTypes.object.isRequired,
     resolutionProgress: PropTypes.object.isRequired,
     statusBar: PropTypes.object,
@@ -163,6 +164,10 @@ export default class RootController extends React.Component {
           <Command
             command="github:view-staged-changes-for-current-file"
             callback={this.viewStagedChangesForCurrentFile}
+          />
+          <Command
+            command="github:select-active-pane-directory"
+            callback={this.selectActivePaneWorkDir}
           />
           <Command
             command="github:close-all-diff-views"
@@ -660,6 +665,47 @@ export default class RootController extends React.Component {
   toggleCommitPreviewItem = () => {
     const workdir = this.props.repository.getWorkingDirectoryPath();
     return this.props.workspace.toggle(CommitPreviewItem.buildURI(workdir));
+  }
+
+  selectActivePaneWorkDir = async () => {
+    const paneItem = this.props.workspace.getCenter().getActivePaneItem();
+
+    let itemPath = null;
+
+    // Likely GitHub package provided pane item
+    if (typeof paneItem.getWorkingDirectory === 'function') {
+      itemPath = path.normalize(paneItem.getWorkingDirectory());
+    }
+
+    // TextEditor-like
+    if (typeof paneItem.getPath === 'function') {
+      itemPath = path.normalize(paneItem.getPath());
+    }
+
+    // Oh well
+    if (!itemPath) {
+      return;
+    }
+
+    // Find valid git working directory
+    const workdir = await this.props.workdirCache.find(itemPath);
+
+    if (workdir) {
+      this.props.changeWorkingDirectory(workdir);
+      return;
+    }
+
+    // At this point, there is no parent git working directory
+    // But, we can still assign the current context to a valid context
+    // if the file is a child of a current working directory
+    const workdirs = this.props.workdirContextPool.getCurrentWorkDirs();
+    for (const dir of workdirs) {
+      const tokens = path.normalize(dir).split(path.sep).filter(i => i.length);
+      if (tokens.every((t, i) => itemPath.split(path.sep)[i] === t)) {
+        // is a child of
+        this.props.changeWorkingDirectory(workdir);
+      }
+    }
   }
 
   showWaterfallDiagnostics() {

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -293,6 +293,7 @@ export default class GithubPackage {
         confirm={this.confirm}
         currentWindow={this.currentWindow}
         workdirContextPool={this.contextPool}
+        workdirCache={this.workdirCache}
         loginModel={this.loginModel}
         repository={this.getActiveRepository()}
         resolutionProgress={this.getActiveResolutionProgress()}

--- a/lib/prop-types.js
+++ b/lib/prop-types.js
@@ -14,6 +14,10 @@ export const WorkdirContextPoolPropType = PropTypes.shape({
   getContext: PropTypes.func.isRequired,
 });
 
+export const WorkdirCachePropType = PropTypes.shape({
+  find: PropTypes.func.isRequired,
+});
+
 export const GithubLoginModelPropType = PropTypes.shape({
   getToken: PropTypes.func.isRequired,
   setToken: PropTypes.func.isRequired,


### PR DESCRIPTION
### Description of the Change

- Adds `github:select-active-pane-directory` command to `RootController`

This allows a shortcut for switching between projects directories without the need to interact with the UI.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
Please read #2335.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Re-introduced active pane complexities, but they are much simpler this time around and are user initiated.

### Applicable Issues

<!-- Enter any applicable Issues here -->
Fixes #2335 

### Tests

- [ ] Adds tests to command in `RootController`