### PR TITLE
Populate StubItem panes that are deserialized after package initialization

### DIFF
--- a/lib/atom/pane-item.js
+++ b/lib/atom/pane-item.js
@@ -71,6 +71,30 @@ export default class PaneItem extends React.Component {
   }
 
   componentDidMount() {
+    // Listen for and adopt StubItems that are added after this component has
+    // already been mounted.
+    this.subs.add(this.props.workspace.onDidAddPaneItem(({item}) => {
+      if (item.getRealItem && item.getRealItem() === null) {
+        const match = this.state.uriPattern.matches(item.getURI());
+        if (!match.ok()) {
+          return;
+        }
+
+        const openItem = new OpenItem(match, item.getElement(), item);
+        openItem.hydrateStub({
+          copy: () => this.copyOpenItem(openItem),
+        });
+        if (this.props.className) {
+          openItem.addClassName(this.props.className);
+        }
+        this.registerCloseListener(item, openItem);
+
+        this.setState(prevState => ({
+          currentlyOpen: [...prevState.currentlyOpen, openItem],
+        }));
+      }
+    }));
+
     for (const openItem of this.state.currentlyOpen) {
       this.registerCloseListener(openItem.stubItem, openItem);
 

--- a/lib/atom/pane-item.js
+++ b/lib/atom/pane-item.js
@@ -74,25 +74,32 @@ export default class PaneItem extends React.Component {
     // Listen for and adopt StubItems that are added after this component has
     // already been mounted.
     this.subs.add(this.props.workspace.onDidAddPaneItem(({item}) => {
-      if (item.getRealItem && item.getRealItem() === null) {
-        const match = this.state.uriPattern.matches(item.getURI());
-        if (!match.ok()) {
-          return;
-        }
-
-        const openItem = new OpenItem(match, item.getElement(), item);
-        openItem.hydrateStub({
-          copy: () => this.copyOpenItem(openItem),
-        });
-        if (this.props.className) {
-          openItem.addClassName(this.props.className);
-        }
-        this.registerCloseListener(item, openItem);
-
-        this.setState(prevState => ({
-          currentlyOpen: [...prevState.currentlyOpen, openItem],
-        }));
+      if (!item._getStub) {
+        return;
       }
+      const stub = item._getStub();
+
+      if (stub.getRealItem() !== null) {
+        return;
+      }
+
+      const match = this.state.uriPattern.matches(item.getURI());
+      if (!match.ok()) {
+        return;
+      }
+
+      const openItem = new OpenItem(match, stub.getElement(), stub);
+      openItem.hydrateStub({
+        copy: () => this.copyOpenItem(openItem),
+      });
+      if (this.props.className) {
+        openItem.addClassName(this.props.className);
+      }
+      this.registerCloseListener(item, openItem);
+
+      this.setState(prevState => ({
+        currentlyOpen: [...prevState.currentlyOpen, openItem],
+      }));
     }));
 
     for (const openItem of this.state.currentlyOpen) {

--- a/test/atom/pane-item.test.js
+++ b/test/atom/pane-item.test.js
@@ -309,5 +309,21 @@ describe('PaneItem', function() {
 
       assert.isTrue(stub.getElement().classList.contains('added'));
     });
+
+    it('adopts StubItems that are deserialized after the package has been initialized', function() {
+      const wrapper = mount(
+        <PaneItem workspace={workspace} uriPattern="atom-github://pattern/root/{id}">
+          {({params, itemHolder}) => <Component ref={itemHolder.setter} text={params.id} />}
+        </PaneItem>,
+      );
+
+      const stub = StubItem.create('some-component', {title: 'Component'}, 'atom-github://pattern/root/45');
+      workspace.getActivePane().addItem(stub);
+
+      wrapper.update();
+
+      assert.isTrue(wrapper.exists('Component[text="45"]'));
+      assert.strictEqual(stub.getText(), '45');
+    });
   });
 });

--- a/test/atom/pane-item.test.js
+++ b/test/atom/pane-item.test.js
@@ -319,11 +319,9 @@ describe('PaneItem', function() {
 
       const stub = StubItem.create('some-component', {title: 'Component'}, 'atom-github://pattern/root/45');
       workspace.getActivePane().addItem(stub);
-
       wrapper.update();
 
       assert.isTrue(wrapper.exists('Component[text="45"]'));
-      assert.strictEqual(stub.getText(), '45');
     });
   });
 });


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

We use `StubItems` to temporarily deserialize React-managed pane items, like the git or GitHub tabs, before the React tree is initialized and actually renders DOM elements within them to make them useful. The `<PaneItem>` component handles the logic of finding and "hydrating" any stubs that were deserialized from persisted workspace state on Atom launch. However, it's possible that StubItems will be deserialized directly into the workspace _after_ the package is initialized, and `<PaneItem>` will never find them!

As a result, a user who opens a project after Atom has been launched - for example, from the `File -> Reopen Project` menu - will be stuck with blank stub panels until they close and re-open the items.

To fix this, let's watch newly added pane items on the workspace, detect when they're stubs that we don't already own, and hydrate them anyway.

### Screenshot/Gif

_Before:_

![blank-stub](https://user-images.githubusercontent.com/17565/76106850-52178a00-5f9d-11ea-96fd-ff911ebd65a4.png)

_After:_

(TBD)

### Alternate Designs

I'd love to revisit the way that `StubItems` work... I think we could simplify that way that they're created and managed to have a single "Item" class that's used consistently regardless of whether the item was opened through the `<PaneItem>`-registered opener function or deserialized from project state. That's a heavier change though and I feel like it'd risk introducing more regressions than it would fix, so I'm preferring the band-aid fix for now.

### Benefits

At least one class of scenarios that would result in orphaned, blank StubItems will be patched.

### Possible Drawbacks

We'll need to do more work on each pane item opening. This could result in performance impacts when large numbers of items are open, although I'll try to avoid it.

### Applicable Issues

Fixes #2414.

### Metrics

_N/A_

### Tests

Following the verification steps in the linked issue, and adding unit tests.

### Documentation

_N/A_

### Release Notes

* Fixed a bug that would result in the Git and GitHub tabs being blank when deserialized from project state.

### User Experience Research (Optional)

_N/A_