### PR TITLE
Context locking

### DIFF
--- a/img/unlock.svg
+++ b/img/unlock.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0beta2 (2b71d25, 2019-12-03)"
+   sodipodi:docname="unlock.svg"
+   id="svg58"
+   version="1.1"
+   fill="none"
+   viewBox="0 0 24 16"
+   height="16"
+   width="24">
+  <metadata
+     id="metadata64">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs62" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg58"
+     inkscape:window-maximized="0"
+     inkscape:window-y="23"
+     inkscape:window-x="2132"
+     inkscape:cy="7.047619"
+     inkscape:cx="6"
+     inkscape:zoom="24.48"
+     showgrid="false"
+     id="namedview60"
+     inkscape:window-height="924"
+     inkscape:window-width="1292"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     inkscape:document-rotation="0"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     sodipodi:nodetypes="ccccccssssssssccssccssscccccccccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path56"
+     fill="#1B1F23"
+     d="m 13.4,13 h -1 v -1 h 1 z m 6,-7 h 1 c 0.55,0 1,0.45 1,1 v 7 c 0,0.55 -0.45,1 -1,1 h -10 c -0.55,0 -1,-0.45 -1,-1 V 7 c 0,-0.55 0.45,-1 1,-1 h 1 V 4.085901 C 11.4,2.1862908 9.8780193,2.4095693 8.904902,2.4143325 8.0404588,2.4185637 6.3689542,2.1882296 6.3689542,4.085901 V 7.4918301 L 4.2521568,7.4509801 4.2930068,4.045051 C 4.3176792,1.987953 5.080245,-0.02206145 8.792353,-0.03403364 13.536238,-0.0493335 13.21,3.1688541 13.21,4.085901 V 6 h -0.01 4.41 m 2.79,1 h -9 v 7 h 9 z m -7,1 h -1 v 1 h 1 z m 0,2 h -1 v 1 h 1 z"
+     clip-rule="evenodd"
+     fill-rule="evenodd" />
+</svg>

--- a/lib/atom/octicon.js
+++ b/lib/atom/octicon.js
@@ -2,8 +2,32 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
+/* eslint-disable max-len */
+const SVG = {
+  unlock: {
+    viewBox: '0 0 24 16',
+    element: (
+      <path
+        fillRule="evenodd"
+        d="m 13.4,13 h -1 v -1 h 1 z m 6,-7 h 1 c 0.55,0 1,0.45 1,1 v 7 c 0,0.55 -0.45,1 -1,1 h -10 c -0.55,0 -1,-0.45 -1,-1 V 7 c 0,-0.55 0.45,-1 1,-1 h 1 V 4.085901 C 11.4,2.1862908 9.8780193,2.4095693 8.904902,2.4143325 8.0404588,2.4185637 6.3689542,2.1882296 6.3689542,4.085901 V 7.4918301 L 4.2521568,7.4509801 4.2930068,4.045051 C 4.3176792,1.987953 5.080245,-0.02206145 8.792353,-0.03403364 13.536238,-0.0493335 13.21,3.1688541 13.21,4.085901 V 6 h -0.01 4.41 m 2.79,1 h -9 v 7 h 9 z m -7,1 h -1 v 1 h 1 z m 0,2 h -1 v 1 h 1 z"
+      />
+    ),
+  },
+};
+/* eslint-enable max-len */
+
 export default function Octicon({icon, ...others}) {
   const classes = cx('icon', `icon-${icon}`, others.className);
+
+  const svgContent = SVG[icon];
+  if (svgContent) {
+    return (
+      <svg {...others} viewBox={svgContent.viewBox} xmlns="http://www.w3.org/2000/svg" className={classes}>
+        {svgContent.element}
+      </svg>
+    );
+  }
+
   return <span {...others} className={classes} />;
 }
 

--- a/lib/containers/github-tab-header-container.js
+++ b/lib/containers/github-tab-header-container.js
@@ -80,7 +80,10 @@ export default class GithubTabHeaderContainer extends React.Component {
 
         // Workspace
         currentWorkDir={this.props.currentWorkDir}
+        contextLocked={this.props.contextLocked}
         getCurrentWorkDirs={this.props.getCurrentWorkDirs}
+        changeWorkingDirectory={this.props.changeWorkingDirectory}
+        setContextLock={this.props.setContextLock}
 
         // Event Handlers
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}

--- a/lib/containers/github-tab-header-container.js
+++ b/lib/containers/github-tab-header-container.js
@@ -17,10 +17,12 @@ export default class GithubTabHeaderContainer extends React.Component {
 
     // Workspace
     currentWorkDir: PropTypes.string,
+    contextLocked: PropTypes.bool.isRequired,
+    changeWorkingDirectory: PropTypes.func.isRequired,
+    setContextLock: PropTypes.func.isRequired,
     getCurrentWorkDirs: PropTypes.func.isRequired,
 
     // Event Handlers
-    handleWorkDirSelect: PropTypes.func,
     onDidChangeWorkDirs: PropTypes.func,
   }
 
@@ -81,7 +83,6 @@ export default class GithubTabHeaderContainer extends React.Component {
         getCurrentWorkDirs={this.props.getCurrentWorkDirs}
 
         // Event Handlers
-        handleWorkDirSelect={this.props.handleWorkDirSelect}
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
       />
     );
@@ -94,10 +95,12 @@ export default class GithubTabHeaderContainer extends React.Component {
 
         // Workspace
         currentWorkDir={this.props.currentWorkDir}
+        contextLocked={this.props.contextLocked}
+        changeWorkingDirectory={this.props.changeWorkingDirectory}
+        setContextLock={this.props.setContextLock}
         getCurrentWorkDirs={this.props.getCurrentWorkDirs}
 
         // Event Handlers
-        handleWorkDirSelect={this.props.handleWorkDirSelect}
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
       />
     );

--- a/lib/containers/github-tab-header-container.js
+++ b/lib/containers/github-tab-header-container.js
@@ -61,12 +61,12 @@ export default class GithubTabHeaderContainer extends React.Component {
         environment={environment}
         variables={{}}
         query={query}
-        render={result => this.renderWithResult(result, token)}
+        render={result => this.renderWithResult(result)}
       />
     );
   }
 
