### PR TITLE
Bump CI host images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
 
 - job: MacOS
   pool:
-    vmImage: macos-10.13
+    vmImage: macos-10.14
   variables:
     atom_channel: dev
     atom_app: Atom Dev.app

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,71 +99,71 @@ jobs:
       summaryFileLocation: $(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml
       reportDirectory: $(System.DefaultworkingDirectory)/coverage/
     condition: succeededOrFailed()
-
-- job: Windows
-  pool:
-    vmImage: vs2017-win2016
-  variables:
-    atom_channel: dev
-    atom_directory: Atom Dev
-  steps:
-  - template: script/azure-pipelines/windows-install.yml
-    parameters:
-      atom_channel: $(atom_channel)
-      atom_directory: $(atom_directory)
-  - powershell: |
-      Set-StrictMode -Version Latest
-      $script:ATOMROOT = "$env:AGENT_HOMEDIRECTORY/atom"
-      $script:ATOM_SCRIPT_PATH = "$script:ATOMROOT\$env:ATOM_DIRECTORY\resources\cli\atom.cmd"
-
-      # Normalize %TEMP% as a long (non 8.3) path.
-      $env:TEMP = (Get-Item -LiteralPath $env:TEMP).FullName
-
-      $env:ELECTRON_NO_ATTACH_CONSOLE = "true"
-      [Environment]::SetEnvironmentVariable("ELECTRON_NO_ATTACH_CONSOLE", "true", "User")
-      $env:ELECTRON_ENABLE_LOGGING = "YES"
-      [Environment]::SetEnvironmentVariable("ELECTRON_ENABLE_LOGGING", "YES", "User")
-
-      Write-Host "Running tests"
-      & "$script:ATOM_SCRIPT_PATH" --test test 2>&1 | %{ "$_" }
-
-      if ($LASTEXITCODE -ne 0) {
-        Write-Host "Specs Failed"
-        $host.SetShouldExit($LASTEXITCODE)
-        exit
-      }
-    displayName: run tests
-    env:
-      TEST_JUNIT_XML_PATH: $(Agent.HomeDirectory)/test-results.xml
-      ATOM_GITHUB_BABEL_ENV: coverage
-      ATOM_GITHUB_SKIP_SYMLINKS: 1
-      FORCE_COLOR: 0
-      MOCHA_TIMEOUT: 60000
-      UNTIL_TIMEOUT: 30000
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      testResultsFiles: $(Agent.HomeDirectory)/test-results.xmlq
-      testRunTitle: Windows $(atom_channel)
-    condition: succeededOrFailed()
-  - powershell: npm run report:coverage
-    displayName: generate code coverage reports
-    condition: succeededOrFailed()
-  - bash: >
-      bash <(curl -s https://codecov.io/bash)
-      -n "Windows $(atom_channel)"
-      -P "${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-}"
-      -B "${SYSTEM_PULLREQUEST_SOURCEBRANCH:-${BUILD_SOURCEBRANCH}}"
-    displayName: publish code coverage to CodeCov
-    env:
-      CODECOV_TOKEN: $(codecov.token)
-    condition: succeededOrFailed()
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codeCoverageTool: cobertura
-      summaryFileLocation: $(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml
-      reportDirectory: $(System.DefaultworkingDirectory)/coverage/
-    condition: succeededOrFailed()
+#
+# - job: Windows
+#   pool:
+#     vmImage: vs2017-win2016
+#   variables:
+#     atom_channel: dev
+#     atom_directory: Atom Dev
+#   steps:
+#   - template: script/azure-pipelines/windows-install.yml
+#     parameters:
+#       atom_channel: $(atom_channel)
+#       atom_directory: $(atom_directory)
+#   - powershell: |
+#       Set-StrictMode -Version Latest
+#       $script:ATOMROOT = "$env:AGENT_HOMEDIRECTORY/atom"
+#       $script:ATOM_SCRIPT_PATH = "$script:ATOMROOT\$env:ATOM_DIRECTORY\resources\cli\atom.cmd"
+#
+#       # Normalize %TEMP% as a long (non 8.3) path.
+#       $env:TEMP = (Get-Item -LiteralPath $env:TEMP).FullName
+#
+#       $env:ELECTRON_NO_ATTACH_CONSOLE = "true"
+#       [Environment]::SetEnvironmentVariable("ELECTRON_NO_ATTACH_CONSOLE", "true", "User")
+#       $env:ELECTRON_ENABLE_LOGGING = "YES"
+#       [Environment]::SetEnvironmentVariable("ELECTRON_ENABLE_LOGGING", "YES", "User")
+#
+#       Write-Host "Running tests"
+#       & "$script:ATOM_SCRIPT_PATH" --test test 2>&1 | %{ "$_" }
+#
+#       if ($LASTEXITCODE -ne 0) {
+#         Write-Host "Specs Failed"
+#         $host.SetShouldExit($LASTEXITCODE)
+#         exit
+#       }
+#     displayName: run tests
+#     env:
+#       TEST_JUNIT_XML_PATH: $(Agent.HomeDirectory)/test-results.xml
+#       ATOM_GITHUB_BABEL_ENV: coverage
+#       ATOM_GITHUB_SKIP_SYMLINKS: 1
+#       FORCE_COLOR: 0
+#       MOCHA_TIMEOUT: 60000
+#       UNTIL_TIMEOUT: 30000
+#   - task: PublishTestResults@2
+#     inputs:
+#       testResultsFormat: JUnit
+#       testResultsFiles: $(Agent.HomeDirectory)/test-results.xmlq
+#       testRunTitle: Windows $(atom_channel)
+#     condition: succeededOrFailed()
+#   - powershell: npm run report:coverage
+#     displayName: generate code coverage reports
+#     condition: succeededOrFailed()
+#   - bash: >
+#       bash <(curl -s https://codecov.io/bash)
+#       -n "Windows $(atom_channel)"
+#       -P "${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-}"
+#       -B "${SYSTEM_PULLREQUEST_SOURCEBRANCH:-${BUILD_SOURCEBRANCH}}"
+#     displayName: publish code coverage to CodeCov
+#     env:
+#       CODECOV_TOKEN: $(codecov.token)
+#     condition: succeededOrFailed()
+#   - task: PublishCodeCoverageResults@1
+#     inputs:
+#       codeCoverageTool: cobertura
+#       summaryFileLocation: $(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml
+#       reportDirectory: $(System.DefaultworkingDirectory)/coverage/
+#     condition: succeededOrFailed()
 
 - job: Lint
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,7 @@ jobs:
 
 - job: Windows
   pool:
-    vmImage: vs2015-win2012r2
+    vmImage: vs2017-win2016
   variables:
     atom_channel: dev
     atom_directory: Atom Dev

--- a/script/azure-pipelines/windows-install.yml
+++ b/script/azure-pipelines/windows-install.yml
@@ -4,6 +4,9 @@ parameters:
 
 steps:
 - powershell: |
+    Write-Host "Installing windows build tools"
+    npm install --global --production windows-build-tools
+- powershell: |
     Set-StrictMode -Version Latest
     $script:ATOMROOT = "$env:AGENT_HOMEDIRECTORY/atom"
 

--- a/script/azure-pipelines/windows-install.yml
+++ b/script/azure-pipelines/windows-install.yml
@@ -4,9 +4,6 @@ parameters:
 
 steps:
 - powershell: |
-    Write-Host "Installing windows build tools"
-    npm install --global --production windows-build-tools
-- powershell: |
     Set-StrictMode -Version Latest
     $script:ATOMROOT = "$env:AGENT_HOMEDIRECTORY/atom"
 


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Get the Windows and macOS CI builds working again by bumping their CI host images to [supported ones](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops) .

### Screenshot/Gif

_N/A_

### Alternate Designs

_N/A_

### Benefits

We'll get more assurances that we aren't introducing cross-platform incompatibilities as we merge PRs.

### Possible Drawbacks

_N/A_

### Applicable Issues

_N/A_
