### PR TITLE
Hide git and GitHub tab avatar alt text when offline

### DIFF
--- a/styles/project.less
+++ b/styles/project.less
@@ -15,6 +15,8 @@
     width: 23px;
     height: 23px;
     border-radius: @component-border-radius;
+    color: transparent;
+    overflow: hidden;
   }
 
   &-lock.btn {


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Add CSS to hide the alt text for the avatar image in the Git tab when the network is not available.

Same problem as #1528, same solution as #2066. Thanks again @rkbhochalya :smile:

### Screenshot/Gif

![non-loaded avatar](https://user-images.githubusercontent.com/17565/78402719-11755580-75c9-11ea-8818-435a3099d5e2.png)

### Alternate Designs

I looked into a few other ways to provide custom fallback images so we could use a local "blank avatar" image when applicable. Too much effort for too little benefit, though.

### Benefits

The git tab header's layout won't break when the alt text overflows out of the avatar image's bounds.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #2410.

### Release Notes

* The alt text on your avatar in the Git tab no longer overflows when you're offline.