-  renderWithResult({error, props, retry}, token) {
+  renderWithResult({error, props}) {
     if (error || props === null) {
       return this.renderNoResult();
     }

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -51,7 +51,9 @@ export default class GitTabController extends React.Component {
     openFiles: PropTypes.func.isRequired,
     openInitializeDialog: PropTypes.func.isRequired,
     controllerRef: RefHolderPropType,
+    contextLocked: PropTypes.bool.isRequired,
     changeWorkingDirectory: PropTypes.func.isRequired,
+    setContextLock: PropTypes.func.isRequired,
     onDidChangeWorkDirs: PropTypes.func.isRequired,
     getCurrentWorkDirs: PropTypes.func.isRequired,
   };
@@ -122,7 +124,9 @@ export default class GitTabController extends React.Component {
         openFiles={this.props.openFiles}
         discardWorkDirChangesForPaths={this.props.discardWorkDirChangesForPaths}
         undoLastDiscard={this.props.undoLastDiscard}
+        contextLocked={this.props.contextLocked}
         changeWorkingDirectory={this.props.changeWorkingDirectory}
+        setContextLock={this.props.setContextLock}
         getCurrentWorkDirs={this.props.getCurrentWorkDirs}
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
 

--- a/lib/controllers/git-tab-header-controller.js
+++ b/lib/controllers/git-tab-header-controller.js
@@ -87,7 +87,7 @@ export default class GitTabHeaderController extends React.Component {
     const nextLock = !this.props.contextLocked;
     try {
       this.setState({changingLock: nextLock});
-      await this.props.setContextLock(this.state.changingWorkDir || this.props.currentWorkDir, nextLock);
+      await this.props.setContextLock(this.getWorkDir(), nextLock);
     } finally {
       await new Promise(resolve => this.setState({changingLock: null}, resolve));
     }
@@ -121,7 +121,7 @@ export default class GitTabHeaderController extends React.Component {
   }
 
   getWorkDir() {
-    return this.state.changeWorkDir !== null ? this.state.changingWorkDir : this.props.currentWorkDir;
+    return this.state.changingWorkDir !== null ? this.state.changingWorkDir : this.props.currentWorkDir;
   }
 
   getLocked() {

--- a/lib/controllers/git-tab-header-controller.js
+++ b/lib/controllers/git-tab-header-controller.js
@@ -11,9 +11,11 @@ export default class GitTabHeaderController extends React.Component {
     // Workspace
     currentWorkDir: PropTypes.string,
     getCurrentWorkDirs: PropTypes.func.isRequired,
+    changeWorkingDirectory: PropTypes.func.isRequired,
+    contextLocked: PropTypes.bool.isRequired,
+    setContextLock: PropTypes.func.isRequired,
 
     // Event Handlers
-    handleWorkDirSelect: PropTypes.func.isRequired,
     onDidChangeWorkDirs: PropTypes.func.isRequired,
     onDidUpdateRepo: PropTypes.func.isRequired,
   }
@@ -21,11 +23,16 @@ export default class GitTabHeaderController extends React.Component {
   constructor(props) {
     super(props);
     this._isMounted = false;
-    this.state = {currentWorkDirs: [], committer: nullAuthor};
+    this.state = {
+      currentWorkDirs: [],
+      committer: nullAuthor,
+      changingLock: null,
+      changingWorkDir: null,
+    };
     this.disposable = new CompositeDisposable();
   }
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps(props) {
     return {
       currentWorkDirs: props.getCurrentWorkDirs(),
     };
@@ -59,17 +66,49 @@ export default class GitTabHeaderController extends React.Component {
         committer={this.state.committer}
 
         // Workspace
-        workdir={this.props.currentWorkDir}
+        workdir={this.getWorkDir()}
         workdirs={this.state.currentWorkDirs}
+        contextLocked={this.getLocked()}
+        changingWorkDir={this.state.changingWorkDir !== null}
+        changingLock={this.state.changingLock !== null}
 
         // Event Handlers
-        handleWorkDirSelect={this.props.handleWorkDirSelect}
+        handleWorkDirSelect={this.handleWorkDirSelect}
+        handleLockToggle={this.handleLockToggle}
       />
     );
   }
 
+  handleLockToggle = async () => {
+    if (this.state.changingLock !== null) {
+      return;
+    }
+
+    const nextLock = !this.props.contextLocked;
+    try {
+      this.setState({changingLock: nextLock});
+      await this.props.setContextLock(this.state.changingWorkDir || this.props.currentWorkDir, nextLock);
+    } finally {
+      await new Promise(resolve => this.setState({changingLock: null}, resolve));
+    }
+  }
+
+  handleWorkDirSelect = async e => {
+    if (this.state.changingWorkDir !== null) {
+      return;
+    }
+
+    const nextWorkDir = e.target.value;
+    try {
+      this.setState({changingWorkDir: nextWorkDir});
+      await this.props.changeWorkingDirectory(nextWorkDir);
+    } finally {
+      await new Promise(resolve => this.setState({changingWork: null}, resolve));
+    }
+  }
+
   resetWorkDirs = () => {
-    this.setState((state, props) => ({
+    this.setState(() => ({
       currentWorkDirs: [],
     }));
   }
@@ -79,6 +118,14 @@ export default class GitTabHeaderController extends React.Component {
     if (this._isMounted) {
       this.setState({committer});
     }
+  }
+
+  getWorkDir() {
+    return this.state.changeWorkDir !== null ? this.state.changingWorkDir : this.props.currentWorkDir;
+  }
+
+  getLocked() {
+    return this.state.changingLock !== null ? this.state.changingLock : this.props.contextLocked;
   }
 
   componentWillUnmount() {

--- a/lib/controllers/git-tab-header-controller.js
+++ b/lib/controllers/git-tab-header-controller.js
@@ -103,7 +103,7 @@ export default class GitTabHeaderController extends React.Component {
       this.setState({changingWorkDir: nextWorkDir});
       await this.props.changeWorkingDirectory(nextWorkDir);
     } finally {
-      await new Promise(resolve => this.setState({changingWork: null}, resolve));
+      await new Promise(resolve => this.setState({changingWorkDir: null}, resolve));
     }
   }
 

--- a/lib/controllers/github-tab-controller.js
+++ b/lib/controllers/github-tab-controller.js
@@ -24,6 +24,8 @@ export default class GitHubTabController extends React.Component {
     currentWorkDir: PropTypes.string,
 
     changeWorkingDirectory: PropTypes.func.isRequired,
+    setContextLock: PropTypes.func.isRequired,
+    contextLocked: PropTypes.bool.isRequired,
     onDidChangeWorkDirs: PropTypes.func.isRequired,
     getCurrentWorkDirs: PropTypes.func.isRequired,
     openCreateDialog: PropTypes.func.isRequired,
@@ -54,6 +56,7 @@ export default class GitHubTabController extends React.Component {
         rootHolder={this.props.rootHolder}
 
         workingDirectory={this.props.workingDirectory || this.props.currentWorkDir}
+        contextLocked={this.props.contextLocked}
         repository={this.props.repository}
         branches={this.props.branches}
         currentBranch={currentBranch}
@@ -67,6 +70,7 @@ export default class GitHubTabController extends React.Component {
         handlePushBranch={this.handlePushBranch}
         handleRemoteSelect={this.handleRemoteSelect}
         changeWorkingDirectory={this.props.changeWorkingDirectory}
+        setContextLock={this.props.setContextLock}
         getCurrentWorkDirs={this.props.getCurrentWorkDirs}
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
         openCreateDialog={this.props.openCreateDialog}

--- a/lib/controllers/github-tab-header-controller.js
+++ b/lib/controllers/github-tab-header-controller.js
@@ -9,19 +9,26 @@ export default class GithubTabHeaderController extends React.Component {
 
     // Workspace
     currentWorkDir: PropTypes.string,
+    contextLocked: PropTypes.bool.isRequired,
+    changeWorkingDirectory: PropTypes.func.isRequired,
+    setContextLock: PropTypes.func.isRequired,
     getCurrentWorkDirs: PropTypes.func.isRequired,
 
     // Event Handlers
-    handleWorkDirSelect: PropTypes.func.isRequired,
     onDidChangeWorkDirs: PropTypes.func.isRequired,
   }
 
   constructor(props) {
     super(props);
-    this.state = {currentWorkDirs: []};
+
+    this.state = {
+      currentWorkDirs: [],
+      changingLock: null,
+      changingWorkDir: null,
+    };
   }
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps(props) {
     return {
       currentWorkDirs: props.getCurrentWorkDirs(),
     };
@@ -46,19 +53,56 @@ export default class GithubTabHeaderController extends React.Component {
         user={this.props.user}
 
         // Workspace
-        workdir={this.props.currentWorkDir}
         workdirs={this.state.currentWorkDirs}
+        workdir={this.getWorkDir()}
+        contextLocked={this.getContextLocked()}
 
-        // Event Handlers
-        handleWorkDirSelect={this.props.handleWorkDirSelect}
+        handleWorkDirChange={this.handleWorkDirChange}
+        handleLockToggle={this.handleLockToggle}
       />
     );
   }
 
   resetWorkDirs = () => {
-    this.setState((state, props) => ({
+    this.setState(() => ({
       currentWorkDirs: [],
     }));
+  }
+
+  handleLockToggle = async () => {
+    if (this.state.changingLock !== null) {
+      return;
+    }
+
+    const nextLock = !this.props.contextLocked;
+    try {
+      this.setState({changingLock: nextLock});
+      await this.props.setContextLock(this.state.changingWorkDir || this.props.currentWorkDir, nextLock);
+    } finally {
+      await new Promise(resolve => this.setState({changingLock: null}, resolve));
+    }
+  }
+
+  handleWorkDirChange = async e => {
+    if (this.state.changingWorkDir !== null) {
+      return;
+    }
+
+    const nextWorkDir = e.target.value;
+    try {
+      this.setState({changingWorkDir: nextWorkDir});
+      await this.props.changeWorkingDirectory(nextWorkDir);
+    } finally {
+      await new Promise(resolve => this.setState({changingWork: null}, resolve));
+    }
+  }
+
+  getWorkDir() {
+    return this.state.changingWorkDir !== null ? this.state.changingWorkDir : this.props.currentWorkDir;
+  }
+
+  getContextLocked() {
+    return this.state.changingLock !== null ? this.state.changingLock : this.props.contextLocked;
   }
 
   componentWillUnmount() {

--- a/lib/controllers/github-tab-header-controller.js
+++ b/lib/controllers/github-tab-header-controller.js
@@ -53,9 +53,11 @@ export default class GithubTabHeaderController extends React.Component {
         user={this.props.user}
 
         // Workspace
-        workdirs={this.state.currentWorkDirs}
         workdir={this.getWorkDir()}
+        workdirs={this.state.currentWorkDirs}
         contextLocked={this.getContextLocked()}
+        changingWorkDir={this.state.changingWorkDir !== null}
+        changingLock={this.state.changingLock !== null}
 
         handleWorkDirChange={this.handleWorkDirChange}
         handleLockToggle={this.handleLockToggle}
@@ -93,7 +95,7 @@ export default class GithubTabHeaderController extends React.Component {
       this.setState({changingWorkDir: nextWorkDir});
       await this.props.changeWorkingDirectory(nextWorkDir);
     } finally {
-      await new Promise(resolve => this.setState({changingWork: null}, resolve));
+      await new Promise(resolve => this.setState({changingWorkDir: null}, resolve));
     }
   }
 

--- a/lib/controllers/root-controller.js
+++ b/lib/controllers/root-controller.js
@@ -67,7 +67,9 @@ export default class RootController extends React.Component {
     clone: PropTypes.func.isRequired,
 
     // Control
+    contextLocked: PropTypes.bool.isRequired,
     changeWorkingDirectory: PropTypes.func.isRequired,
+    setContextLock: PropTypes.func.isRequired,
     startOpen: PropTypes.bool,
     startRevealed: PropTypes.bool,
   }
@@ -294,7 +296,9 @@ export default class RootController extends React.Component {
               currentWorkDir={this.props.currentWorkDir}
               getCurrentWorkDirs={getCurrentWorkDirs}
               onDidChangeWorkDirs={onDidChangeWorkDirs}
+              contextLocked={this.props.contextLocked}
               changeWorkingDirectory={this.props.changeWorkingDirectory}
+              setContextLock={this.props.setContextLock}
             />
           )}
         </PaneItem>
@@ -311,7 +315,9 @@ export default class RootController extends React.Component {
               currentWorkDir={this.props.currentWorkDir}
               getCurrentWorkDirs={getCurrentWorkDirs}
               onDidChangeWorkDirs={onDidChangeWorkDirs}
+              contextLocked={this.props.contextLocked}
               changeWorkingDirectory={this.props.changeWorkingDirectory}
+              setContextLock={this.props.setContextLock}
               openCreateDialog={this.openCreateDialog}
               openPublishDialog={this.openPublishDialog}
               openCloneDialog={this.openCloneDialog}

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -598,12 +598,17 @@ export default class GithubPackage {
       }
     }
 
-    // 2 - Follow the active workspace pane item.
+    // 2 - Use the currently locked context, if one is present.
+    if (this.lockedContext) {
+      return this.lockedContext;
+    }
+
+    // 3 - Follow the active workspace pane item.
     if (activeItemWorkdir) {
       return this.contextPool.getContext(activeItemWorkdir);
     }
 
-    // 3 - The first open project.
+    // 4 - The first open project.
     if (firstProjectWorkdir) {
       return this.contextPool.getContext(firstProjectWorkdir);
     }

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -290,7 +290,11 @@ export default class GithubPackage {
     }
 
     const changeWorkingDirectory = workingDirectory => {
-      this.scheduleActiveContextUpdate({activeRepositoryPath: workingDirectory});
+      this.scheduleActiveContextUpdate({usePath: workingDirectory});
+    };
+
+    const setContextLock = (workingDirectory, lock) => {
+      this.scheduleActiveContextUpdate({usePath: workingDirectory, lock});
     };
 
     this.renderFn(
@@ -319,7 +323,9 @@ export default class GithubPackage {
         startRevealed={this.startRevealed}
         removeFilePatchItem={this.removeFilePatchItem}
         currentWorkDir={this.getActiveWorkdir()}
+        contextLocked={this.lockedContext !== null}
         changeWorkingDirectory={changeWorkingDirectory}
+        setContextLock={setContextLock}
       />, this.element, callback,
     );
   }

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -26,7 +26,7 @@ import {reporterProxy} from './reporter-proxy';
 
 const defaultState = {
   newProject: true,
-  activeContextPath: null,
+  activeRepositoryPath: null,
   contextLocked: false,
 };
 
@@ -242,7 +242,7 @@ export default class GithubPackage {
 
     this.activated = true;
     this.scheduleActiveContextUpdate({
-      usePath: savedState.activeContextPath,
+      usePath: savedState.activeRepositoryPath,
       lock: savedState.contextLocked,
     });
     this.rerender();
@@ -266,7 +266,7 @@ export default class GithubPackage {
 
   serialize() {
     return {
-      activeContextPath: this.getActiveRepositoryPath(),
+      activeRepositoryPath: this.getActiveRepositoryPath(),
       contextLocked: Boolean(this.lockedContext),
       newProject: false,
     };

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -643,18 +643,29 @@ export default class GithubPackage {
         this.guessedContext = null;
       }
       this.activeContext = nextActiveContext;
+      if (lock === true) {
+        this.lockedContext = this.activeContext;
+      } else if (lock === false) {
+        this.lockedContext = null;
+      }
+
+      this.rerender(() => {
+        this.switchboard.didFinishContextChangeRender();
+        this.switchboard.didFinishActiveContextUpdate();
+      });
+    } else if ((lock === true || lock === false) && lock !== (this.lockedContext !== null)) {
+      if (lock) {
+        this.lockedContext = this.activeContext;
+      } else {
+        this.lockedContext = null;
+      }
+
       this.rerender(() => {
         this.switchboard.didFinishContextChangeRender();
         this.switchboard.didFinishActiveContextUpdate();
       });
     } else {
       this.switchboard.didFinishActiveContextUpdate();
-    }
-
-    if (lock === true) {
-      this.lockedContext = this.activeContext;
-    } else if (lock === false) {
-      this.lockedContext = null;
     }
   }
 

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -266,7 +266,7 @@ export default class GithubPackage {
 
   serialize() {
     return {
-      activeRepositoryPath: this.getActiveRepositoryPath(),
+      activeRepositoryPath: this.getActiveWorkdir(),
       contextLocked: Boolean(this.lockedContext),
       newProject: false,
     };
@@ -504,14 +504,6 @@ export default class GithubPackage {
 
   getActiveRepository() {
     return this.activeContext.getRepository();
-  }
-
-  getActiveRepositoryPath() {
-    const activeRepository = this.activeContext.getRepository();
-    if (!activeRepository) {
-      return null;
-    }
-    return activeRepository.getWorkingDirectoryPath();
   }
 
   getActiveResolutionProgress() {

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -26,6 +26,8 @@ import {reporterProxy} from './reporter-proxy';
 
 const defaultState = {
   newProject: true,
+  activeContextPath: null,
+  contextLocked: false,
 };
 
 export default class GithubPackage {
@@ -71,6 +73,7 @@ export default class GithubPackage {
     this.activeContextQueue = new AsyncQueue();
     this.guessedContext = WorkdirContext.guess(criteria, this.pipelineManager);
     this.activeContext = this.guessedContext;
+    this.lockedContext = null;
     this.workdirCache = new WorkdirCache();
     this.contextPool = new WorkdirContextPool({
       window,
@@ -159,10 +162,10 @@ export default class GithubPackage {
   }
 
   async activate(state = {}) {
-    this.savedState = {...defaultState, ...state};
+    const savedState = {...defaultState, ...state};
 
     const firstRun = !await fileExists(this.configPath);
-    const newProject = this.savedState.firstRun !== undefined ? this.savedState.firstRun : this.savedState.newProject;
+    const newProject = savedState.firstRun !== undefined ? savedState.firstRun : savedState.newProject;
 
     this.startOpen = firstRun || newProject;
     this.startRevealed = firstRun && !this.config.get('welcome.showOnStartup');
@@ -175,14 +178,9 @@ export default class GithubPackage {
       return !!event.target.closest('.github-FilePatchListView').querySelector('.is-selected');
     };
 
-    const handleProjectPathsChange = () => {
-      const activeRepository = this.getActiveRepository();
-      const activeRepositoryPath = activeRepository ? activeRepository.getWorkingDirectoryPath() : null;
-      this.scheduleActiveContextUpdate({activeRepositoryPath});
-    };
-
     this.subscriptions.add(
-      this.project.onDidChangePaths(handleProjectPathsChange),
+      this.workspace.getCenter().onDidChangeActivePaneItem(this.handleActivePaneItemChange),
+      this.project.onDidChangePaths(this.handleProjectPathsChange),
       this.styleCalculator.startWatching(
         'github-package-styles',
         ['editor.fontSize', 'editor.fontFamily', 'editor.lineHeight', 'editor.tabLength'],
@@ -243,16 +241,33 @@ export default class GithubPackage {
     );
 
     this.activated = true;
-    this.scheduleActiveContextUpdate(this.savedState);
+    this.scheduleActiveContextUpdate({
+      usePath: savedState.activeContextPath,
+      lock: savedState.contextLocked,
+    });
     this.rerender();
   }
 
-  serialize() {
-    const activeRepository = this.getActiveRepository();
-    const activeRepositoryPath = activeRepository ? activeRepository.getWorkingDirectoryPath() : null;
+  handleActivePaneItemChange = () => {
+    if (this.lockedContext) {
+      return;
+    }
 
+    const itemPath = pathForPaneItem(this.workspace.getCenter().getActivePaneItem());
+    this.scheduleActiveContextUpdate({
+      usePath: itemPath,
+      lock: false,
+    });
+  }
+
+  handleProjectPathsChange = () => {
+    this.scheduleActiveContextUpdate();
+  }
+
+  serialize() {
     return {
-      activeRepositoryPath,
+      activeContextPath: this.getActiveRepositoryPath(),
+      contextLocked: Boolean(this.lockedContext),
       newProject: false,
     };
   }
@@ -485,6 +500,14 @@ export default class GithubPackage {
     return this.activeContext.getRepository();
   }
 
+  getActiveRepositoryPath() {
+    const activeRepository = this.activeContext.getRepository();
+    if (!activeRepository) {
+      return null;
+    }
+    return activeRepository.getWorkingDirectoryPath();
+  }
+
   getActiveResolutionProgress() {
     return this.activeContext.getResolutionProgress();
   }
@@ -497,65 +520,117 @@ export default class GithubPackage {
     return this.switchboard;
   }
 
-  async scheduleActiveContextUpdate(savedState = {}) {
+  /**
+   * Enqueue a request to modify the active context.
+   *
+   * options:
+   *   usePath - Path of the context to use as the next context, if it is present in the pool.
+   *   lock - True or false to lock the ultimately chosen context. Omit to preserve the current lock state.
+   *
+   * This method returns a Promise that resolves when the requested context update has completed. Note that it's
+   * *possible* for the active context after resolution to differ from a requested `usePath`, if the workdir
+   * containing `usePath` is no longer a viable option, such as if it belongs to a project that is no longer present.
+   */
+  async scheduleActiveContextUpdate(options = {}) {
     this.switchboard.didScheduleActiveContextUpdate();
-    await this.activeContextQueue.push(this.updateActiveContext.bind(this, savedState), {parallel: false});
+    await this.activeContextQueue.push(this.updateActiveContext.bind(this, options), {parallel: false});
   }
 
   /**
    * Derive the git working directory context that should be used for the package's git operations based on the current
    * state of the Atom workspace. In priority, this prefers:
    *
-   * - The preferred git working directory set by the user (This is also the working directory that was active when the
-   *   package was last serialized).
-   * - A git working directory corresponding to "first" Project, whether or not there is a single project or multiple.
+   * - When activating: the working directory that was active when the package was last serialized, if it still a viable
+   *   option. (usePath)
+   * - The working directory chosen by the user from the context tile on the git or GitHub tabs. (usePath)
+   * - The working directory containing the path of the active pane item.
+   * - A git working directory corresponding to "first" project, if any projects are open.
    * - The current context, unchanged, which may be a `NullWorkdirContext`.
    *
    * First updates the pool of resident contexts to match all git working directories that correspond to open
-   * projects.
+   * projects and pane items.
    */
-  async getNextContext(savedState) {
+  async getNextContext(usePath = null) {
+    // Identify paths that *could* contribute a git working directory to the pool. This is drawn from
+    // the roots of open projects, the currently locked context if one is present, and the path of the
+    // open workspace item.
+    const candidatePaths = new Set(this.project.getPaths());
+    if (this.lockedContext) {
+      const lockedRepo = this.lockedContext.getRepository();
+      if (lockedRepo) {
+        candidatePaths.add(lockedRepo.getWorkingDirectoryPath());
+      }
+    }
+    const activeItemPath = pathForPaneItem(this.workspace.getCenter().getActivePaneItem());
+    if (activeItemPath) {
+      candidatePaths.add(activeItemPath);
+    }
+
+    let activeItemWorkdir = null;
+    let firstProjectWorkdir = null;
+
+    // Convert the candidate paths into the set of viable git working directories, by means of a cached
+    // `git rev-parse` call. Candidate paths that are not contained within a git working directory will
+    // be preserved as-is within the pool, to allow users to initialize them.
     const workdirs = new Set(
       await Promise.all(
-        this.project.getPaths().map(async projectPath => {
-          const workdir = await this.workdirCache.find(projectPath);
-          return workdir || projectPath;
+        Array.from(candidatePaths, async candidatePath => {
+          const workdir = (await this.workdirCache.find(candidatePath)) || candidatePath;
+          // Note the workdirs associated with the active pane item and the first open project so we can
+          // prefer them later.
+          if (candidatePath === activeItemPath) {
+            activeItemWorkdir = workdir;
+          } else if (candidatePath === this.project.getPaths()[0]) {
+            firstProjectWorkdir = workdir;
+          }
+          return workdir;
         }),
       ),
     );
 
-    // Update pool with the open projects
-    this.contextPool.set(workdirs, savedState);
+    // Update pool with the identified projects.
+    this.contextPool.set(workdirs);
 
-    if (savedState.activeRepositoryPath) {
-      // Preferred git directory (the preferred directory or the last serialized directory).
-      const stateContext = this.contextPool.getContext(savedState.activeRepositoryPath);
-      // If the context exists chose it, else continue.
+    // 1 - Explicitly requested workdir. This is either selected by the user from a context tile or
+    //     deserialized from package state. Choose this context only if it still exists in the pool.
+    if (usePath) {
+      const stateContext = this.contextPool.getContext(usePath);
       if (stateContext.isPresent()) {
         return stateContext;
       }
     }
 
-    const projectPaths = this.project.getPaths();
-
-    if (projectPaths.length >= 1) {
-      // Single or multiple projects (just choose the first, the user can select after)
-      const projectPath = projectPaths[0];
-      const activeWorkingDir = await this.workdirCache.find(projectPath);
-      return this.contextPool.getContext(activeWorkingDir || projectPath);
+    // 2 - Follow the active workspace pane item.
+    if (activeItemWorkdir) {
+      return this.contextPool.getContext(activeItemWorkdir);
     }
 
-    if (projectPaths.length === 0 && !this.activeContext.getRepository().isUndetermined()) {
-      // No projects. Revert to the absent context unless we've guessed that more projects are on the way.
+    // 3 - The first open project.
+    if (firstProjectWorkdir) {
+      return this.contextPool.getContext(firstProjectWorkdir);
+    }
+
+    // No projects. Revert to the absent context unless we've guessed that more projects are on the way.
+    if (this.project.getPaths().length === 0 && !this.activeContext.getRepository().isUndetermined()) {
       return WorkdirContext.absent({pipelineManager: this.pipelineManager});
     }
 
-    // It is only possible to reach here if there there was no preferred directory, there are no project paths and the
-    // the active context's repository is not undetermined.
+    // It is only possible to reach here if there there was no preferred directory, there are no project paths, and the
+    // the active context's repository is not undetermined. Preserve the existing active context.
     return this.activeContext;
   }
 
-  setActiveContext(nextActiveContext) {
+  /**
+   * Modify the active context and re-render the React tree. This should only be done as part of the
+   * context update queue; use scheduleActiveContextUpdate() to do this.
+   *
+   * nextActiveContext - The WorkdirContext to make active next, as derived from the current workspace
+   *   state by getNextContext(). This may be absent or undetermined.
+   * lock - If true, also set this context as the "locked" one and engage the context lock if it isn't
+   *   already. If false, clear any existing context lock. If null or undefined, leave the lock in its
+   *   existing state.
+   */
+  setActiveContext(nextActiveContext, lock) {
     if (nextActiveContext !== this.activeContext) {
       if (this.activeContext === this.guessedContext) {
         this.guessedContext.destroy();
@@ -569,17 +644,30 @@ export default class GithubPackage {
     } else {
       this.switchboard.didFinishActiveContextUpdate();
     }
+
+    if (lock === true) {
+      this.lockedContext = this.activeContext;
+    } else if (lock === false) {
+      this.lockedContext = null;
+    }
   }
 
-  async updateActiveContext(savedState = {}) {
+  /**
+   * Derive the next active context with getNextContext(), then enact the context change with setActiveContext().
+   *
+   * options:
+   *   usePath - Path of the context to use as the next context, if it is present in the pool.
+   *   lock - True or false to lock the ultimately chosen context. Omit to preserve the current lock state.
+   */
+  async updateActiveContext(options = {}) {
     if (this.workspace.isDestroyed()) {
       return;
     }
 
     this.switchboard.didBeginActiveContextUpdate();
 
-    const nextActiveContext = await this.getNextContext(savedState);
-    this.setActiveContext(nextActiveContext);
+    const nextActiveContext = await this.getNextContext(options.usePath);
+    this.setActiveContext(nextActiveContext, options.lock);
   }
 
   async refreshAtomGitRepository(workdir) {
@@ -593,4 +681,23 @@ export default class GithubPackage {
       await atomGitRepo.refreshStatus();
     }
   }
+}
+
+function pathForPaneItem(paneItem) {
+  if (!paneItem) {
+    return null;
+  }
+
+  // Likely GitHub package provided pane item
+  if (typeof paneItem.getWorkingDirectory === 'function') {
+    return paneItem.getWorkingDirectory();
+  }
+
+  // TextEditor-like
+  if (typeof paneItem.getPath === 'function') {
+    return paneItem.getPath();
+  }
+
+  // Oh well
+  return null;
 }

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -555,6 +555,7 @@ export default class GithubPackage {
     const candidatePaths = new Set(this.project.getPaths());
     if (this.lockedContext) {
       const lockedRepo = this.lockedContext.getRepository();
+      /* istanbul ignore else */
       if (lockedRepo) {
         candidatePaths.add(lockedRepo.getWorkingDirectoryPath());
       }
@@ -673,7 +674,7 @@ export default class GithubPackage {
    *   usePath - Path of the context to use as the next context, if it is present in the pool.
    *   lock - True or false to lock the ultimately chosen context. Omit to preserve the current lock state.
    */
-  async updateActiveContext(options = {}) {
+  async updateActiveContext(options) {
     if (this.workspace.isDestroyed()) {
       return;
     }

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -290,11 +290,11 @@ export default class GithubPackage {
     }
 
     const changeWorkingDirectory = workingDirectory => {
-      this.scheduleActiveContextUpdate({usePath: workingDirectory});
+      return this.scheduleActiveContextUpdate({usePath: workingDirectory});
     };
 
     const setContextLock = (workingDirectory, lock) => {
-      this.scheduleActiveContextUpdate({usePath: workingDirectory, lock});
+      return this.scheduleActiveContextUpdate({usePath: workingDirectory, lock});
     };
 
     this.renderFn(

--- a/lib/views/git-tab-header-view.js
+++ b/lib/views/git-tab-header-view.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import path from 'path';
+
 import {AuthorPropType} from '../prop-types';
+import Octicon from '../atom/octicon';
 
 export default class GitTabHeaderView extends React.Component {
   static propTypes = {
@@ -10,9 +12,13 @@ export default class GitTabHeaderView extends React.Component {
     // Workspace
     workdir: PropTypes.string,
     workdirs: PropTypes.shape({[Symbol.iterator]: PropTypes.func.isRequired}).isRequired,
+    contextLocked: PropTypes.bool.isRequired,
+    changingWorkDir: PropTypes.bool.isRequired,
+    changingLock: PropTypes.bool.isRequired,
 
     // Event Handlers
     handleWorkDirSelect: PropTypes.func,
+    handleLockToggle: PropTypes.func,
   }
 
   render() {
@@ -24,6 +30,9 @@ export default class GitTabHeaderView extends React.Component {
           onChange={this.props.handleWorkDirSelect ? this.props.handleWorkDirSelect : () => {}}>
           {this.renderWorkDirs()}
         </select>
+        <button className="github-Project-lock btn btn-small" onClick={this.props.handleLockToggle}>
+          <Octicon icon={this.props.contextLocked ? 'globe' : 'lock'} />
+        </button>
       </header>
     );
   }

--- a/lib/views/git-tab-header-view.js
+++ b/lib/views/git-tab-header-view.js
@@ -22,6 +22,11 @@ export default class GitTabHeaderView extends React.Component {
   }
 
   render() {
+    const lockIcon = this.props.contextLocked ? 'lock' : 'unlock';
+    const lockToggleTitle = this.props.contextLocked ?
+      'Change repository with the dropdown' :
+      'Follow the active pane item';
+
     return (
       <header className="github-Project">
         {this.renderCommitter()}
@@ -33,8 +38,9 @@ export default class GitTabHeaderView extends React.Component {
         </select>
         <button className="github-Project-lock btn btn-small"
           onClick={this.props.handleLockToggle}
-          disabled={this.props.changingLock}>
-          <Octicon icon={this.props.contextLocked ? 'lock' : 'globe'} />
+          disabled={this.props.changingLock}
+          title={lockToggleTitle}>
+          <Octicon icon={lockIcon} />
         </button>
       </header>
     );

--- a/lib/views/git-tab-header-view.js
+++ b/lib/views/git-tab-header-view.js
@@ -31,7 +31,7 @@ export default class GitTabHeaderView extends React.Component {
       <header className="github-Project">
         {this.renderCommitter()}
         <select className="github-Project-path input-select"
-          value={this.props.workdir ? path.normalize(this.props.workdir) : undefined}
+          value={this.props.workdir || ''}
           onChange={this.props.handleWorkDirSelect}
           disabled={this.props.changingWorkDir}>
           {this.renderWorkDirs()}

--- a/lib/views/git-tab-header-view.js
+++ b/lib/views/git-tab-header-view.js
@@ -27,11 +27,14 @@ export default class GitTabHeaderView extends React.Component {
         {this.renderCommitter()}
         <select className="github-Project-path input-select"
           value={this.props.workdir ? path.normalize(this.props.workdir) : undefined}
-          onChange={this.props.handleWorkDirSelect ? this.props.handleWorkDirSelect : () => {}}>
+          onChange={this.props.handleWorkDirSelect}
+          disabled={this.props.changingWorkDir}>
           {this.renderWorkDirs()}
         </select>
-        <button className="github-Project-lock btn btn-small" onClick={this.props.handleLockToggle}>
-          <Octicon icon={this.props.contextLocked ? 'globe' : 'lock'} />
+        <button className="github-Project-lock btn btn-small"
+          onClick={this.props.handleLockToggle}
+          disabled={this.props.changingLock}>
+          <Octicon icon={this.props.contextLocked ? 'lock' : 'globe'} />
         </button>
       </header>
     );

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -129,12 +129,12 @@ export default class GitTabView extends React.Component {
         currentWorkDir={this.props.workingDirectoryPath}
         getCurrentWorkDirs={this.props.getCurrentWorkDirs}
         contextLocked={this.props.contextLocked}
+        changeWorkingDirectory={this.props.changeWorkingDirectory}
+        setContextLock={this.props.setContextLock}
 
         // Event Handlers
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
         onDidUpdateRepo={repository.onDidUpdate.bind(repository)}
-        handleWorkDirSelect={e => this.props.changeWorkingDirectory(e.target.value)}
-        setContextLock={this.props.setContextLock}
       />
     );
   }

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -61,7 +61,9 @@ export default class GitTabView extends React.Component {
     attemptFileStageOperation: PropTypes.func.isRequired,
     discardWorkDirChangesForPaths: PropTypes.func.isRequired,
     openFiles: PropTypes.func.isRequired,
+    contextLocked: PropTypes.bool.isRequired,
     changeWorkingDirectory: PropTypes.func.isRequired,
+    setContextLock: PropTypes.func.isRequired,
     onDidChangeWorkDirs: PropTypes.func.isRequired,
     getCurrentWorkDirs: PropTypes.func.isRequired,
   };
@@ -126,11 +128,13 @@ export default class GitTabView extends React.Component {
         // Workspace
         currentWorkDir={this.props.workingDirectoryPath}
         getCurrentWorkDirs={this.props.getCurrentWorkDirs}
+        contextLocked={this.props.contextLocked}
 
         // Event Handlers
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
         onDidUpdateRepo={repository.onDidUpdate.bind(repository)}
         handleWorkDirSelect={e => this.props.changeWorkingDirectory(e.target.value)}
+        setContextLock={this.props.setContextLock}
       />
     );
   }

--- a/lib/views/github-tab-header-view.js
+++ b/lib/views/github-tab-header-view.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import path from 'path';
+
 import {AuthorPropType} from '../prop-types';
+import Octicon from '../atom/octicon';
 
 export default class GithubTabHeaderView extends React.Component {
   static propTypes = {
@@ -10,9 +12,9 @@ export default class GithubTabHeaderView extends React.Component {
     // Workspace
     workdir: PropTypes.string,
     workdirs: PropTypes.shape({[Symbol.iterator]: PropTypes.func.isRequired}).isRequired,
-
-    // Event Handlers
-    handleWorkDirSelect: PropTypes.func,
+    contextLocked: PropTypes.bool.isRequired,
+    handleWorkDirChange: PropTypes.func.isRequired,
+    handleLockToggle: PropTypes.func.isRequired,
   }
 
   render() {
@@ -21,9 +23,12 @@ export default class GithubTabHeaderView extends React.Component {
         {this.renderUser()}
         <select className="github-Project-path input-select"
           value={this.props.workdir ? path.normalize(this.props.workdir) : undefined}
-          onChange={this.props.handleWorkDirSelect ? this.props.handleWorkDirSelect : () => {}}>
+          onChange={this.props.handleWorkDirChange}>
           {this.renderWorkDirs()}
         </select>
+        <button className="github-Project-lock btn btn-small" onClick={this.props.handleLockToggle}>
+          <Octicon icon={this.props.contextLocked ? 'globe' : 'lock'} />
+        </button>
       </header>
     );
   }

--- a/lib/views/github-tab-header-view.js
+++ b/lib/views/github-tab-header-view.js
@@ -13,6 +13,8 @@ export default class GithubTabHeaderView extends React.Component {
     workdir: PropTypes.string,
     workdirs: PropTypes.shape({[Symbol.iterator]: PropTypes.func.isRequired}).isRequired,
     contextLocked: PropTypes.bool.isRequired,
+    changingWorkDir: PropTypes.bool.isRequired,
+    changingLock: PropTypes.bool.isRequired,
     handleWorkDirChange: PropTypes.func.isRequired,
     handleLockToggle: PropTypes.func.isRequired,
   }
@@ -22,11 +24,15 @@ export default class GithubTabHeaderView extends React.Component {
       <header className="github-Project">
         {this.renderUser()}
         <select className="github-Project-path input-select"
-          value={this.props.workdir ? path.normalize(this.props.workdir) : undefined}
+          value={this.props.workdir}
+          disabled={this.props.changingWorkDir}
           onChange={this.props.handleWorkDirChange}>
           {this.renderWorkDirs()}
         </select>
-        <button className="github-Project-lock btn btn-small" onClick={this.props.handleLockToggle}>
+        <button
+          className="github-Project-lock btn btn-small"
+          disabled={this.props.changingLock}
+          onClick={this.props.handleLockToggle}>
           <Octicon icon={this.props.contextLocked ? 'lock' : 'globe'} />
         </button>
       </header>

--- a/lib/views/github-tab-header-view.js
+++ b/lib/views/github-tab-header-view.js
@@ -20,6 +20,11 @@ export default class GithubTabHeaderView extends React.Component {
   }
 
   render() {
+    const lockIcon = this.props.contextLocked ? 'lock' : 'unlock';
+    const lockToggleTitle = this.props.contextLocked ?
+      'Change repository with the dropdown' :
+      'Follow the active pane item';
+
     return (
       <header className="github-Project">
         {this.renderUser()}
@@ -29,11 +34,11 @@ export default class GithubTabHeaderView extends React.Component {
           onChange={this.props.handleWorkDirChange}>
           {this.renderWorkDirs()}
         </select>
-        <button
-          className="github-Project-lock btn btn-small"
+        <button className="github-Project-lock btn btn-small"
+          onClick={this.props.handleLockToggle}
           disabled={this.props.changingLock}
-          onClick={this.props.handleLockToggle}>
-          <Octicon icon={this.props.contextLocked ? 'lock' : 'globe'} />
+          title={lockToggleTitle}>
+          <Octicon icon={lockIcon} />
         </button>
       </header>
     );

--- a/lib/views/github-tab-header-view.js
+++ b/lib/views/github-tab-header-view.js
@@ -27,7 +27,7 @@ export default class GithubTabHeaderView extends React.Component {
           {this.renderWorkDirs()}
         </select>
         <button className="github-Project-lock btn btn-small" onClick={this.props.handleLockToggle}>
-          <Octicon icon={this.props.contextLocked ? 'globe' : 'lock'} />
+          <Octicon icon={this.props.contextLocked ? 'lock' : 'globe'} />
         </button>
       </header>
     );

--- a/lib/views/github-tab-header-view.js
+++ b/lib/views/github-tab-header-view.js
@@ -29,7 +29,7 @@ export default class GithubTabHeaderView extends React.Component {
       <header className="github-Project">
         {this.renderUser()}
         <select className="github-Project-path input-select"
-          value={this.props.workdir}
+          value={this.props.workdir || ''}
           disabled={this.props.changingWorkDir}
           onChange={this.props.handleWorkDirChange}>
           {this.renderWorkDirs()}

--- a/lib/views/github-tab-view.js
+++ b/lib/views/github-tab-view.js
@@ -42,7 +42,7 @@ export default class GitHubTabView extends React.Component {
     aheadCount: PropTypes.number,
     pushInProgress: PropTypes.bool.isRequired,
 
-    // Event Handelrs
+    // Event Handlers
     handleWorkDirSelect: PropTypes.func,
     handlePushBranch: PropTypes.func.isRequired,
     handleRemoteSelect: PropTypes.func.isRequired,

--- a/lib/views/github-tab-view.js
+++ b/lib/views/github-tab-view.js
@@ -28,6 +28,8 @@ export default class GitHubTabView extends React.Component {
     workingDirectory: PropTypes.string,
     getCurrentWorkDirs: PropTypes.func.isRequired,
     changeWorkingDirectory: PropTypes.func.isRequired,
+    contextLocked: PropTypes.bool.isRequired,
+    setContextLock: PropTypes.func.isRequired,
     repository: PropTypes.object.isRequired,
 
     // Remotes
@@ -137,10 +139,13 @@ export default class GitHubTabView extends React.Component {
 
           // Workspace
           currentWorkDir={this.props.workingDirectory}
+          contextLocked={this.props.contextLocked}
+          changeWorkingDirectory={this.props.changeWorkingDirectory}
+          setContextLock={this.props.setContextLock}
           getCurrentWorkDirs={this.props.getCurrentWorkDirs}
 
           // Event Handlers
-          handleWorkDirSelect={e => this.props.changeWorkingDirectory(e.target.value)}
+          // handleWorkDirSelect={e => this.props.changeWorkingDirectory(e.target.value)}
           onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
         />
       );
@@ -151,10 +156,12 @@ export default class GitHubTabView extends React.Component {
 
         // Workspace
         currentWorkDir={this.props.workingDirectory}
+        contextLocked={this.props.contextLocked}
+        changeWorkingDirectory={this.props.changeWorkingDirectory}
+        setContextLock={this.props.setContextLock}
         getCurrentWorkDirs={this.props.getCurrentWorkDirs}
 
         // Event Handlers
-        handleWorkDirSelect={e => this.props.changeWorkingDirectory(e.target.value)}
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
       />
     );

--- a/styles/project.less
+++ b/styles/project.less
@@ -18,8 +18,38 @@
   }
 
   &-lock.btn {
+    width: 40px;
+    height: 20px;
+    padding: 0;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: baseline;
+
     border: none;
     background-color: transparent;
     background-image: none;
+
+    &:active, &:hover {
+      background-color: transparent;
+      background-image: none;
+    }
+  }
+
+  .icon {
+    padding: 0;
+    margin: 0;
+    line-height: 1em;
+    fill: @text-color;
+
+    &:hover {
+      fill: @text-color-highlight;
+    }
+
+    &.icon-unlock {
+      width: 21px;
+      height: 17px;
+      padding-left: 1px;
+    }
   }
 }

--- a/styles/project.less
+++ b/styles/project.less
@@ -17,4 +17,9 @@
     border-radius: @component-border-radius;
   }
 
+  &-lock.btn {
+    border: none;
+    background-color: transparent;
+    background-image: none;
+  }
 }

--- a/test/atom/octicon.test.js
+++ b/test/atom/octicon.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import Octicon from '../../lib/atom/octicon';
+
+describe('Octicon', function() {
+  it('defaults to rendering an octicon span', function() {
+    const wrapper = shallow(<Octicon icon="octoface" />);
+    assert.isTrue(wrapper.exists('span.icon.icon-octoface'));
+  });
+
+  it('renders SVG overrides', function() {
+    const wrapper = shallow(<Octicon icon="unlock" />);
+
+    assert.strictEqual(wrapper.find('svg').prop('viewBox'), '0 0 24 16');
+  });
+});

--- a/test/containers/github-tab-header-container.test.js
+++ b/test/containers/github-tab-header-container.test.js
@@ -27,7 +27,12 @@ describe('GithubTabHeaderContainer', function() {
       <GithubTabHeaderContainer
         loginModel={model}
         endpoint={getEndpoint('github.com')}
-        getCurrentWorkDirs={() => null}
+        currentWorkDir={null}
+        contextLocked={false}
+        changeWorkingDirectory={() => {}}
+        setContextLock={() => {}}
+        getCurrentWorkDirs={() => new Set()}
+        onDidChangeWorkDirs={() => {}}
         {...overrideProps}
       />
     );

--- a/test/controllers/git-tab-header-controller.test.js
+++ b/test/controllers/git-tab-header-controller.test.js
@@ -115,7 +115,7 @@ describe('GitTabHeaderController', function() {
     let resolveLockChange;
     const setContextLock = sinon.stub().returns(new Promise(resolve => {
       resolveLockChange = resolve;
-    }))
+    }));
     const wrapper = shallow(buildApp({currentWorkDir: 'the/workdir', contextLocked: false, setContextLock}));
 
     assert.isFalse(wrapper.find('GitTabHeaderView').prop('contextLocked'));
@@ -141,7 +141,7 @@ describe('GitTabHeaderController', function() {
     let resolveWorkdirChange;
     const changeWorkingDirectory = sinon.stub().returns(new Promise(resolve => {
       resolveWorkdirChange = resolve;
-    }))
+    }));
     const wrapper = shallow(buildApp({currentWorkDir: 'original', changeWorkingDirectory}));
 
     assert.strictEqual(wrapper.find('GitTabHeaderView').prop('workdir'), 'original');

--- a/test/controllers/github-tab-controller.test.js
+++ b/test/controllers/github-tab-controller.test.js
@@ -45,6 +45,8 @@ describe('GitHubTabController', function() {
         currentWorkDir={repo.getWorkingDirectoryPath()}
 
         changeWorkingDirectory={() => {}}
+        setContextLock={() => {}}
+        contextLocked={false}
         onDidChangeWorkDirs={() => {}}
         getCurrentWorkDirs={() => []}
         openCreateDialog={() => {}}

--- a/test/controllers/github-tab-header-controller.test.js
+++ b/test/controllers/github-tab-header-controller.test.js
@@ -79,7 +79,7 @@ describe('GithubTabHeaderController', function() {
     let resolveLockChange;
     const setContextLock = sinon.stub().returns(new Promise(resolve => {
       resolveLockChange = resolve;
-    }))
+    }));
     const wrapper = shallow(buildApp({currentWorkDir: 'the/workdir', contextLocked: false, setContextLock}));
 
     assert.isFalse(wrapper.find('GithubTabHeaderView').prop('contextLocked'));
@@ -105,7 +105,7 @@ describe('GithubTabHeaderController', function() {
     let resolveWorkdirChange;
     const changeWorkingDirectory = sinon.stub().returns(new Promise(resolve => {
       resolveWorkdirChange = resolve;
-    }))
+    }));
     const wrapper = shallow(buildApp({currentWorkDir: 'original', changeWorkingDirectory}));
 
     assert.strictEqual(wrapper.find('GithubTabHeaderView').prop('workdir'), 'original');

--- a/test/controllers/github-tab-header-controller.test.js
+++ b/test/controllers/github-tab-header-controller.test.js
@@ -15,10 +15,12 @@ describe('GithubTabHeaderController', function() {
   function buildApp(overrides) {
     const props = {
       user: nullAuthor,
+      currentWorkDir: null,
+      contextLocked: false,
+      changeWorkingDirectory: () => {},
+      setContextLock: () => {},
       getCurrentWorkDirs: () => createWorkdirs([]),
-      onDidUpdateRepo: () => new Disposable(),
       onDidChangeWorkDirs: () => new Disposable(),
-      handleWorkDirSelect: () => null,
       ...overrides,
     };
     return (
@@ -71,6 +73,62 @@ describe('GithubTabHeaderController', function() {
     const wrapper = shallow(buildApp({getCurrentWorkDirs}));
     wrapper.instance().resetWorkDirs();
     assert.isTrue(getCurrentWorkDirs.calledTwice);
+  });
+
+  it('handles a lock toggle', async function() {
+    let resolveLockChange;
+    const setContextLock = sinon.stub().returns(new Promise(resolve => {
+      resolveLockChange = resolve;
+    }))
+    const wrapper = shallow(buildApp({currentWorkDir: 'the/workdir', contextLocked: false, setContextLock}));
+
+    assert.isFalse(wrapper.find('GithubTabHeaderView').prop('contextLocked'));
+    assert.isFalse(wrapper.find('GithubTabHeaderView').prop('changingLock'));
+
+    const handlerPromise = wrapper.find('GithubTabHeaderView').prop('handleLockToggle')();
+    wrapper.update();
+
+    assert.isTrue(wrapper.find('GithubTabHeaderView').prop('contextLocked'));
+    assert.isTrue(wrapper.find('GithubTabHeaderView').prop('changingLock'));
+    assert.isTrue(setContextLock.calledWith('the/workdir', true));
+
+    // Ignored while in-progress
+    wrapper.find('GithubTabHeaderView').prop('handleLockToggle')();
+
+    resolveLockChange();
+    await handlerPromise;
+
+    assert.isFalse(wrapper.find('GithubTabHeaderView').prop('changingLock'));
+  });
+
+  it('handles a workdir selection', async function() {
+    let resolveWorkdirChange;
+    const changeWorkingDirectory = sinon.stub().returns(new Promise(resolve => {
+      resolveWorkdirChange = resolve;
+    }))
+    const wrapper = shallow(buildApp({currentWorkDir: 'original', changeWorkingDirectory}));
+
+    assert.strictEqual(wrapper.find('GithubTabHeaderView').prop('workdir'), 'original');
+    assert.isFalse(wrapper.find('GithubTabHeaderView').prop('changingWorkDir'));
+
+    const handlerPromise = wrapper.find('GithubTabHeaderView').prop('handleWorkDirChange')({
+      target: {value: 'work/dir'},
+    });
+    wrapper.update();
+
+    assert.strictEqual(wrapper.find('GithubTabHeaderView').prop('workdir'), 'work/dir');
+    assert.isTrue(wrapper.find('GithubTabHeaderView').prop('changingWorkDir'));
+    assert.isTrue(changeWorkingDirectory.calledWith('work/dir'));
+
+    // Ignored while in-progress
+    wrapper.find('GithubTabHeaderView').prop('handleWorkDirChange')({
+      target: {value: 'ig/nored'},
+    });
+
+    resolveWorkdirChange();
+    await handlerPromise;
+
+    assert.isFalse(wrapper.find('GithubTabHeaderView').prop('changingWorkDir'));
   });
 
   it('disposes on unmount', function() {

--- a/test/controllers/root-controller.test.js
+++ b/test/controllers/root-controller.test.js
@@ -58,13 +58,13 @@ describe('RootController', function() {
         workspace={workspace}
         commands={commands}
         deserializers={deserializers}
-        grammars={grammars}
         notificationManager={notificationManager}
         tooltips={tooltips}
-        config={config}
-        confirm={confirm}
-        project={project}
         keymaps={atomEnv.keymaps}
+        grammars={grammars}
+        config={config}
+        project={project}
+        confirm={confirm}
         currentWindow={atomEnv.getCurrentWindow()}
 
         loginModel={loginModel}
@@ -72,9 +72,14 @@ describe('RootController', function() {
         repository={absentRepository}
         resolutionProgress={emptyResolutionProgress}
 
+        currentWorkDir={null}
+
         initialize={() => {}}
         clone={() => {}}
 
+        contextLocked={false}
+        changeWorkingDirectory={() => {}}
+        setContextLock={() => {}}
         startOpen={false}
         startRevealed={false}
       />

--- a/test/fixtures/props/git-tab-props.js
+++ b/test/fixtures/props/git-tab-props.js
@@ -102,9 +102,11 @@ export async function gitTabViewProps(atomEnv, repository, overrides = {}) {
     discardWorkDirChangesForPaths: () => {},
     openFiles: () => {},
 
+    contextLocked: false,
     changeWorkingDirectory: () => {},
+    setContextLock: () => {},
     onDidChangeWorkDirs: () => ({dispose: () => {}}),
-    getCurrentWorkDirs: () => [],
+    getCurrentWorkDirs: () => new Set(),
     onDidUpdateRepo: () => ({dispose: () => {}}),
     getCommitter: () => nullAuthor,
 

--- a/test/fixtures/props/git-tab-props.js
+++ b/test/fixtures/props/git-tab-props.js
@@ -27,8 +27,10 @@ export function gitTabItemProps(atomEnv, repository, overrides = {}) {
     openFiles: noop,
     openInitializeDialog: noop,
     changeWorkingDirectory: noop,
+    contextLocked: false,
+    setContextLock: () => {},
     onDidChangeWorkDirs: () => ({dispose: () => {}}),
-    getCurrentWorkDirs: () => [],
+    getCurrentWorkDirs: () => new Set(),
     ...overrides
   };
 }

--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -455,7 +455,7 @@ describe('GithubPackage', function() {
         let resolutionMergeConflict;
         beforeEach(async function() {
           await githubPackage.scheduleActiveContextUpdate({
-            activeRepositoryPath: workdirMergeConflict,
+            usePath: workdirMergeConflict,
           });
           resolutionMergeConflict = contextPool.getContext(workdirMergeConflict).getResolutionProgress();
         });
@@ -477,7 +477,7 @@ describe('GithubPackage', function() {
         let resolutionNoConflict;
         beforeEach(async function() {
           await githubPackage.scheduleActiveContextUpdate({
-            activeRepositoryPath: workdirNoConflict,
+            usePath: workdirNoConflict,
           });
           resolutionNoConflict = contextPool.getContext(workdirNoConflict).getResolutionProgress();
         });
@@ -494,7 +494,7 @@ describe('GithubPackage', function() {
       describe('when opening a non-repository project', function() {
         beforeEach(async function() {
           await githubPackage.scheduleActiveContextUpdate({
-            activeRepositoryPath: nonRepositoryPath,
+            usePath: nonRepositoryPath,
           });
         });
 
@@ -515,7 +515,7 @@ describe('GithubPackage', function() {
         project.setPaths([workdirPath1, workdirPath2]);
 
         await githubPackage.scheduleActiveContextUpdate({
-          activeRepositoryPath: workdirPath3,
+          usePath: workdirPath3,
         });
         context1 = contextPool.getContext(workdirPath1);
       });
@@ -538,7 +538,7 @@ describe('GithubPackage', function() {
         project.setPaths([workdirPath1]);
 
         await githubPackage.scheduleActiveContextUpdate({
-          activeRepositoryPath: workdirPath2,
+          usePath: workdirPath2,
         });
         context1 = contextPool.getContext(workdirPath1);
       });
@@ -561,7 +561,7 @@ describe('GithubPackage', function() {
         project.setPaths([workdirPath1, workdirPath2]);
 
         await githubPackage.scheduleActiveContextUpdate({
-          activeRepositoryPath: workdirPath2,
+          usePath: workdirPath2,
         });
       });
 

--- a/test/views/git-tab-header-view.test.js
+++ b/test/views/git-tab-header-view.test.js
@@ -92,7 +92,7 @@ describe('GitTabHeaderView', function() {
       const wrapper = build({changingLock: true});
 
       assert.isTrue(wrapper.find('button').prop('disabled'));
-    })
+    });
   });
 
   describe('with falsish props', function() {

--- a/test/views/git-tab-header-view.test.js
+++ b/test/views/git-tab-header-view.test.js
@@ -69,7 +69,7 @@ describe('GitTabHeaderView', function() {
     it('renders unlocked when the lock is disengaged', function() {
       const wrapper = build({contextLocked: false});
 
-      assert.isTrue(wrapper.exists('Octicon[icon="globe"]'));
+      assert.isTrue(wrapper.exists('Octicon[icon="unlock"]'));
     });
 
     it('calls handleLockToggle when the lock is clicked', function() {

--- a/test/views/git-tab-header-view.test.js
+++ b/test/views/git-tab-header-view.test.js
@@ -15,7 +15,13 @@ describe('GitTabHeaderView', function() {
   function build(options = {}) {
     const props = {
       committer: nullAuthor,
+      workdir: null,
       workdirs: createWorkdirs([]),
+      contextLocked: false,
+      changingWorkDir: false,
+      changingLock: false,
+      handleWorkDirSelect: () => {},
+      handleLockToggle: () => {},
       ...options,
     };
     return shallow(<GitTabHeaderView {...props} />);
@@ -29,7 +35,11 @@ describe('GitTabHeaderView', function() {
 
     beforeEach(function() {
       select = sinon.spy();
-      wrapper = build({handleWorkDirSelect: select, workdirs: createWorkdirs(paths), workdir: path2});
+      wrapper = build({
+        handleWorkDirSelect: select,
+        workdirs: createWorkdirs(paths),
+        workdir: path2,
+      });
     });
 
     it('renders an option for all given working directories', function() {
@@ -47,6 +57,42 @@ describe('GitTabHeaderView', function() {
       wrapper.find('select').simulate('change', {target: {value: path1}});
       assert.isTrue(select.calledWith({target: {value: path1}}));
     });
+  });
+
+  describe('context lock control', function() {
+    it('renders locked when the lock is engaged', function() {
+      const wrapper = build({contextLocked: true});
+
+      assert.isTrue(wrapper.exists('.icon-lock'));
+    });
+
+    it('renders unlocked when the lock is disengaged', function() {
+      const wrapper = build({contextLocked: false});
+
+      assert.isTrue(wrapper.exists('.icon-globe'));
+    });
+
+    it('calls handleLockToggle when the lock is clicked', function() {
+      const handleLockToggle = sinon.spy();
+      const wrapper = build({handleLockToggle});
+
+      wrapper.find('button').simulate('click');
+      assert.isTrue(handleLockToggle.called);
+    });
+  });
+
+  describe('when changes are in progress', function() {
+    it('disables the workdir select while the workdir is changing', function() {
+      const wrapper = build({changingWorkDir: true});
+
+      assert.isTrue(wrapper.find('select').prop('disabled'));
+    });
+
+    it('disables the context lock toggle while the context lock is changing', function() {
+      const wrapper = build({changingLock: true});
+
+      assert.isTrue(wrapper.find('button').prop('disabled'));
+    })
   });
 
   describe('with falsish props', function() {

--- a/test/views/git-tab-header-view.test.js
+++ b/test/views/git-tab-header-view.test.js
@@ -63,13 +63,13 @@ describe('GitTabHeaderView', function() {
     it('renders locked when the lock is engaged', function() {
       const wrapper = build({contextLocked: true});
 
-      assert.isTrue(wrapper.exists('.icon-lock'));
+      assert.isTrue(wrapper.exists('Octicon[icon="lock"]'));
     });
 
     it('renders unlocked when the lock is disengaged', function() {
       const wrapper = build({contextLocked: false});
 
-      assert.isTrue(wrapper.exists('.icon-globe'));
+      assert.isTrue(wrapper.exists('Octicon[icon="globe"]'));
     });
 
     it('calls handleLockToggle when the lock is clicked', function() {

--- a/test/views/git-tab-view.test.js
+++ b/test/views/git-tab-view.test.js
@@ -286,7 +286,7 @@ describe('GitTabView', function() {
   it('calls changeWorkingDirectory when a project is selected', async function() {
     const changeWorkingDirectory = sinon.spy();
     const wrapper = shallow(await buildApp({changeWorkingDirectory}));
-    wrapper.find('GitTabHeaderController').prop('handleWorkDirSelect')({target: {value: 'some-path'}});
+    wrapper.find('GitTabHeaderController').prop('changeWorkingDirectory')('some-path');
     assert.isTrue(changeWorkingDirectory.calledWith('some-path'));
   });
 });

--- a/test/views/github-tab-header-view.test.js
+++ b/test/views/github-tab-header-view.test.js
@@ -88,7 +88,7 @@ describe('GithubTabHeaderView', function() {
       const wrapper = build({changingLock: true});
 
       assert.isTrue(wrapper.find('button').prop('disabled'));
-    })
+    });
   });
 
   describe('with falsish props', function() {

--- a/test/views/github-tab-header-view.test.js
+++ b/test/views/github-tab-header-view.test.js
@@ -15,7 +15,13 @@ describe('GithubTabHeaderView', function() {
   function build(options = {}) {
     const props = {
       user: nullAuthor,
+      workdir: null,
       workdirs: createWorkdirs([]),
+      contextLocked: false,
+      changingWorkDir: false,
+      changingLock: false,
+      handleWorkDirChange: () => {},
+      handleLockToggle: () => {},
       ...options,
     };
     return shallow(<GithubTabHeaderView {...props} />);
@@ -29,7 +35,7 @@ describe('GithubTabHeaderView', function() {
 
     beforeEach(function() {
       select = sinon.spy();
-      wrapper = build({handleWorkDirSelect: select, workdirs: createWorkdirs(paths), workdir: path2});
+      wrapper = build({handleWorkDirChange: select, workdirs: createWorkdirs(paths), workdir: path2});
     });
 
     it('renders an option for all given working directories', function() {
@@ -47,6 +53,42 @@ describe('GithubTabHeaderView', function() {
       wrapper.find('select').simulate('change', {target: {value: path1}});
       assert.isTrue(select.calledWith({target: {value: path1}}));
     });
+  });
+
+  describe('context lock control', function() {
+    it('renders locked when the lock is engaged', function() {
+      const wrapper = build({contextLocked: true});
+
+      assert.isTrue(wrapper.exists('Octicon[icon="lock"]'));
+    });
+
+    it('renders unlocked when the lock is disengaged', function() {
+      const wrapper = build({contextLocked: false});
+
+      assert.isTrue(wrapper.exists('Octicon[icon="globe"]'));
+    });
+
+    it('calls handleLockToggle when the lock is clicked', function() {
+      const handleLockToggle = sinon.spy();
+      const wrapper = build({handleLockToggle});
+
+      wrapper.find('button').simulate('click');
+      assert.isTrue(handleLockToggle.called);
+    });
+  });
+
+  describe('when changes are in progress', function() {
+    it('disables the workdir select while the workdir is changing', function() {
+      const wrapper = build({changingWorkDir: true});
+
+      assert.isTrue(wrapper.find('select').prop('disabled'));
+    });
+
+    it('disables the context lock toggle while the context lock is changing', function() {
+      const wrapper = build({changingLock: true});
+
+      assert.isTrue(wrapper.find('button').prop('disabled'));
+    })
   });
 
   describe('with falsish props', function() {

--- a/test/views/github-tab-header-view.test.js
+++ b/test/views/github-tab-header-view.test.js
@@ -65,7 +65,7 @@ describe('GithubTabHeaderView', function() {
     it('renders unlocked when the lock is disengaged', function() {
       const wrapper = build({contextLocked: false});
 
-      assert.isTrue(wrapper.exists('Octicon[icon="globe"]'));
+      assert.isTrue(wrapper.exists('Octicon[icon="unlock"]'));
     });
 
     it('calls handleLockToggle when the lock is clicked', function() {

--- a/test/views/github-tab-view.test.js
+++ b/test/views/github-tab-view.test.js
@@ -31,26 +31,31 @@ describe('GitHubTabView', function() {
 
     return (
       <GitHubTabView
-        workspace={atomEnv.workspace}
         refresher={new Refresher()}
-        loginModel={new GithubLoginModel(InMemoryStrategy)}
         rootHolder={new RefHolder()}
 
+        loginModel={new GithubLoginModel(InMemoryStrategy)}
+
+        workspace={atomEnv.workspace}
         workingDirectory={repo.getWorkingDirectoryPath()}
+        getCurrentWorkDirs={() => []}
+        changeWorkingDirectory={() => {}}
+        contextLocked={false}
+        setContextLock={() => {}}
         repository={repo}
-        branches={new BranchSet()}
-        currentBranch={nullBranch}
+
         remotes={new RemoteSet()}
         currentRemote={nullRemote}
         manyRemotesAvailable={false}
-        pushInProgress={false}
         isLoading={false}
+        branches={new BranchSet()}
+        currentBranch={nullBranch}
+        pushInProgress={false}
 
+        handleWorkDirSelect={() => {}}
         handlePushBranch={() => {}}
         handleRemoteSelect={() => {}}
-        changeWorkingDirectory={() => {}}
         onDidChangeWorkDirs={() => {}}
-        getCurrentWorkDirs={() => []}
         openCreateDialog={() => {}}
         openBoundPublishDialog={() => {}}
         openCloneDialog={() => {}}
@@ -125,7 +130,7 @@ describe('GitHubTabView', function() {
     const currentRemote = new Remote('aaa', 'git@github.com:aaa/bbb.git');
     const changeWorkingDirectory = sinon.spy();
     const wrapper = shallow(buildApp({currentRemote, changeWorkingDirectory}));
-    wrapper.find('GithubTabHeaderContainer').prop('handleWorkDirSelect')({target: {value: 'some-path'}});
+    wrapper.find('GithubTabHeaderContainer').prop('changeWorkingDirectory')('some-path');
     assert.isTrue(changeWorkingDirectory.calledWith('some-path'));
   });
 });


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Restores the behavior of following the WorkdirContext associated with the active pane item. Introduces the concept of a "locking" a WorkdirContext, so that one chosen explicitly from a context tile can be preserved even as you navigate elsewhere. Adds a padlock icon to the context tile to control toggling the lock.

Hat tip to @jarvelov for the locking idea! Solves a tricky UX problem in an elegant way.

#### Remaining work

- [x] Introduce context locking in GitHubPackage
- [x] Restore active pane following in GitHubPackage
- [x] Drill context lock state and context lock manipulation callbacks into the git and GitHub tab react trees
- [x] Implement context lock toggling action in the appropriate controllers
- [x] Add the context lock toggle control to the context tile views
- [x] Find an SVG editor and edit the `lock` octicon to make an `unlocked` svg icon.
- [x] Actually run the code and fix the inevitable bugs :smile:
- [x] Tests passing and full change coverage

### Screenshot/Gif

![context lock](https://user-images.githubusercontent.com/17565/73879438-7cedb180-482a-11ea-880f-adca3e7b4441.gif)

### Alternate Designs

See #2335 for an extended discussion about this.

### Benefits

This will allow us to preserve the benefits of having visibility of, and explicit control over, the current WorkdirContext, while reintroducing the convenience of the context following active workspace items.

### Possible Drawbacks

It will still be possible for users to get lost if they do something like open a file outside of their working repo for a quick configuration edit; see #1595 for some of this confusion. With this change, they will be able to lock their context to prevent this from happening, but if they aren't already working across multiple projects

### Applicable Issues

Fixes #2335.

### Documentation

_N/A_

### Release Notes

* Git repository context may be "locked" to manage manually or "unlocked" to follow the active pane item.

### User Experience Research (Optional)

_N/A_

