### PR TITLE
Enable Avatar OnClick Actions

### DIFF
--- a/lib/containers/git-tab-container.js
+++ b/lib/containers/git-tab-container.js
@@ -5,12 +5,14 @@ import yubikiri from 'yubikiri';
 import {autobind} from '../helpers';
 import {nullCommit} from '../models/commit';
 import {nullBranch} from '../models/branch';
+import {nullAuthor} from '../models/author';
 import ObserveModel from '../views/observe-model';
 import GitTabController from '../controllers/git-tab-controller';
 
 const DEFAULT_REPO_DATA = {
   lastCommit: nullCommit,
   recentCommits: [],
+  committer: nullAuthor,
   isMerging: false,
   isRebasing: false,
   hasUndoHistory: false,
@@ -38,6 +40,7 @@ export default class GitTabContainer extends React.Component {
     return yubikiri({
       lastCommit: repository.getLastCommit(),
       recentCommits: repository.getRecentCommits({max: 10}),
+      committer: repository.getCommitter(),
       isMerging: repository.isMerging(),
       isRebasing: repository.isRebasing(),
       hasUndoHistory: repository.hasDiscardHistory(),

--- a/lib/containers/github-tab-header-container.js
+++ b/lib/containers/github-tab-header-container.js
@@ -20,8 +20,9 @@ export default class GithubTabHeaderContainer extends React.Component {
     getCurrentWorkDirs: PropTypes.func.isRequired,
 
     // Event Handlers
-    handleWorkDirSelect: PropTypes.func,
-    onDidChangeWorkDirs: PropTypes.func,
+    handleWorkDirSelect: PropTypes.func.isRequired,
+    onDidChangeWorkDirs: PropTypes.func.isRequired,
+    onDidClickAvatar: PropTypes.func.isRequired,
   }
 
   render() {
@@ -83,6 +84,7 @@ export default class GithubTabHeaderContainer extends React.Component {
         // Event Handlers
         handleWorkDirSelect={this.props.handleWorkDirSelect}
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
+        onDidClickAvatar={this.props.onDidClickAvatar}
       />
     );
   }
@@ -99,6 +101,7 @@ export default class GithubTabHeaderContainer extends React.Component {
         // Event Handlers
         handleWorkDirSelect={this.props.handleWorkDirSelect}
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
+        onDidClickAvatar={() => {}}
       />
     );
   }

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -75,6 +75,7 @@ export default class GitTabController extends React.Component {
 
     this.state = {
       selectedCoAuthors: [],
+      showIntroduction: false,
     };
 
     this.userStore = new UserStore({
@@ -93,6 +94,7 @@ export default class GitTabController extends React.Component {
 
         isLoading={this.props.fetchInProgress}
         repository={this.props.repository}
+        showIntroduction={this.state.showIntroduction}
 
         lastCommit={this.props.lastCommit}
         recentCommits={this.props.recentCommits}
@@ -127,6 +129,8 @@ export default class GitTabController extends React.Component {
         changeWorkingDirectory={this.props.changeWorkingDirectory}
         getCurrentWorkDirs={this.props.getCurrentWorkDirs}
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
+        onDidClickAvatar={() => this.setState({showIntroduction: true})}
+        onDidCancelIntroduction={() => this.setState({showIntroduction: false})}
 
         attemptFileStageOperation={this.attemptFileStageOperation}
         attemptStageAllOperation={this.attemptStageAllOperation}

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -7,7 +7,7 @@ import GitTabView from '../views/git-tab-view';
 import UserStore from '../models/user-store';
 import RefHolder from '../models/ref-holder';
 import {
-  CommitPropType, BranchPropType, FilePatchItemPropType, MergeConflictItemPropType, RefHolderPropType,
+  AuthorPropType, CommitPropType, BranchPropType, FilePatchItemPropType, MergeConflictItemPropType, RefHolderPropType,
 } from '../prop-types';
 import {autobind} from '../helpers';
 
@@ -22,6 +22,7 @@ export default class GitTabController extends React.Component {
 
     lastCommit: CommitPropType.isRequired,
     recentCommits: PropTypes.arrayOf(CommitPropType).isRequired,
+    committer: AuthorPropType.isRequired,
     isMerging: PropTypes.bool.isRequired,
     isRebasing: PropTypes.bool.isRequired,
     hasUndoHistory: PropTypes.bool.isRequired,
@@ -95,6 +96,7 @@ export default class GitTabController extends React.Component {
 
         lastCommit={this.props.lastCommit}
         recentCommits={this.props.recentCommits}
+        committer={this.props.committer}
         isMerging={this.props.isMerging}
         isRebasing={this.props.isRebasing}
         hasUndoHistory={this.props.hasUndoHistory}

--- a/lib/controllers/git-tab-header-controller.js
+++ b/lib/controllers/git-tab-header-controller.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {CompositeDisposable} from 'atom';
-import {nullAuthor} from '../models/author';
+import {AuthorPropType} from '../prop-types';
 import GitTabHeaderView from '../views/git-tab-header-view';
 
 export default class GitTabHeaderController extends React.Component {
   static propTypes = {
-    getCommitter: PropTypes.func.isRequired,
+    committer: AuthorPropType.isRequired,
 
     // Workspace
     currentWorkDir: PropTypes.string,
@@ -15,14 +15,11 @@ export default class GitTabHeaderController extends React.Component {
     // Event Handlers
     handleWorkDirSelect: PropTypes.func.isRequired,
     onDidChangeWorkDirs: PropTypes.func.isRequired,
-    onDidUpdateRepo: PropTypes.func.isRequired,
   }
 
   constructor(props) {
     super(props);
-    this._isMounted = false;
-    this.state = {currentWorkDirs: [], committer: nullAuthor};
-    this.disposable = new CompositeDisposable();
+    this.state = {currentWorkDirs: []};
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -32,31 +29,20 @@ export default class GitTabHeaderController extends React.Component {
   }
 
   componentDidMount() {
-    this._isMounted = true;
-    this.disposable.add(this.props.onDidChangeWorkDirs(this.resetWorkDirs));
-    this.disposable.add(this.props.onDidUpdateRepo(this.updateCommitter));
-    this.updateCommitter();
+    this.disposable = this.props.onDidChangeWorkDirs(this.resetWorkDirs);
   }
 
   componentDidUpdate(prevProps) {
-    if (
-      prevProps.onDidChangeWorkDirs !== this.props.onDidChangeWorkDirs
-      || prevProps.onDidUpdateRepo !== this.props.onDidUpdateRepo
-    ) {
+    if (prevProps.onDidChangeWorkDirs !== this.props.onDidChangeWorkDirs) {
       this.disposable.dispose();
-      this.disposable = new CompositeDisposable();
-      this.disposable.add(this.props.onDidChangeWorkDirs(this.resetWorkDirs));
-      this.disposable.add(this.props.onDidUpdateRepo(this.updateCommitter));
-    }
-    if (prevProps.getCommitter !== this.props.getCommitter) {
-      this.updateCommitter();
+      this.disposable = this.props.onDidChangeWorkDirs(this.resetWorkDirs);
     }
   }
 
   render() {
     return (
       <GitTabHeaderView
-        committer={this.state.committer}
+        committer={this.props.committer}
 
         // Workspace
         workdir={this.props.currentWorkDir}
@@ -74,15 +60,7 @@ export default class GitTabHeaderController extends React.Component {
     }));
   }
 
-  updateCommitter = async () => {
-    const committer = await this.props.getCommitter() || nullAuthor;
-    if (this._isMounted) {
-      this.setState({committer});
-    }
-  }
-
   componentWillUnmount() {
-    this._isMounted = false;
     this.disposable.dispose();
   }
 }

--- a/lib/controllers/git-tab-header-controller.js
+++ b/lib/controllers/git-tab-header-controller.js
@@ -15,6 +15,7 @@ export default class GitTabHeaderController extends React.Component {
     // Event Handlers
     handleWorkDirSelect: PropTypes.func.isRequired,
     onDidChangeWorkDirs: PropTypes.func.isRequired,
+    onDidClickAvatar: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -50,6 +51,7 @@ export default class GitTabHeaderController extends React.Component {
 
         // Event Handlers
         handleWorkDirSelect={this.props.handleWorkDirSelect}
+        onDidClickAvatar={this.props.onDidClickAvatar}
       />
     );
   }

--- a/lib/controllers/github-tab-controller.js
+++ b/lib/controllers/github-tab-controller.js
@@ -32,6 +32,13 @@ export default class GitHubTabController extends React.Component {
     openGitTab: PropTypes.func.isRequired,
   }
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      showLogin: false,
+    }
+  }
+
   render() {
     const gitHubRemotes = this.props.allRemotes.filter(remote => remote.isGithubRepo());
     const currentBranch = this.props.branches.getHeadBranch();
@@ -48,6 +55,7 @@ export default class GitHubTabController extends React.Component {
       <GitHubTabView
         // Connection
         loginModel={this.props.loginModel}
+        showLogin={this.state.showLogin}
 
         workspace={this.props.workspace}
         refresher={this.props.refresher}
@@ -73,6 +81,8 @@ export default class GitHubTabController extends React.Component {
         openBoundPublishDialog={this.openBoundPublishDialog}
         openCloneDialog={this.props.openCloneDialog}
         openGitTab={this.props.openGitTab}
+        onDidClickAvatar={() => this.setState({showLogin: true})}
+        onCancelLogin={() => this.setState({showLogin: false})}
       />
     );
   }

--- a/lib/controllers/github-tab-header-controller.js
+++ b/lib/controllers/github-tab-header-controller.js
@@ -14,6 +14,7 @@ export default class GithubTabHeaderController extends React.Component {
     // Event Handlers
     handleWorkDirSelect: PropTypes.func.isRequired,
     onDidChangeWorkDirs: PropTypes.func.isRequired,
+    onDidClickAvatar: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -51,6 +52,8 @@ export default class GithubTabHeaderController extends React.Component {
 
         // Event Handlers
         handleWorkDirSelect={this.props.handleWorkDirSelect}
+        onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
+        onDidClickAvatar={this.props.onDidClickAvatar}
       />
     );
   }

--- a/lib/views/git-introduction-view.js
+++ b/lib/views/git-introduction-view.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {AuthorPropType} from '../prop-types';
+
+import Author from '../models/author';
+import Commands, {Command} from '../atom/commands';
+
+export default class GitIntroductionView extends React.Component {
+  static propTypes = {
+    commands: PropTypes.object.isRequired,
+    identity: AuthorPropType.isRequired,
+    onSave: PropTypes.func.isRequired,
+    onCancel: PropTypes.func,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      name: '',
+      email: '',
+      saveDisabled: true,
+    };
+  }
+
+  render() {
+    return (
+      <div className='git-Introduction native-key-bindings'>
+        <Commands registry={this.props.commands} target=".github-Introduction">
+          <Command command="core:cancel" callback={this.cancel} />
+          <Command command="core:confirm" callback={this.confirm} />
+        </Commands>
+        <h1 className='git-Introduction-heading'>Your Current Identity</h1>
+        {this.renderIndentity()}
+        <p className='git-Introduction-context'>Add your name and email that will be used to identify your commits.</p>
+        <div className='git-Introduction-options'>
+          <input
+            type="text"
+            placeholder={this.props.identity.getFullName()}
+            ref={e => (this.nameInput = e)}
+            className="input-text github-Introduction-input"
+            value={this.state.name}
+            onChange={this.onNameChange}
+            tabIndex="1"
+          />
+          <input
+            type="email"
+            placeholder={this.props.identity.getEmail()}
+            ref={e => (this.emailInput = e)}
+            className="input-text github-Introduction-input"
+            value={this.state.email}
+            onChange={this.onEmailChange}
+            tabIndex="2"
+          />
+          <button className="btn btn-primary" disabled={this.state.saveDisabled} tabIndex="3" onClick={this.confirm}>
+            Save
+          </button>
+          <button className="btn github-CancelButton" tabIndex="4" onClick={this.cancel}>Cancel</button>
+        </div>
+        <p className='git-Introduction-explanation'>
+          This will only modify/overwrite your local (repository)&nbsp;
+          <span className='git-Introduction-keyword'>user.name</span> and&nbsp;
+          <span className='git-Introduction-keyword'>user.email</span>.
+        </p>
+      </div>
+    );
+  }
+
+  renderIndentity() {
+    return null;
+  }
+
+  confirm = () => {
+    if (this.isInputValid()) {
+      this.props.onSave(
+        new Author(
+          this.state.email || this.props.identity.getEmail(),
+          this.state.name || this.props.identity.getFullName()
+        )
+      );
+    }
+  }
+
+  cancel = () => {
+    this.props.onCancel();
+  }
+
+  onNameChange = e => {
+    this.setState({name: e.target.value}, this.validate);
+  }
+
+  onEmailChange = e => {
+    this.setState({email: e.target.value}, this.validate);
+  }
+
+  validate = () => {
+    this.setState({saveDisabled: !this.isInputValid()});
+  }
+
+  isInputValid = () => {
+    // email validation with regex has a LOT of corner cases, dawg.
+    // https://stackoverflow.com/questions/48055431/can-it-cause-harm-to-validate-email-addresses-with-a-regex
+    // to avoid bugs for users with nonstandard email addresses,
+    // just check to make sure email address contains `@` and move on with our lives.
+    return !!(
+      (this.state.name || this.state.email.includes('@'))
+      && (this.state.name || this.props.identity.getFullName())
+      && (this.state.email.includes('@') || this.props.identity.getEmail())
+    );
+  }
+}

--- a/lib/views/git-introduction-view.js
+++ b/lib/views/git-introduction-view.js
@@ -30,15 +30,14 @@ export default class GitIntroductionView extends React.Component {
           <Command command="core:cancel" callback={this.cancel} />
           <Command command="core:confirm" callback={this.confirm} />
         </Commands>
-        <h1 className='git-Introduction-heading'>Your Current Identity</h1>
         {this.renderIndentity()}
-        <p className='git-Introduction-context'>Add your name and email that will be used to identify your commits.</p>
         <div className='git-Introduction-options'>
+          <p className='git-Introduction-context'>Add your name and email that will be used to identify your commits.</p>
           <input
             type="text"
             placeholder={this.props.identity.getFullName()}
             ref={e => (this.nameInput = e)}
-            className="input-text github-Introduction-input"
+            className="input-text git-Introduction-input"
             value={this.state.name}
             onChange={this.onNameChange}
             tabIndex="1"
@@ -47,15 +46,17 @@ export default class GitIntroductionView extends React.Component {
             type="email"
             placeholder={this.props.identity.getEmail()}
             ref={e => (this.emailInput = e)}
-            className="input-text github-Introduction-input"
+            className="input-text git-Introduction-input"
             value={this.state.email}
             onChange={this.onEmailChange}
             tabIndex="2"
           />
-          <button className="btn btn-primary" disabled={this.state.saveDisabled} tabIndex="3" onClick={this.confirm}>
-            Save
-          </button>
-          <button className="btn github-CancelButton" tabIndex="4" onClick={this.cancel}>Cancel</button>
+          <div className='git-Introduction-row'>
+            <button className="btn btn-primary" disabled={this.state.saveDisabled} tabIndex="3" onClick={this.confirm}>
+              Save
+            </button>
+            <button className="btn" tabIndex="4" onClick={this.cancel}>Cancel</button>
+          </div>
         </div>
         <p className='git-Introduction-explanation'>
           This will only modify/overwrite your local (repository)&nbsp;
@@ -67,7 +68,14 @@ export default class GitIntroductionView extends React.Component {
   }
 
   renderIndentity() {
-    return null;
+    return (
+      <div className='git-Introduction-header'>
+        <h1 className='git-Introduction-heading'>Your Current Identity</h1>
+        <img className='git-Introduction-avatar' src={this.props.identity.getAvatarUrl() || 'atom://github/img/avatar.svg'} />
+        <h3 className='git-Introduction-name'>{this.props.identity.getFullName()}</h3>
+        <h3 className='git-Introduction-email'>{this.props.identity.getEmail()}</h3>
+      </div>
+    );
   }
 
   confirm = () => {

--- a/lib/views/git-introduction-view.js
+++ b/lib/views/git-introduction-view.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {AuthorPropType} from '../prop-types';
 
+import RefHolder from '../models/ref-holder';
+
 import Author from '../models/author';
 import Commands, {Command} from '../atom/commands';
 
@@ -16,6 +18,8 @@ export default class GitIntroductionView extends React.Component {
   constructor(props) {
     super(props);
 
+    this.refRoot = new RefHolder();
+
     this.state = {
       name: '',
       email: '',
@@ -25,8 +29,8 @@ export default class GitIntroductionView extends React.Component {
 
   render() {
     return (
-      <div className='git-Introduction native-key-bindings'>
-        <Commands registry={this.props.commands} target=".github-Introduction">
+      <div className='git-Introduction native-key-bindings' ref={this.refRoot.setter}>
+        <Commands registry={this.props.commands} target={this.refRoot}>
           <Command command="core:cancel" callback={this.cancel} />
           <Command command="core:confirm" callback={this.confirm} />
         </Commands>

--- a/lib/views/git-tab-header-view.js
+++ b/lib/views/git-tab-header-view.js
@@ -12,7 +12,7 @@ export default class GitTabHeaderView extends React.Component {
     workdirs: PropTypes.shape({[Symbol.iterator]: PropTypes.func.isRequired}).isRequired,
 
     // Event Handlers
-    handleWorkDirSelect: PropTypes.func,
+    handleWorkDirSelect: PropTypes.func.isRequired,
   }
 
   render() {
@@ -21,7 +21,7 @@ export default class GitTabHeaderView extends React.Component {
         {this.renderCommitter()}
         <select className="github-Project-path input-select"
           value={this.props.workdir ? path.normalize(this.props.workdir) : undefined}
-          onChange={this.props.handleWorkDirSelect ? this.props.handleWorkDirSelect : () => {}}>
+          onChange={this.props.handleWorkDirSelect}>
           {this.renderWorkDirs()}
         </select>
       </header>

--- a/lib/views/git-tab-header-view.js
+++ b/lib/views/git-tab-header-view.js
@@ -13,6 +13,7 @@ export default class GitTabHeaderView extends React.Component {
 
     // Event Handlers
     handleWorkDirSelect: PropTypes.func.isRequired,
+    onDidClickAvatar: PropTypes.func.isRequired,
   }
 
   render() {
@@ -46,6 +47,7 @@ export default class GitTabHeaderView extends React.Component {
         src={avatarUrl || 'atom://github/img/avatar.svg'}
         title={`${name} ${email}`}
         alt={`${name}'s avatar`}
+        onClick={this.props.onDidClickAvatar}
       />
     );
   }

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -27,6 +27,7 @@ export default class GitTabView extends React.Component {
 
     lastCommit: PropTypes.object.isRequired,
     currentBranch: PropTypes.object,
+    committer: AuthorPropType,
     recentCommits: PropTypes.arrayOf(PropTypes.object).isRequired,
     isMerging: PropTypes.bool,
     isRebasing: PropTypes.bool,
@@ -121,7 +122,7 @@ export default class GitTabView extends React.Component {
     const {repository} = this.props;
     return (
       <GitTabHeaderController
-        getCommitter={repository.getCommitter.bind(repository)}
+        committer={this.props.committer}
 
         // Workspace
         currentWorkDir={this.props.workingDirectoryPath}
@@ -129,7 +130,6 @@ export default class GitTabView extends React.Component {
 
         // Event Handlers
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
-        onDidUpdateRepo={repository.onDidUpdate.bind(repository)}
         handleWorkDirSelect={e => this.props.changeWorkingDirectory(e.target.value)}
       />
     );

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -118,13 +118,13 @@ export default class GitTabView extends React.Component {
         className={cx('github-Git', {'is-empty': isEmpty, 'is-loading': !isEmpty && isLoading})}
         tabIndex="-1"
         ref={this.props.refRoot.setter}>
-        {this.renderHeader()}
+        {this.renderHeader(isEmpty || isLoading)}
         {this[renderMethod]()}
       </div>
     );
   }
 
-  renderHeader() {
+  renderHeader(disableOnDidClickAvatar) {
     const {repository} = this.props;
     return (
       <GitTabHeaderController
@@ -136,7 +136,7 @@ export default class GitTabView extends React.Component {
 
         // Event Handlers
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
-        onDidClickAvatar={this.props.onDidClickAvatar}
+        onDidClickAvatar={disableOnDidClickAvatar ? () => {} : this.props.onDidClickAvatar}
         handleWorkDirSelect={e => this.props.changeWorkingDirectory(e.target.value)}
       />
     );

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -147,7 +147,11 @@ export default class GitTabView extends React.Component {
       <GitIntroductionView
         commands={this.props.commands}
         identity={this.props.committer}
-        onSave={()=>{}}
+        onSave={newIdentity => {
+          this.props.repository.setConfig('user.name', newIdentity.getFullName());
+          this.props.repository.setConfig('user.email', newIdentity.getEmail());
+          this.props.onDidCancelIntroduction();
+        }}
         onCancel={this.props.onDidCancelIntroduction}
       />
     );

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -7,6 +7,7 @@ import StagingView from './staging-view';
 import GitTabHeaderController from '../controllers/git-tab-header-controller';
 import CommitController from '../controllers/commit-controller';
 import RecentCommitsController from '../controllers/recent-commits-controller';
+import GitIntroductionView from './git-introduction-view';
 import RefHolder from '../models/ref-holder';
 import {isValidWorkdir, autobind} from '../helpers';
 import {AuthorPropType, UserStorePropType, RefHolderPropType} from '../prop-types';
@@ -24,6 +25,7 @@ export default class GitTabView extends React.Component {
 
     repository: PropTypes.object.isRequired,
     isLoading: PropTypes.bool.isRequired,
+    showIntroduction: PropTypes.bool.isRequired,
 
     lastCommit: PropTypes.object.isRequired,
     currentBranch: PropTypes.object,
@@ -65,6 +67,8 @@ export default class GitTabView extends React.Component {
     changeWorkingDirectory: PropTypes.func.isRequired,
     onDidChangeWorkDirs: PropTypes.func.isRequired,
     getCurrentWorkDirs: PropTypes.func.isRequired,
+    onDidClickAvatar: PropTypes.func.isRequired,
+    onDidCancelIntroduction: PropTypes.func.isRequired,
   };
 
   constructor(props, context) {
@@ -105,6 +109,8 @@ export default class GitTabView extends React.Component {
       isEmpty = true;
     } else if (this.props.isLoading || this.props.repository.showGitTabLoading()) {
       isLoading = true;
+    } else if (this.props.showIntroduction || !this.props.committer.isPresent()) {
+      renderMethod = 'renderIntroduction';
     }
 
     return (
@@ -130,7 +136,19 @@ export default class GitTabView extends React.Component {
 
         // Event Handlers
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
+        onDidClickAvatar={this.props.onDidClickAvatar}
         handleWorkDirSelect={e => this.props.changeWorkingDirectory(e.target.value)}
+      />
+    );
+  }
+
+  renderIntroduction() {
+    return (
+      <GitIntroductionView
+        commands={this.props.commands}
+        identity={this.props.committer}
+        onSave={()=>{}}
+        onCancel={this.props.onDidCancelIntroduction}
       />
     );
   }

--- a/lib/views/github-login-view.js
+++ b/lib/views/github-login-view.js
@@ -7,6 +7,7 @@ export default class GithubLoginView extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     onLogin: PropTypes.func,
+    onCancel: PropTypes.func,
   }
 
   static defaultProps = {
@@ -53,6 +54,13 @@ export default class GithubLoginView extends React.Component {
         <button onClick={this.handleLoginClick} className="btn btn-primary icon icon-octoface">
           Login
         </button>
+        {
+          typeof this.props.onCancel === 'function' ? (
+            <button onClick={this.props.onCancel} className="btn">
+              Cancel
+            </button>
+          ) : null
+        }
       </div>
     );
   }
@@ -77,14 +85,16 @@ export default class GithubLoginView extends React.Component {
         />
         <ul>
           <li>
-            <button type="button" onClick={this.handleCancelTokenClick} className="btn icon icon-remove-close">
-              Cancel
+            <button
+              type="submit"
+              onClick={this.handleSubmitTokenClick}
+              className="btn btn-primary icon icon-check">
+              Login
             </button>
           </li>
           <li>
-            <button
-              type="submit" onClick={this.handleSubmitTokenClick} className="btn btn-primary icon icon-check">
-                Login
+            <button type="button" onClick={this.handleCancelTokenClick} className="btn icon icon-remove-close">
+              Cancel
             </button>
           </li>
         </ul>

--- a/lib/views/github-tab-header-view.js
+++ b/lib/views/github-tab-header-view.js
@@ -12,7 +12,8 @@ export default class GithubTabHeaderView extends React.Component {
     workdirs: PropTypes.shape({[Symbol.iterator]: PropTypes.func.isRequired}).isRequired,
 
     // Event Handlers
-    handleWorkDirSelect: PropTypes.func,
+    handleWorkDirSelect: PropTypes.func.isRequired,
+    onDidClickAvatar: PropTypes.func.isRequired,
   }
 
   render() {
@@ -21,7 +22,7 @@ export default class GithubTabHeaderView extends React.Component {
         {this.renderUser()}
         <select className="github-Project-path input-select"
           value={this.props.workdir ? path.normalize(this.props.workdir) : undefined}
-          onChange={this.props.handleWorkDirSelect ? this.props.handleWorkDirSelect : () => {}}>
+          onChange={this.props.handleWorkDirSelect}>
           {this.renderWorkDirs()}
         </select>
       </header>
@@ -45,6 +46,7 @@ export default class GithubTabHeaderView extends React.Component {
         src={avatarUrl || 'atom://github/img/avatar.svg'}
         title={`@${login}`}
         alt={`@${login}'s avatar`}
+        onClick={this.props.onDidClickAvatar}
       />
     );
   }

--- a/lib/views/github-tab-view.js
+++ b/lib/views/github-tab-view.js
@@ -7,6 +7,7 @@ import {
 } from '../prop-types';
 import LoadingView from './loading-view';
 import RemoteSelectorView from './remote-selector-view';
+import GithubLoginView from './github-login-view';
 import GithubTabHeaderContainer from '../containers/github-tab-header-container';
 import GithubTabHeaderController from '../controllers/github-tab-header-controller';
 import GitHubBlankNoLocal from './github-blank-nolocal';
@@ -49,6 +50,8 @@ export default class GitHubTabView extends React.Component {
     openBoundPublishDialog: PropTypes.func.isRequired,
     openCloneDialog: PropTypes.func.isRequired,
     openGitTab: PropTypes.func.isRequired,
+    onDidClickAvatar: PropTypes.func.isRequired,
+    onCancelLogin: PropTypes.func.isRequired,
   }
 
   render() {
@@ -82,6 +85,14 @@ export default class GitHubTabView extends React.Component {
           openBoundPublishDialog={this.props.openBoundPublishDialog}
           openGitTab={this.props.openGitTab}
         />
+      );
+    }
+
+    if (this.props.showLogin) {
+      return (
+        <GithubLoginView onLogin={()=>{}} onCancel={this.props.onCancelLogin}>
+          <p>Log in to GitHub to access pull request informationand more!</p>
+        </GithubLoginView>
       );
     }
 
@@ -142,6 +153,7 @@ export default class GitHubTabView extends React.Component {
           // Event Handlers
           handleWorkDirSelect={e => this.props.changeWorkingDirectory(e.target.value)}
           onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
+          onDidClickAvatar={this.props.onDidClickAvatar}
         />
       );
     }
@@ -156,6 +168,7 @@ export default class GitHubTabView extends React.Component {
         // Event Handlers
         handleWorkDirSelect={e => this.props.changeWorkingDirectory(e.target.value)}
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
+        onDidClickAvatar={() => {}}
       />
     );
   }

--- a/styles/git-introduction.less
+++ b/styles/git-introduction.less
@@ -1,0 +1,75 @@
+@import "variables";
+
+.git-Introduction {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: @component-padding;
+
+  &-header {
+    margin-bottom: @component-padding;
+    color: @text-color-highlight;
+  }
+
+  &-heading {
+    margin: 0;
+    margin-bottom: @component-padding;
+  }
+
+  &-avatar {
+    width: 50%;
+    border-radius: @component-border-radius * 3;
+  }
+
+  &-name {
+    margin: @component-padding/2;
+  }
+
+  &-email {
+    margin: 0;
+  }
+
+  &-header, &-context, &-explanation {
+    text-align: center;
+  }
+
+  &-options {
+    display: flex;
+    flex: 2;
+    flex-direction: column;
+    align-items: center;
+    padding-left: @component-padding;
+    padding-right: @component-padding;
+  }
+
+  &-context {
+    margin-bottom: @component-padding/2;
+  }
+
+  &-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+
+    .btn {
+      flex: 2
+    }
+
+    .btn-primary {
+      flex: 5;
+      margin-right: @component-padding;
+    }
+  }
+
+  &-input {
+    margin-bottom: @component-padding/2;
+  }
+
+  &-explanation {
+    color: @text-color-subtle;
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
### Description of the Change 
Canonical Pr: #2308 

Enables users to click on the heading avatar to do different identity related actions.
- [X] add on click to git tab header
- [x] add on click to github tab header

Introduces a new view to view and modify your git identity settings.

### Screenshot/Gif
#### New `GitIntroductionView`:
![Untitled](https://user-images.githubusercontent.com/8658372/69380397-f1777200-0c77-11ea-9818-e26ba5106921.png)

### Benefits

<!-- What benefits will be realized by the code change? -->
- The ability to modify git local `user.name` and `user.email`
- The ability to change your github login status

 ### Possible Drawbacks

- Once in `GitIntroductionView` if you switch git projects, the view will just switch to that project's introduction view. IE you must explicitly close the introduction view via the cancel button.

### Tests

TBD
