### PR TITLE
Create repository for single file

### DIFF
--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -549,6 +549,29 @@ export default class GithubPackage {
    * projects and pane items.
    */
   async getNextContext(usePath = null) {
+    // Internal utility function to normalize paths not contained within a git
+    // working tree.
+    const workdirForNonGitPath = async sourcePath => {
+      const containingRoot = this.project.getDirectories().find(root => root.contains(sourcePath));
+      if (containingRoot) {
+        return containingRoot.getPath();
+      /* istanbul ignore else */
+      } else if (!(await fs.stat(sourcePath)).isDirectory()) {
+        return path.dirname(sourcePath);
+      } else {
+        return sourcePath;
+      }
+    };
+
+    // Internal utility function to identify the working directory to use for
+    // an arbitrary (file or directory) path.
+    const workdirForPath = async sourcePath => {
+      return (await Promise.all([
+        this.workdirCache.find(sourcePath),
+        workdirForNonGitPath(sourcePath),
+      ])).find(Boolean);
+    };
+
     // Identify paths that *could* contribute a git working directory to the pool. This is drawn from
     // the roots of open projects, the currently locked context if one is present, and the path of the
     // open workspace item.
@@ -560,19 +583,8 @@ export default class GithubPackage {
         candidatePaths.add(lockedRepo.getWorkingDirectoryPath());
       }
     }
-    let activeItemPath = pathForPaneItem(this.workspace.getCenter().getActivePaneItem());
+    const activeItemPath = pathForPaneItem(this.workspace.getCenter().getActivePaneItem());
     if (activeItemPath) {
-      // Normalize the active item path.
-      // * if it belongs to a known project root, use the known project root.
-      // * if it isn't a directory, use its containing directory.
-      const containingRoot = this.project.getDirectories().find(root => root.contains(activeItemPath));
-      if (containingRoot) {
-        activeItemPath = containingRoot.getPath();
-      /* istanbul ignore else */
-      } else if (!(await fs.stat(activeItemPath)).isDirectory()) {
-        activeItemPath = path.dirname(activeItemPath);
-      }
-
       candidatePaths.add(activeItemPath);
     }
 
@@ -585,7 +597,8 @@ export default class GithubPackage {
     const workdirs = new Set(
       await Promise.all(
         Array.from(candidatePaths, async candidatePath => {
-          const workdir = (await this.workdirCache.find(candidatePath)) || candidatePath;
+          const workdir = await workdirForPath(candidatePath);
+
           // Note the workdirs associated with the active pane item and the first open project so we can
           // prefer them later.
           if (candidatePath === activeItemPath) {
@@ -593,6 +606,7 @@ export default class GithubPackage {
           } else if (candidatePath === this.project.getPaths()[0]) {
             firstProjectWorkdir = workdir;
           }
+
           return workdir;
         }),
       ),
@@ -605,16 +619,16 @@ export default class GithubPackage {
     //     deserialized from package state. Choose this context only if it still exists in the pool.
     if (usePath) {
       // Normalize usePath in a similar fashion to the way we do activeItemPath.
-      let normalizedUsePath = usePath;
-      const containingRoot = this.project.getDirectories().find(root => root.contains(normalizedUsePath));
-      if (containingRoot) {
-        normalizedUsePath = containingRoot.getPath();
-      /* istanbul ignore else */
-      } else if (!(await fs.stat(normalizedUsePath)).isDirectory()) {
-        normalizedUsePath = path.dirname(normalizedUsePath);
+      let useWorkdir = usePath;
+      if (usePath === activeItemPath) {
+        useWorkdir = activeItemWorkdir;
+      } else if (usePath === this.project.getPaths()[0]) {
+        useWorkdir = firstProjectWorkdir;
+      } else {
+        useWorkdir = await workdirForPath(usePath);
       }
 
-      const stateContext = this.contextPool.getContext(normalizedUsePath);
+      const stateContext = this.contextPool.getContext(useWorkdir);
       if (stateContext.isPresent()) {
         return stateContext;
       }

--- a/lib/github-package.js
+++ b/lib/github-package.js
@@ -560,8 +560,19 @@ export default class GithubPackage {
         candidatePaths.add(lockedRepo.getWorkingDirectoryPath());
       }
     }
-    const activeItemPath = pathForPaneItem(this.workspace.getCenter().getActivePaneItem());
+    let activeItemPath = pathForPaneItem(this.workspace.getCenter().getActivePaneItem());
     if (activeItemPath) {
+      // Normalize the active item path.
+      // * if it belongs to a known project root, use the known project root.
+      // * if it isn't a directory, use its containing directory.
+      const containingRoot = this.project.getDirectories().find(root => root.contains(activeItemPath));
+      if (containingRoot) {
+        activeItemPath = containingRoot.getPath();
+      /* istanbul ignore else */
+      } else if (!(await fs.stat(activeItemPath)).isDirectory()) {
+        activeItemPath = path.dirname(activeItemPath);
+      }
+
       candidatePaths.add(activeItemPath);
     }
 
@@ -593,7 +604,17 @@ export default class GithubPackage {
     // 1 - Explicitly requested workdir. This is either selected by the user from a context tile or
     //     deserialized from package state. Choose this context only if it still exists in the pool.
     if (usePath) {
-      const stateContext = this.contextPool.getContext(usePath);
+      // Normalize usePath in a similar fashion to the way we do activeItemPath.
+      let normalizedUsePath = usePath;
+      const containingRoot = this.project.getDirectories().find(root => root.contains(normalizedUsePath));
+      if (containingRoot) {
+        normalizedUsePath = containingRoot.getPath();
+      /* istanbul ignore else */
+      } else if (!(await fs.stat(normalizedUsePath)).isDirectory()) {
+        normalizedUsePath = path.dirname(normalizedUsePath);
+      }
+
+      const stateContext = this.contextPool.getContext(normalizedUsePath);
       if (stateContext.isPresent()) {
         return stateContext;
       }

--- a/test/github-package.test.js
+++ b/test/github-package.test.js
@@ -455,6 +455,29 @@ describe('GithubPackage', function() {
           assert.strictEqual(githubPackage.getActiveWorkdir(), workdirPath2);
         });
 
+        it('uses a context associated with a project root for paths within that root', async function() {
+          const workdirPath4 = await getTempDir();
+          await fs.mkdir(path.join(workdirPath4, 'subdir'));
+          const itemPath4 = path.join(workdirPath4, 'subdir/file.txt');
+          await fs.writeFile(itemPath4, 'content\n');
+
+          await contextUpdateAfter(githubPackage, () => project.setPaths([workdirPath1, workdirPath4]));
+
+          assert.strictEqual(githubPackage.getActiveWorkdir(), workdirPath1);
+          await contextUpdateAfter(githubPackage, () => atomEnv.workspace.open(itemPath4));
+          assert.strictEqual(githubPackage.getActiveWorkdir(), workdirPath4);
+        });
+
+        it('uses a context of the containing directory for file item paths not in any root', async function() {
+          const workdirPath4 = await getTempDir();
+          const itemPath4 = path.join(workdirPath4, 'file.txt');
+          await fs.writeFile(itemPath4, 'content\n');
+
+          assert.strictEqual(githubPackage.getActiveWorkdir(), workdirPath1);
+          await contextUpdateAfter(githubPackage, () => atomEnv.workspace.open(itemPath4));
+          assert.strictEqual(githubPackage.getActiveWorkdir(), workdirPath4);
+        });
+
         it('does nothing if the context is locked', async function() {
           const itemPath2 = path.join(workdirPath2, 'c.txt');
 


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Modify the way that active pane item paths are used to influence the active context paths. Specifically:

* If the item path is not within a beneath one of the open project roots, use that project root instead.
* If the item path is not a directory, use its containing directory.

### Screenshot/Gif

_N/A_

### Alternate Designs

_N/A_

### Benefits

The "repository path" derived from paths within non-git-working-directory project roots will behave more predictably. (This path is used by the "create repository" blank state of the git and GitHub tabs, for example.)

Previously, if you:

* Opened a (non-git) project root `/some/root`
* Opened a file within a subdirectory of it (`/some/root/subdir/a.txt`)
* Opened the Git tab.

The Git tab would previously prompt you to initialize a repo at `/some/root/subdir/a.txt`, which doesn't make any sense and would fail. After this change, it would prompt you to initialize at `/some/root` instead.

Similarly, if you opened a path `/a/long/path/b.txt` that was outside of any git working directory, you'd be prompted to initialize at `/a/long/path/b.txt, but now you'll be prompted to initialize at `/a/long/path`.

### Possible Drawbacks

We don't _officially_ support submodules... but this will likely mess them up further, by preventing you from ever having a submodule as an active path if its parent repo was a project root. I'll investigate how badly it fails before I merge this.

Update: it did indeed break the ability to perform operations within submodules. I've rewritten it to only normalize workdir candidate paths that _don't_ map to git workdirs, which lets us have the best of both worlds.

### Applicable Issues

Fixes #2240.

### Release Notes

* The GitHub package will no longer offer to initialize git repositories at non-directory paths.