### PR TITLE
Add setting to use project from active panel

### DIFF
--- a/lib/containers/git-tab-container.js
+++ b/lib/containers/git-tab-container.js
@@ -25,6 +25,7 @@ const DEFAULT_REPO_DATA = {
 
 export default class GitTabContainer extends React.Component {
   static propTypes = {
+    config: PropTypes.object.isRequired,
     repository: PropTypes.object.isRequired,
   }
 

--- a/lib/containers/github-tab-container.js
+++ b/lib/containers/github-tab-container.js
@@ -17,6 +17,7 @@ export default class GitHubTabContainer extends React.Component {
     repository: PropTypes.object,
     loginModel: GithubLoginModelPropType.isRequired,
     rootHolder: RefHolderPropType.isRequired,
+    config: PropTypes.object.isRequired,
 
     changeWorkingDirectory: PropTypes.func.isRequired,
     onDidChangeWorkDirs: PropTypes.func.isRequired,

--- a/lib/containers/github-tab-header-container.js
+++ b/lib/containers/github-tab-header-container.js
@@ -11,6 +11,8 @@ import GithubTabHeaderController from '../controllers/github-tab-header-controll
 
 export default class GithubTabHeaderContainer extends React.Component {
   static propTypes = {
+    config: PropTypes.object.isRequired,
+
     // Connection
     loginModel: PropTypes.object.isRequired,
     endpoint: EndpointPropType.isRequired,
@@ -74,6 +76,7 @@ export default class GithubTabHeaderContainer extends React.Component {
 
     return (
       <GithubTabHeaderController
+        config={this.props.config}
         user={new Author(email, name, login, false, avatarUrl)}
 
         // Workspace
@@ -90,6 +93,7 @@ export default class GithubTabHeaderContainer extends React.Component {
   renderNoResult() {
     return (
       <GithubTabHeaderController
+        config={this.props.config}
         user={nullAuthor}
 
         // Workspace

--- a/lib/controllers/git-tab-header-controller.js
+++ b/lib/controllers/git-tab-header-controller.js
@@ -6,6 +6,7 @@ import GitTabHeaderView from '../views/git-tab-header-view';
 
 export default class GitTabHeaderController extends React.Component {
   static propTypes = {
+    config: PropTypes.object.isRequired,
     getCommitter: PropTypes.func.isRequired,
 
     // Workspace
@@ -21,7 +22,11 @@ export default class GitTabHeaderController extends React.Component {
   constructor(props) {
     super(props);
     this._isMounted = false;
-    this.state = {currentWorkDirs: [], committer: nullAuthor};
+    this.state = {
+      currentWorkDirs: [],
+      committer: nullAuthor,
+      disableProjectSelection: this.props.config.get('github.useProjectFromActivePanel'),
+    };
     this.disposable = new CompositeDisposable();
   }
 
@@ -33,8 +38,11 @@ export default class GitTabHeaderController extends React.Component {
 
   componentDidMount() {
     this._isMounted = true;
-    this.disposable.add(this.props.onDidChangeWorkDirs(this.resetWorkDirs));
-    this.disposable.add(this.props.onDidUpdateRepo(this.updateCommitter));
+    this.disposable.add(
+      this.props.onDidChangeWorkDirs(this.resetWorkDirs),
+      this.props.onDidUpdateRepo(this.updateCommitter),
+      this.props.config.onDidChange('github.useProjectFromActivePanel', this.handleUseProjectFromActivePanelChange),
+    );
     this.updateCommitter();
   }
 
@@ -45,8 +53,11 @@ export default class GitTabHeaderController extends React.Component {
     ) {
       this.disposable.dispose();
       this.disposable = new CompositeDisposable();
-      this.disposable.add(this.props.onDidChangeWorkDirs(this.resetWorkDirs));
-      this.disposable.add(this.props.onDidUpdateRepo(this.updateCommitter));
+      this.disposable.add(
+        this.props.onDidChangeWorkDirs(this.resetWorkDirs),
+        this.props.onDidUpdateRepo(this.updateCommitter),
+        this.props.config.onDidChange('github.useProjectFromActivePanel', this.handleUseProjectFromActivePanelChange),
+      );
     }
     if (prevProps.getCommitter !== this.props.getCommitter) {
       this.updateCommitter();
@@ -56,6 +67,7 @@ export default class GitTabHeaderController extends React.Component {
   render() {
     return (
       <GitTabHeaderView
+        disableProjectSelection={this.state.disableProjectSelection}
         committer={this.state.committer}
 
         // Workspace
@@ -72,6 +84,10 @@ export default class GitTabHeaderController extends React.Component {
     this.setState((state, props) => ({
       currentWorkDirs: [],
     }));
+  }
+
+  handleUseProjectFromActivePanelChange = ({newValue}) => {
+    this.setState({disableProjectSelection: newValue});
   }
 
   updateCommitter = async () => {

--- a/lib/controllers/github-tab-controller.js
+++ b/lib/controllers/github-tab-controller.js
@@ -12,6 +12,7 @@ export default class GitHubTabController extends React.Component {
     refresher: RefresherPropType.isRequired,
     loginModel: GithubLoginModelPropType.isRequired,
     rootHolder: RefHolderPropType.isRequired,
+    config: PropTypes.object.isRequired,
 
     workingDirectory: PropTypes.string,
     repository: PropTypes.object.isRequired,
@@ -52,6 +53,7 @@ export default class GitHubTabController extends React.Component {
         workspace={this.props.workspace}
         refresher={this.props.refresher}
         rootHolder={this.props.rootHolder}
+        config={this.props.config}
 
         workingDirectory={this.props.workingDirectory || this.props.currentWorkDir}
         repository={this.props.repository}

--- a/lib/controllers/github-tab-header-controller.js
+++ b/lib/controllers/github-tab-header-controller.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {AuthorPropType} from '../prop-types';
+import {CompositeDisposable} from 'atom';
 import GithubTabHeaderView from '../views/github-tab-header-view';
 
 export default class GithubTabHeaderController extends React.Component {
   static propTypes = {
+    config: PropTypes.object.isRequired,
     user: AuthorPropType.isRequired,
 
     // Workspace
@@ -18,7 +20,11 @@ export default class GithubTabHeaderController extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {currentWorkDirs: []};
+    this.state = {
+      currentWorkDirs: [],
+      disableProjectSelection: this.props.config.get('github.useProjectFromActivePanel'),
+    };
+    this.disposable = new CompositeDisposable();
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -28,21 +34,27 @@ export default class GithubTabHeaderController extends React.Component {
   }
 
   componentDidMount() {
-    this.disposable = this.props.onDidChangeWorkDirs(this.resetWorkDirs);
+    this.disposable.add(
+      this.props.onDidChangeWorkDirs(this.resetWorkDirs),
+      this.props.config.onDidChange('github.useProjectFromActivePanel', this.handleUseProjectFromActivePanelChange),
+    );
   }
 
   componentDidUpdate(prevProps) {
     if (prevProps.onDidChangeWorkDirs !== this.props.onDidChangeWorkDirs) {
-      if (this.disposable) {
-        this.disposable.dispose();
-      }
-      this.disposable = this.props.onDidChangeWorkDirs(this.resetWorkDirs);
+      this.disposable.dispose();
+      this.disposeable = new CompositeDisposable();
+      this.disposable.add(
+        this.props.onDidChangeWorkDirs(this.resetWorkDirs),
+        this.props.config.onDidChange('github.useProjectFromActivePanel', this.handleUseProjectFromActivePanelChange),
+      );
     }
   }
 
   render() {
     return (
       <GithubTabHeaderView
+        disableProjectSelection={this.state.disableProjectSelection}
         user={this.props.user}
 
         // Workspace
@@ -53,6 +65,10 @@ export default class GithubTabHeaderController extends React.Component {
         handleWorkDirSelect={this.props.handleWorkDirSelect}
       />
     );
+  }
+
+  handleUseProjectFromActivePanelChange = ({newValue}) => {
+    this.setState({disableProjectSelection: newValue});
   }
 
   resetWorkDirs = () => {

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -308,6 +308,7 @@ export default class RootController extends React.Component {
               repository={this.props.repository}
               loginModel={this.props.loginModel}
               workspace={this.props.workspace}
+              config={this.props.config}
               currentWorkDir={this.props.currentWorkDir}
               getCurrentWorkDirs={getCurrentWorkDirs}
               onDidChangeWorkDirs={onDidChangeWorkDirs}

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -60,6 +60,7 @@ export default class GithubPackage {
     this.confirm = confirm;
     this.startOpen = false;
     this.activated = false;
+    this.projectFromActivePanel = false;
 
     const criteria = {
       projectPathCount: this.project.getPaths().length,
@@ -181,8 +182,26 @@ export default class GithubPackage {
       this.scheduleActiveContextUpdate({activeRepositoryPath});
     };
 
+    const handleActivePaneChange = item => {
+      if (!this.projectFromActivePanel || !item || !this.workspace.isTextEditor(item) || !item.getBuffer() || !item.getBuffer().getPath()) {
+        return;
+      }
+
+      const activeDirectory = this.project.getDirectories().find(directory => {
+        return directory.contains(item.getBuffer().getPath());
+      });
+      const activeRepositoryPath = activeDirectory ? activeDirectory.getPath() : undefined;
+      this.scheduleActiveContextUpdate({activeRepositoryPath}, {item});
+    };
+
+    const handleUseProjectFromActivePanelChange = newValue => {
+      this.projectFromActivePanel = newValue;
+    };
+
     this.subscriptions.add(
       this.project.onDidChangePaths(handleProjectPathsChange),
+      this.workspace.getCenter().onDidStopChangingActivePaneItem(handleActivePaneChange),
+      this.config.observe('github.useProjectFromActivePanel', handleUseProjectFromActivePanelChange),
       this.styleCalculator.startWatching(
         'github-package-styles',
         ['editor.fontSize', 'editor.fontFamily', 'editor.lineHeight', 'editor.tabLength'],

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -191,8 +191,14 @@ export default class GithubPackage {
       const activeDirectory = this.project.getDirectories().find(directory => {
         return directory.contains(item.getBuffer().getPath());
       });
-      const activeRepositoryPath = activeDirectory ? activeDirectory.getPath() : undefined;
-      this.scheduleActiveContextUpdate({activeRepositoryPath}, {item});
+
+      if (activeDirectory) {
+        this.workdirCache.find(activeDirectory.getPath()).then(activeRepositoryPath => {
+          this.scheduleActiveContextUpdate({activeRepositoryPath}, {item});
+        }).catch(e => {
+          throw e;
+        });
+      }
     };
 
     const handleUseProjectFromActivePanelChange = newValue => {

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -183,7 +183,8 @@ export default class GithubPackage {
     };
 
     const handleActivePaneChange = item => {
-      if (!this.projectFromActivePanel || !item || !this.workspace.isTextEditor(item) || !item.getBuffer() || !item.getBuffer().getPath()) {
+      if (!this.projectFromActivePanel || !item || !this.workspace.isTextEditor(item)
+        || !item.getBuffer() || !item.getBuffer().getPath()) {
         return;
       }
 

--- a/lib/items/git-tab-item.js
+++ b/lib/items/git-tab-item.js
@@ -6,6 +6,7 @@ import GitTabContainer from '../containers/git-tab-container';
 
 export default class GitTabItem extends React.Component {
   static propTypes = {
+    config: PropTypes.object.isRequired,
     repository: PropTypes.object.isRequired,
   }
 

--- a/lib/items/github-tab-item.js
+++ b/lib/items/github-tab-item.js
@@ -10,6 +10,7 @@ export default class GitHubTabItem extends React.Component {
     workspace: PropTypes.object.isRequired,
     repository: PropTypes.object,
     loginModel: GithubLoginModelPropType.isRequired,
+    config: PropTypes.object.isRequired,
 
     documentActiveElement: PropTypes.func,
 

--- a/lib/views/git-tab-header-view.js
+++ b/lib/views/git-tab-header-view.js
@@ -5,6 +5,7 @@ import {AuthorPropType} from '../prop-types';
 
 export default class GitTabHeaderView extends React.Component {
   static propTypes = {
+    disableProjectSelection: PropTypes.bool,
     committer: AuthorPropType.isRequired,
 
     // Workspace
@@ -21,7 +22,8 @@ export default class GitTabHeaderView extends React.Component {
         {this.renderCommitter()}
         <select className="github-Project-path input-select"
           value={this.props.workdir ? path.normalize(this.props.workdir) : undefined}
-          onChange={this.props.handleWorkDirSelect ? this.props.handleWorkDirSelect : () => {}}>
+          onChange={this.props.handleWorkDirSelect ? this.props.handleWorkDirSelect : () => {}}
+          disabled={this.props.disableProjectSelection}>
           {this.renderWorkDirs()}
         </select>
       </header>

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -121,6 +121,7 @@ export default class GitTabView extends React.Component {
     const {repository} = this.props;
     return (
       <GitTabHeaderController
+        config={this.props.config}
         getCommitter={repository.getCommitter.bind(repository)}
 
         // Workspace

--- a/lib/views/github-tab-header-view.js
+++ b/lib/views/github-tab-header-view.js
@@ -5,6 +5,7 @@ import {AuthorPropType} from '../prop-types';
 
 export default class GithubTabHeaderView extends React.Component {
   static propTypes = {
+    disableProjectSelection: PropTypes.bool,
     user: AuthorPropType.isRequired,
 
     // Workspace
@@ -21,7 +22,8 @@ export default class GithubTabHeaderView extends React.Component {
         {this.renderUser()}
         <select className="github-Project-path input-select"
           value={this.props.workdir ? path.normalize(this.props.workdir) : undefined}
-          onChange={this.props.handleWorkDirSelect ? this.props.handleWorkDirSelect : () => {}}>
+          onChange={this.props.handleWorkDirSelect ? this.props.handleWorkDirSelect : () => {}}
+          disabled={this.props.disableProjectSelection}>
           {this.renderWorkDirs()}
         </select>
       </header>

--- a/lib/views/github-tab-view.js
+++ b/lib/views/github-tab-view.js
@@ -19,6 +19,7 @@ export default class GitHubTabView extends React.Component {
   static propTypes = {
     refresher: RefresherPropType.isRequired,
     rootHolder: RefHolderPropType.isRequired,
+    config: PropTypes.object.isRequired,
 
     // Connection
     loginModel: GithubLoginModelPropType.isRequired,
@@ -40,7 +41,7 @@ export default class GitHubTabView extends React.Component {
     aheadCount: PropTypes.number,
     pushInProgress: PropTypes.bool.isRequired,
 
-    // Event Handelrs
+    // Event Handlers
     handleWorkDirSelect: PropTypes.func,
     handlePushBranch: PropTypes.func.isRequired,
     handleRemoteSelect: PropTypes.func.isRequired,
@@ -131,6 +132,8 @@ export default class GitHubTabView extends React.Component {
     if (this.props.currentRemote.isPresent()) {
       return (
         <GithubTabHeaderContainer
+          config={this.props.config}
+
           // Connection
           loginModel={this.props.loginModel}
           endpoint={this.props.currentRemote.getEndpoint()}
@@ -147,6 +150,7 @@ export default class GitHubTabView extends React.Component {
     }
     return (
       <GithubTabHeaderController
+        config={this.props.config}
         user={nullAuthor}
 
         // Workspace

--- a/package.json
+++ b/package.json
@@ -209,6 +209,11 @@
         "ssh"
       ],
       "description": "Transport protocol to prefer when creating a new git remote"
+    },
+    "useProjectFromActivePanel": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use active panel to determine which project to show"
     }
   },
   "deserializers": {

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -57,3 +57,7 @@
     }
   }
 }
+
+.input-select:disabled {
+  color: @text-color-subtle;
+}

--- a/test/containers/github-tab-container.test.js
+++ b/test/containers/github-tab-container.test.js
@@ -37,9 +37,10 @@ describe('GitHubTabContainer', function() {
         repository={repository}
         loginModel={new GithubLoginModel(InMemoryStrategy)}
         rootHolder={new RefHolder()}
+        config={atomEnv.config}
 
         changeWorkingDirectory={() => {}}
-        onDidChangeWorkDirs={() => {}}
+        onDidChangeWorkDirs={() => { return {dispose: () => {}}; }}
         getCurrentWorkDirs={() => []}
         openCreateDialog={() => {}}
         openPublishDialog={() => {}}

--- a/test/containers/github-tab-header-container.test.js
+++ b/test/containers/github-tab-header-container.test.js
@@ -25,6 +25,7 @@ describe('GithubTabHeaderContainer', function() {
   function buildApp(overrideProps = {}) {
     return (
       <GithubTabHeaderContainer
+        config={atomEnv.config}
         loginModel={model}
         endpoint={getEndpoint('github.com')}
         getCurrentWorkDirs={() => null}

--- a/test/controllers/git-tab-header-controller.test.js
+++ b/test/controllers/git-tab-header-controller.test.js
@@ -13,7 +13,10 @@ describe('GitTabHeaderController', function() {
   }
 
   function buildApp(overrides) {
+    const atomEnv = global.buildAtomEnvironment();
+
     const props = {
+      config: atomEnv.config,
       getCommitter: () => nullAuthor,
       getCurrentWorkDirs: () => createWorkdirs([]),
       onDidUpdateRepo: () => new Disposable(),
@@ -116,5 +119,36 @@ describe('GitTabHeaderController', function() {
     const wrapper = shallow(buildApp());
     wrapper.unmount();
     assert.strictEqual(wrapper.children().length, 0);
+  });
+
+  describe('disableProjectSelection', function() {
+    const configKey = 'github.useProjectFromActivePanel';
+
+    it('initializes from config when true', function() {
+      const atomEnv = global.buildAtomEnvironment();
+      atomEnv.config.set(configKey, true);
+      const wrapper = shallow(buildApp({config: atomEnv.config}));
+      assert.strictEqual(wrapper.state('disableProjectSelection'), true);
+    });
+
+    it('initializes from config when false', function() {
+      const atomEnv = global.buildAtomEnvironment();
+      atomEnv.config.set(configKey, false);
+      const wrapper = shallow(buildApp({config: atomEnv.config}));
+      assert.strictEqual(wrapper.state('disableProjectSelection'), false);
+    });
+
+    it('updates state when config changes', function() {
+      const atomEnv = global.buildAtomEnvironment();
+      atomEnv.config.set(configKey, true);
+      const wrapper = shallow(buildApp({config: atomEnv.config}));
+      assert.strictEqual(wrapper.state('disableProjectSelection'), true);
+
+      atomEnv.config.set(configKey, false);
+      assert.strictEqual(wrapper.state('disableProjectSelection'), false);
+
+      atomEnv.config.set(configKey, true);
+      assert.strictEqual(wrapper.state('disableProjectSelection'), true);
+    });
   });
 });

--- a/test/controllers/github-tab-controller.test.js
+++ b/test/controllers/github-tab-controller.test.js
@@ -35,6 +35,7 @@ describe('GitHubTabController', function() {
         refresher={new Refresher()}
         loginModel={new GithubLoginModel(InMemoryStrategy)}
         rootHolder={new RefHolder()}
+        config={atomEnv.config}
 
         workingDirectory={repo.getWorkingDirectoryPath()}
         repository={repo}

--- a/test/items/github-tab-item.test.js
+++ b/test/items/github-tab-item.test.js
@@ -24,6 +24,7 @@ describe('GitHubTabItem', function() {
 
   function buildApp(props = {}) {
     const workspace = props.workspace || atomEnv.workspace;
+    const config = props.config || atomEnv.config;
 
     return (
       <PaneItem workspace={workspace} uriPattern={GitHubTabItem.uriPattern}>
@@ -34,9 +35,10 @@ describe('GitHubTabItem', function() {
             workspace={workspace}
             repository={repository}
             loginModel={new GithubLoginModel(InMemoryStrategy)}
+            config={config}
 
             changeWorkingDirectory={() => {}}
-            onDidChangeWorkDirs={() => {}}
+            onDidChangeWorkDirs={() => { return {dispose: () => {}}; }}
             getCurrentWorkDirs={() => []}
             openCreateDialog={() => {}}
             openPublishDialog={() => {}}

--- a/test/views/git-tab-header-view.test.js
+++ b/test/views/git-tab-header-view.test.js
@@ -63,5 +63,21 @@ describe('GitTabHeaderView', function() {
     it('renders an avatar placeholder', function() {
       assert.strictEqual(wrapper.find('img.github-Project-avatar').prop('src'), 'atom://github/img/avatar.svg');
     });
+
+    it('renders project selection enabled', function() {
+      assert.strictEqual(wrapper.find('select.github-Project-path').prop('disabled'), undefined);
+    });
+  });
+
+  describe('with project selection disabled', function() {
+    let wrapper;
+
+    beforeEach(function() {
+      wrapper = build({disableProjectSelection: true});
+    });
+
+    it('renders project selection disabled', function() {
+      assert.strictEqual(wrapper.find('select.github-Project-path').prop('disabled'), true);
+    });
   });
 });

--- a/test/views/github-tab-header-view.test.js
+++ b/test/views/github-tab-header-view.test.js
@@ -63,5 +63,21 @@ describe('GithubTabHeaderView', function() {
     it('renders an avatar placeholder', function() {
       assert.strictEqual(wrapper.find('img.github-Project-avatar').prop('src'), 'atom://github/img/avatar.svg');
     });
+
+    it('renders project selection enabled', function() {
+      assert.strictEqual(wrapper.find('select.github-Project-path').prop('disabled'), undefined);
+    });
+  });
+
+  describe('with project selection disabled', function() {
+    let wrapper;
+
+    beforeEach(function() {
+      wrapper = build({disableProjectSelection: true});
+    });
+
+    it('renders project selection disabled', function() {
+      assert.strictEqual(wrapper.find('select.github-Project-path').prop('disabled'), true);
+    });
   });
 });

--- a/test/views/github-tab-view.test.js
+++ b/test/views/github-tab-view.test.js
@@ -35,6 +35,7 @@ describe('GitHubTabView', function() {
         refresher={new Refresher()}
         loginModel={new GithubLoginModel(InMemoryStrategy)}
         rootHolder={new RefHolder()}
+        config={atomEnv.config}
 
         workingDirectory={repo.getWorkingDirectoryPath()}
         repository={repo}


### PR DESCRIPTION
<!-- **Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.
-->

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

In https://github.com/atom/github/pull/2308 the behavior for determining the selected project changed to use the project selected from a project management dropdown instead of using the project from the currently active pane. This behavior can be useful however I also think it can be valuable to have the old behavior, specifically when switching between several projects quickly.

In this PR I implement a setting to bring back the old behavior. The setting is disabled by default (so behavior from before this PR remains the same by default).

If enabled, the project management dropdown will become disabled (the text color changes to be more subtle in the dropdown and it is no longer selectable). It will still show the active project however it will change on its own based on the current active pane with an associated project.

This setting can be toggled and will have an impact immediately (listeners for the setting changes are all configured).

### Screenshot/Gif

<!-- If the changes are visual, add a screenshot or record a Gif. This doesn't have to be updated during implementation, but after a PR is merged, a final screenshot/gif should be added. It might get used for blog posts, documentation etc. Write "N/A" if not applicable. -->

Disabled Project Dropdown: 
![image](https://user-images.githubusercontent.com/6043371/72672607-86a1a780-3a2a-11ea-8316-e2e2ef1904aa.png)

New Setting:
![image](https://user-images.githubusercontent.com/6043371/72672617-991be100-3a2a-11ea-9a62-b4b0bd6f2c3f.png)



### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I considered hiding the project selection UI entirely but I believe it is actually helpful to view the project name the git pane is showing for.

There are alternate designs being considered as a part of https://github.com/atom/github/issues/2335 but I do not think they completely solve the issue. All of the options suggest adding at least 1 step to what the previous behavior was (at the very least, running a command to switch projects). This design does not conflict with the designs considered in that issue because they both provide different levels of autonomy to power users.

### Benefits

<!-- What benefits will be realized by the code change? -->

Power users can switch project with no more effort than opening a file. I think this is a huge win for when you are working in multiple projects quickly. An example is if you say, have to update a node dependency in several projects at once and want to quickly commit the change and open a PR. 

Without this setting you would need to open the package.json file, update it, find your project in the dropdown (if you have more than a few projects it can take some effort to find the correct one), then continue to do the actions with git / github.
With this setting you need to open the package.json file, updated it and then continue to do the actions with git / github.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
It can be slightly disorienting when the selected project in git changes as you change to open files from a different project if you are not expecting it. With that said it is rare you open a file from another project unintentionally. Also if this is disabled by default you would expect this behavior since you explicitly opted in to it.

### Applicable Issues

<!-- Enter any applicable Issues here -->
There is discussion that the previous workflow (re-added in this PR as a setting) is more useful to some: https://github.com/atom/github/pull/2308#issuecomment-551173295

As mentioned above there is an issue with proposed resolutions that do not fully solve the problem: https://github.com/atom/github/issues/2335

### Metrics

<!-- What metrics are associated with this code change and what questions can they help us answer? Write "N/A" if not applicable. -->
N/A

### Tests

<!-- 

How did you verify that your change has the desired effects?
- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

What unit or integration tests were (or will be) added to help protect against future regressions? 
For manual testing, be sure to describe in detail the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and the results you observed.
If you chose not to include a specific test, please explain why. 

Write "N/A" if not applicable. 

-->

Unit tests were added to test this behavior and existing tests updated for the new pass-thru props.

### Documentation

<!-- Describe the documentation added or improved. Write "N/A" if not applicable. -->

A new setting was added with a title & description. Not sure if that is what this section is referring to about documentation though.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where the merge message did not show up in the commit message box.
- Increased the performance of rendering diffs.

-->

- Added an option to the GitHub package to restore the previous behavior of using currently active panel for determining which project to show.

