### PR TITLE
Git identity panel

### DIFF
--- a/lib/containers/git-tab-container.js
+++ b/lib/containers/git-tab-container.js
@@ -8,6 +8,7 @@ import ObserveModel from '../views/observe-model';
 import GitTabController from '../controllers/git-tab-controller';
 
 const DEFAULT_REPO_DATA = {
+  repository: null,
   username: '',
   email: '',
   lastCommit: nullCommit,
@@ -31,6 +32,7 @@ export default class GitTabContainer extends React.Component {
 
   fetchData = repository => {
     return yubikiri({
+      repository,
       username: repository.getConfig('user.name').then(n => n || ''),
       email: repository.getConfig('user.email').then(n => n || ''),
       lastCommit: repository.getLastCommit(),
@@ -54,7 +56,17 @@ export default class GitTabContainer extends React.Component {
   render() {
     return (
       <ObserveModel model={this.props.repository} fetchData={this.fetchData}>
-        {data => <GitTabController {...this.props} {...(data || DEFAULT_REPO_DATA)} />}
+        {data => {
+          const dataProps = data || DEFAULT_REPO_DATA;
+
+          return (
+            <GitTabController
+              {...dataProps}
+              {...this.props}
+              repositoryDrift={this.props.repository !== dataProps.repository}
+            />
+          );
+        }}
       </ObserveModel>
     );
   }

--- a/lib/containers/git-tab-container.js
+++ b/lib/containers/git-tab-container.js
@@ -28,13 +28,7 @@ export default class GitTabContainer extends React.Component {
     repository: PropTypes.object.isRequired,
   }
 
-  constructor(props) {
-    super(props);
-
-    autobind(this, 'fetchData');
-  }
-
-  fetchData(repository) {
+  fetchData = repository => {
     return yubikiri({
       lastCommit: repository.getLastCommit(),
       recentCommits: repository.getRecentCommits({max: 10}),

--- a/lib/containers/git-tab-container.js
+++ b/lib/containers/git-tab-container.js
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import yubikiri from 'yubikiri';
 
-import {autobind} from '../helpers';
 import {nullCommit} from '../models/commit';
 import {nullBranch} from '../models/branch';
 import ObserveModel from '../views/observe-model';
 import GitTabController from '../controllers/git-tab-controller';
 
 const DEFAULT_REPO_DATA = {
+  username: '',
+  email: '',
   lastCommit: nullCommit,
   recentCommits: [],
   isMerging: false,
@@ -30,6 +31,8 @@ export default class GitTabContainer extends React.Component {
 
   fetchData = repository => {
     return yubikiri({
+      username: repository.getConfig('user.name').then(n => n || ''),
+      email: repository.getConfig('user.email').then(n => n || ''),
       lastCommit: repository.getLastCommit(),
       recentCommits: repository.getRecentCommits({max: 10}),
       isMerging: repository.isMerging(),

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -36,6 +36,7 @@ export default class GitTabController extends React.Component {
     mergeMessage: PropTypes.string,
     fetchInProgress: PropTypes.bool.isRequired,
     currentWorkDir: PropTypes.string,
+    repositoryDrift: PropTypes.bool.isRequired,
 
     workspace: PropTypes.object.isRequired,
     commands: PropTypes.object.isRequired,
@@ -96,7 +97,7 @@ export default class GitTabController extends React.Component {
   static getDerivedStateFromProps(props, state) {
     return {
       editingIdentity: state.editingIdentity ||
-        (!props.fetchInProgress && !props.repository.showGitTabLoading()) &&
+        (!props.fetchInProgress && !props.repository.showGitTabLoading() && !props.repositoryDrift) &&
         (props.username === '' || props.email === ''),
     };
   }

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -2,6 +2,8 @@ import path from 'path';
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import {TextBuffer} from 'atom';
+import {CompositeDisposable} from 'event-kit';
 
 import GitTabView from '../views/git-tab-view';
 import UserStore from '../models/user-store';
@@ -19,6 +21,8 @@ export default class GitTabController extends React.Component {
     repository: PropTypes.object.isRequired,
     loginModel: PropTypes.object.isRequired,
 
+    username: PropTypes.string.isRequired,
+    email: PropTypes.string.isRequired,
     lastCommit: CommitPropType.isRequired,
     recentCommits: PropTypes.arrayOf(CommitPropType).isRequired,
     isMerging: PropTypes.bool.isRequired,
@@ -69,13 +73,32 @@ export default class GitTabController extends React.Component {
 
     this.state = {
       selectedCoAuthors: [],
+      editingIdentity: false,
     };
+
+    this.usernameBuffer = new TextBuffer({text: props.username});
+    this.usernameBuffer.retain();
+    this.emailBuffer = new TextBuffer({text: props.email});
+    this.emailBuffer.retain();
 
     this.userStore = new UserStore({
       repository: this.props.repository,
       login: this.props.loginModel,
       config: this.props.config,
     });
+
+    this.subs = new CompositeDisposable(
+      this.usernameBuffer.onDidStopChanging(this.setUsername),
+      this.emailBuffer.onDidStopChanging(this.setEmail),
+    );
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    return {
+      editingIdentity: state.editingIdentity ||
+        (!props.fetchInProgress && !props.repository.showGitTabLoading()) &&
+        (props.username === '' || props.email === ''),
+    };
   }
 
   render() {
@@ -86,8 +109,11 @@ export default class GitTabController extends React.Component {
         refStagingView={this.refStagingView}
 
         isLoading={this.props.fetchInProgress}
+        editingIdentity={this.state.editingIdentity}
         repository={this.props.repository}
 
+        usernameBuffer={this.usernameBuffer}
+        emailBuffer={this.emailBuffer}
         lastCommit={this.props.lastCommit}
         recentCommits={this.props.recentCommits}
         isMerging={this.props.isMerging}
@@ -113,6 +139,8 @@ export default class GitTabController extends React.Component {
         confirm={this.props.confirm}
         config={this.props.config}
 
+        toggleIdentityEditor={this.toggleIdentityEditor}
+        closeIdentityEditor={this.closeIdentityEditor}
         openInitializeDialog={this.props.openInitializeDialog}
         openFiles={this.props.openFiles}
         discardWorkDirChangesForPaths={this.props.discardWorkDirChangesForPaths}
@@ -148,10 +176,18 @@ export default class GitTabController extends React.Component {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     this.userStore.setRepository(this.props.repository);
     this.userStore.setLoginModel(this.props.loginModel);
     this.refreshResolutionProgress(false, false);
+
+    if (prevProps.username !== this.props.username) {
+      this.usernameBuffer.setTextViaDiff(this.props.username);
+    }
+
+    if (prevProps.email !== this.props.email) {
+      this.emailBuffer.setTextViaDiff(this.props.email);
+    }
   }
 
   componentWillUnmount() {
@@ -329,6 +365,14 @@ export default class GitTabController extends React.Component {
   rememberLastFocus = event => {
     this.lastFocus = this.refView.map(view => view.getFocus(event.target)).getOr(null) || GitTabView.focus.STAGING;
   }
+
+  toggleIdentityEditor = () => this.setState(before => ({editingIdentity: !before.editingIdentity}))
+
+  closeIdentityEditor = () => this.setState({editingIdentity: false})
+
+  setUsername = () => this.props.repository.setConfig('user.name', this.usernameBuffer.getText(), {global: true})
+
+  setEmail = () => this.props.repository.setConfig('user.email', this.emailBuffer.getText(), {global: true})
 
   restoreFocus() {
     this.refView.map(view => view.setFocus(this.lastFocus));

--- a/lib/controllers/git-tab-controller.js
+++ b/lib/controllers/git-tab-controller.js
@@ -9,7 +9,6 @@ import RefHolder from '../models/ref-holder';
 import {
   CommitPropType, BranchPropType, FilePatchItemPropType, MergeConflictItemPropType, RefHolderPropType,
 } from '../prop-types';
-import {autobind} from '../helpers';
 
 export default class GitTabController extends React.Component {
   static focus = {
@@ -60,12 +59,6 @@ export default class GitTabController extends React.Component {
 
   constructor(props, context) {
     super(props, context);
-    autobind(
-      this,
-      'attemptStageAllOperation', 'attemptFileStageOperation', 'unstageFiles', 'prepareToCommit',
-      'commit', 'updateSelectedCoAuthors', 'undoLastCommit', 'abortMerge', 'resolveAsOurs', 'resolveAsTheirs',
-      'checkout', 'rememberLastFocus', 'quietlySelectItem',
-    );
 
     this.stagingOperationInProgress = false;
     this.lastFocus = GitTabView.focus.STAGING;
@@ -199,11 +192,11 @@ export default class GitTabController extends React.Component {
     }
   }
 
-  attemptStageAllOperation(stageStatus) {
+  attemptStageAllOperation = stageStatus => {
     return this.attemptFileStageOperation(['.'], stageStatus);
   }
 
-  attemptFileStageOperation(filePaths, stageStatus) {
+  attemptFileStageOperation = (filePaths, stageStatus) => {
     if (this.stagingOperationInProgress) {
       return {
         stageOperationPromise: Promise.resolve(),
@@ -259,15 +252,15 @@ export default class GitTabController extends React.Component {
     return this.props.repository.unstageFiles(filePaths);
   }
 
-  async prepareToCommit() {
+  prepareToCommit = async () => {
     return !await this.props.ensureGitTab();
   }
 
-  commit(message, options) {
+  commit = (message, options) => {
     return this.props.repository.commit(message, options);
   }
 
-  updateSelectedCoAuthors(selectedCoAuthors, newAuthor) {
+  updateSelectedCoAuthors = (selectedCoAuthors, newAuthor) => {
     if (newAuthor) {
       this.userStore.addUsers([newAuthor]);
       selectedCoAuthors = selectedCoAuthors.concat([newAuthor]);
@@ -275,7 +268,7 @@ export default class GitTabController extends React.Component {
     this.setState({selectedCoAuthors});
   }
 
-  async undoLastCommit() {
+  undoLastCommit = async () => {
     const repo = this.props.repository;
     const lastCommit = await repo.getLastCommit();
     if (lastCommit.isUnbornRef()) { return null; }
@@ -287,7 +280,7 @@ export default class GitTabController extends React.Component {
     return null;
   }
 
-  async abortMerge() {
+  abortMerge = async () => {
     const choice = this.props.confirm({
       message: 'Abort merge',
       detailedMessage: 'Are you sure?',
@@ -309,7 +302,7 @@ export default class GitTabController extends React.Component {
     }
   }
 
-  async resolveAsOurs(paths) {
+  resolveAsOurs = async paths => {
     if (this.props.fetchInProgress) {
       return;
     }
@@ -319,7 +312,7 @@ export default class GitTabController extends React.Component {
     this.refreshResolutionProgress(false, true);
   }
 
-  async resolveAsTheirs(paths) {
+  resolveAsTheirs = async paths => {
     if (this.props.fetchInProgress) {
       return;
     }
@@ -329,11 +322,11 @@ export default class GitTabController extends React.Component {
     this.refreshResolutionProgress(false, true);
   }
 
-  checkout(branchName, options) {
+  checkout = (branchName, options) => {
     return this.props.repository.checkout(branchName, options);
   }
 
-  rememberLastFocus(event) {
+  rememberLastFocus = event => {
     this.lastFocus = this.refView.map(view => view.getFocus(event.target)).getOr(null) || GitTabView.focus.STAGING;
   }
 

--- a/lib/controllers/git-tab-header-controller.js
+++ b/lib/controllers/git-tab-header-controller.js
@@ -16,6 +16,7 @@ export default class GitTabHeaderController extends React.Component {
     setContextLock: PropTypes.func.isRequired,
 
     // Event Handlers
+    onDidClickAvatar: PropTypes.func.isRequired,
     onDidChangeWorkDirs: PropTypes.func.isRequired,
     onDidUpdateRepo: PropTypes.func.isRequired,
   }
@@ -73,6 +74,7 @@ export default class GitTabHeaderController extends React.Component {
         changingLock={this.state.changingLock !== null}
 
         // Event Handlers
+        handleAvatarClick={this.props.onDidClickAvatar}
         handleWorkDirSelect={this.handleWorkDirSelect}
         handleLockToggle={this.handleLockToggle}
       />

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -1025,7 +1025,7 @@ export default class GitShellOutStrategy {
   setConfig(option, value, {replaceAll, global} = {}) {
     let args = ['config'];
     if (replaceAll) { args.push('--replace-all'); }
-    if (global) { args.push('--global'); }
+    if (global && !atom.inSpecMode()) { args.push('--global'); }
     args = args.concat(option, value);
     return this.exec(args, {writeOperation: true});
   }

--- a/lib/git-shell-out-strategy.js
+++ b/lib/git-shell-out-strategy.js
@@ -1022,9 +1022,10 @@ export default class GitShellOutStrategy {
     return output.trim();
   }
 
-  setConfig(option, value, {replaceAll} = {}) {
+  setConfig(option, value, {replaceAll, global} = {}) {
     let args = ['config'];
     if (replaceAll) { args.push('--replace-all'); }
+    if (global) { args.push('--global'); }
     args = args.concat(option, value);
     return this.exec(args, {writeOperation: true});
   }

--- a/lib/models/author.js
+++ b/lib/models/author.js
@@ -5,12 +5,14 @@ export const NO_REPLY_GITHUB_EMAIL = 'noreply@github.com';
 export default class Author {
   constructor(email, fullName, login = null, isNew = null, avatarUrl = null) {
     if (avatarUrl == null) {
-      const match = email.match(/^(\d+)\+[^@]+@users.noreply.github.com$/);
+      const match = (email || '').match(/^(\d+)\+[^@]+@users.noreply.github.com$/);
 
       if (match) {
         avatarUrl = 'https://avatars.githubusercontent.com/u/' + match[1] + '?s=32';
-      } else {
+      } else if (email && email !== '') {
         avatarUrl = 'https://avatars.githubusercontent.com/u/e?email=' + encodeURIComponent(email) + '&s=32';
+      } else {
+        avatarUrl = '';
       }
     }
 

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -2,6 +2,7 @@ import path from 'path';
 
 import {Emitter} from 'event-kit';
 import fs from 'fs-extra';
+import yubikiri from 'yubikiri';
 
 import {getNullActionPipelineManager} from '../action-pipeline';
 import CompositeGitStrategy from '../composite-git-strategy';
@@ -229,18 +230,10 @@ export default class Repository {
   }
 
   async getCommitter(options = {}) {
-    const output = await this.getConfig(['--get-regexp', '^user.*'], options);
-    const committer = {name: null, email: null};
-    // todo (tt, 4/2018): do we need null byte terminated output here for Windows?
-    if (output) {
-      output.trim().split('\n').forEach(line => {
-        if (line.includes('user.email')) {
-          committer.email = line.slice(11);
-        } else if (line.includes('user.name')) {
-          committer.name = line.slice(10);
-        }
-      });
-    }
+    const committer = await yubikiri({
+      email: this.getConfig('user.email', options),
+      name: this.getConfig('user.name', options),
+    });
 
     return committer.name !== null && committer.email !== null
       ? new Author(committer.email, committer.name)

--- a/lib/views/git-identity-view.js
+++ b/lib/views/git-identity-view.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import AtomTextEditor from '../atom/atom-text-editor';
+
+export default class GitIdentityView extends React.Component {
+  static propTypes = {
+    // Model
+    usernameBuffer: PropTypes.object.isRequired,
+    emailBuffer: PropTypes.object.isRequired,
+
+    // Action methods
+    close: PropTypes.func.isRequired,
+  };
+
+  render() {
+    return (
+      <div className="github-GitIdentity">
+        <h1 className="github-GitIdentity-title">
+          Git Identity
+        </h1>
+        <p className="github-GitIdentity-explanation">
+          Please set the username and email address that you wish to use to
+          author git commits.
+        </p>
+        <div className="github-GitIdentity-text">
+          <AtomTextEditor mini placeholderText="name" buffer={this.props.usernameBuffer} />
+          <AtomTextEditor mini placeholderText="email address" buffer={this.props.emailBuffer} />
+        </div>
+        <div className="github-GitIdentity-buttons">
+          <button className="btn btn-primary" onClick={this.props.close}>Continue</button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/lib/views/git-identity-view.js
+++ b/lib/views/git-identity-view.js
@@ -27,7 +27,12 @@ export default class GitIdentityView extends React.Component {
           <AtomTextEditor mini placeholderText="email address" buffer={this.props.emailBuffer} />
         </div>
         <div className="github-GitIdentity-buttons">
-          <button className="btn btn-primary" onClick={this.props.close}>Continue</button>
+          <button
+            className="btn btn-primary"
+            onClick={this.props.close}
+            disabled={this.props.usernameBuffer.isEmpty() || this.props.emailBuffer.isEmpty()}>
+            Continue
+          </button>
         </div>
       </div>
     );

--- a/lib/views/git-tab-header-view.js
+++ b/lib/views/git-tab-header-view.js
@@ -17,6 +17,7 @@ export default class GitTabHeaderView extends React.Component {
     changingLock: PropTypes.bool.isRequired,
 
     // Event Handlers
+    handleAvatarClick: PropTypes.func,
     handleWorkDirSelect: PropTypes.func,
     handleLockToggle: PropTypes.func,
   }
@@ -60,11 +61,13 @@ export default class GitTabHeaderView extends React.Component {
     const name = this.props.committer.getFullName();
 
     return (
-      <img className="github-Project-avatar"
-        src={avatarUrl || 'atom://github/img/avatar.svg'}
-        title={`${name} ${email}`}
-        alt={`${name}'s avatar`}
-      />
+      <button className="github-Project-avatarBtn" onClick={this.props.handleAvatarClick}>
+        <img className="github-Project-avatar"
+          src={avatarUrl || 'atom://github/img/avatar.svg'}
+          title={`${name} ${email}`}
+          alt={`${name}'s avatar`}
+        />
+      </button>
     );
   }
 }

--- a/lib/views/git-tab-view.js
+++ b/lib/views/git-tab-view.js
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import {CompositeDisposable} from 'atom';
 
 import StagingView from './staging-view';
+import GitIdentityView from './git-identity-view';
 import GitTabHeaderController from '../controllers/git-tab-header-controller';
 import CommitController from '../controllers/commit-controller';
 import RecentCommitsController from '../controllers/recent-commits-controller';
@@ -24,7 +25,10 @@ export default class GitTabView extends React.Component {
 
     repository: PropTypes.object.isRequired,
     isLoading: PropTypes.bool.isRequired,
+    editingIdentity: PropTypes.bool.isRequired,
 
+    usernameBuffer: PropTypes.object.isRequired,
+    emailBuffer: PropTypes.object.isRequired,
     lastCommit: PropTypes.object.isRequired,
     currentBranch: PropTypes.object,
     recentCommits: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -49,6 +53,8 @@ export default class GitTabView extends React.Component {
     project: PropTypes.object.isRequired,
     tooltips: PropTypes.object.isRequired,
 
+    toggleIdentityEditor: PropTypes.func.isRequired,
+    closeIdentityEditor: PropTypes.func.isRequired,
     openInitializeDialog: PropTypes.func.isRequired,
     abortMerge: PropTypes.func.isRequired,
     commit: PropTypes.func.isRequired,
@@ -94,7 +100,9 @@ export default class GitTabView extends React.Component {
     let renderMethod = 'renderNormal';
     let isEmpty = false;
     let isLoading = false;
-    if (this.props.repository.isTooLarge()) {
+    if (this.props.editingIdentity) {
+      renderMethod = 'renderIdentityView';
+    } else if (this.props.repository.isTooLarge()) {
       renderMethod = 'renderTooLarge';
       isEmpty = true;
     } else if (this.props.repository.hasDirectory() &&
@@ -133,6 +141,7 @@ export default class GitTabView extends React.Component {
         setContextLock={this.props.setContextLock}
 
         // Event Handlers
+        onDidClickAvatar={this.props.toggleIdentityEditor}
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
         onDidUpdateRepo={repository.onDidUpdate.bind(repository)}
       />
@@ -250,6 +259,16 @@ export default class GitTabView extends React.Component {
             ? 'Creating repository...' : 'Create repository'}
         </button>
       </div>
+    );
+  }
+
+  renderIdentityView() {
+    return (
+      <GitIdentityView
+        usernameBuffer={this.props.usernameBuffer}
+        emailBuffer={this.props.emailBuffer}
+        close={this.props.closeIdentityEditor}
+      />
     );
   }
 

--- a/styles/git-identity.less
+++ b/styles/git-identity.less
@@ -1,0 +1,30 @@
+// Styles for the Git Identity view.
+
+.github-GitIdentity {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: @component-padding;
+
+  &-title {
+    margin-bottom: @component-padding;
+  }
+
+  &-explanation {
+    margin-bottom: @component-padding * 3;
+  }
+
+  &-text {
+    width: 90%;
+    margin-bottom: @component-padding * 3;
+
+    .github-AtomTextEditor-container {
+      margin: @component-padding/2 0;
+    }
+  }
+
+  &-buttons {
+    //
+  }
+}

--- a/styles/project.less
+++ b/styles/project.less
@@ -11,6 +11,15 @@
     margin-left: @component-padding;
   }
 
+  &-avatarBtn {
+    height: 23px;
+    width: 23px;
+    padding: 0;
+    border-radius: @component-border-radius;
+    background-color: @pane-item-background-color;
+    border: none;
+  }
+
   &-avatar {
     width: 23px;
     height: 23px;

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -95,6 +95,108 @@ describe('GitTabController', function() {
     assert.isFalse(refreshResolutionProgress.calledWith(path.join(workdirPath, 'added-to-both.txt')));
   });
 
+  describe('identity editor', function() {
+    it('is not shown while loading data', async function() {
+      const repository = await buildRepository(await cloneRepository('three-files'));
+      const wrapper = mount(await buildApp(repository, {
+        fetchInProgress: true,
+        username: '',
+        email: '',
+      }));
+
+      assert.isFalse(wrapper.find('GitTabView').prop('editingIdentity'));
+    });
+
+    it('is shown by default when username or email are empty', async function() {
+      const repository = await buildRepository(await cloneRepository('three-files'));
+      const wrapper = mount(await buildApp(repository, {
+        username: '',
+        email: 'not@empty.com',
+      }));
+
+      assert.isTrue(wrapper.find('GitTabView').prop('editingIdentity'));
+    });
+
+    it('is toggled on and off with toggleIdentityEditor', async function() {
+      const repository = await buildRepository(await cloneRepository('three-files'));
+      const wrapper = mount(await buildApp(repository));
+
+      assert.isFalse(wrapper.find('GitTabView').prop('editingIdentity'));
+
+      wrapper.find('GitTabView').prop('toggleIdentityEditor')();
+      wrapper.update();
+
+      assert.isTrue(wrapper.find('GitTabView').prop('editingIdentity'));
+
+      wrapper.find('GitTabView').prop('toggleIdentityEditor')();
+      wrapper.update();
+
+      assert.isFalse(wrapper.find('GitTabView').prop('editingIdentity'));
+    });
+
+    it('is toggled off with closeIdentityEditor', async function() {
+      const repository = await buildRepository(await cloneRepository('three-files'));
+      const wrapper = mount(await buildApp(repository));
+
+      assert.isFalse(wrapper.find('GitTabView').prop('editingIdentity'));
+
+      wrapper.find('GitTabView').prop('toggleIdentityEditor')();
+      wrapper.update();
+
+      assert.isTrue(wrapper.find('GitTabView').prop('editingIdentity'));
+
+      wrapper.find('GitTabView').prop('closeIdentityEditor')();
+      wrapper.update();
+
+      assert.isFalse(wrapper.find('GitTabView').prop('editingIdentity'));
+
+      wrapper.find('GitTabView').prop('closeIdentityEditor')();
+      wrapper.update();
+
+      assert.isFalse(wrapper.find('GitTabView').prop('editingIdentity'));
+    });
+
+    it('synchronizes buffer contents with fetched properties', async function() {
+      const repository = await buildRepository(await cloneRepository('three-files'));
+      const wrapper = mount(await buildApp(repository, {
+        username: 'initial',
+        email: 'initial@email.com',
+      }));
+
+      const usernameBuffer = wrapper.find('GitTabView').prop('usernameBuffer');
+      const emailBuffer = wrapper.find('GitTabView').prop('emailBuffer');
+
+      assert.strictEqual(usernameBuffer.getText(), 'initial');
+      assert.strictEqual(emailBuffer.getText(), 'initial@email.com');
+
+      usernameBuffer.setText('initial+');
+      emailBuffer.setText('initial+@email.com');
+
+      wrapper.setProps({
+        username: 'changed',
+        email: 'changed@email.com',
+      });
+
+      assert.strictEqual(wrapper.find('GitTabView').prop('usernameBuffer'), usernameBuffer);
+      assert.strictEqual(usernameBuffer.getText(), 'changed');
+      assert.strictEqual(wrapper.find('GitTabView').prop('emailBuffer'), emailBuffer);
+      assert.strictEqual(emailBuffer.getText(), 'changed@email.com');
+
+      usernameBuffer.setText('changed+');
+      emailBuffer.setText('changed+@email.com');
+
+      wrapper.setProps({
+        username: 'changed',
+        email: 'changed@email.com',
+      });
+
+      assert.strictEqual(wrapper.find('GitTabView').prop('usernameBuffer'), usernameBuffer);
+      assert.strictEqual(usernameBuffer.getText(), 'changed+');
+      assert.strictEqual(wrapper.find('GitTabView').prop('emailBuffer'), emailBuffer);
+      assert.strictEqual(emailBuffer.getText(), 'changed+@email.com');
+    });
+  });
+
   describe('abortMerge()', function() {
     it('resets merge related state', async function() {
       const workdirPath = await cloneRepository('merge-conflict');

--- a/test/controllers/git-tab-controller.test.js
+++ b/test/controllers/git-tab-controller.test.js
@@ -107,6 +107,18 @@ describe('GitTabController', function() {
       assert.isFalse(wrapper.find('GitTabView').prop('editingIdentity'));
     });
 
+    it('is not shown when the repository is out of sync', async function() {
+      const repository = await buildRepository(await cloneRepository('three-files'));
+      const wrapper = mount(await buildApp(repository, {
+        fetchInProgress: false,
+        username: '',
+        email: '',
+        repositoryDrift: true,
+      }));
+
+      assert.isFalse(wrapper.find('GitTabView').prop('editingIdentity'));
+    });
+
     it('is shown by default when username or email are empty', async function() {
       const repository = await buildRepository(await cloneRepository('three-files'));
       const wrapper = mount(await buildApp(repository, {

--- a/test/controllers/git-tab-header-controller.test.js
+++ b/test/controllers/git-tab-header-controller.test.js
@@ -20,6 +20,7 @@ describe('GitTabHeaderController', function() {
       changeWorkingDirectory: () => {},
       contextLocked: false,
       setContextLock: () => {},
+      onDidClickAvatar: () => {},
       onDidChangeWorkDirs: () => new Disposable(),
       onDidUpdateRepo: () => new Disposable(),
       ...overrides,

--- a/test/fixtures/props/git-tab-props.js
+++ b/test/fixtures/props/git-tab-props.js
@@ -1,3 +1,5 @@
+import {TextBuffer} from 'atom';
+
 import ResolutionProgress from '../../../lib/models/conflicts/resolution-progress';
 import {InMemoryStrategy} from '../../../lib/shared/keytar-strategy';
 import GithubLoginModel from '../../../lib/models/github-login-model';
@@ -67,7 +69,10 @@ export async function gitTabViewProps(atomEnv, repository, overrides = {}) {
 
     repository,
     isLoading: false,
+    editingIdentity: false,
 
+    usernameBuffer: new TextBuffer(),
+    emailBuffer: new TextBuffer(),
     lastCommit: await repository.getLastCommit(),
     currentBranch: await repository.getCurrentBranch(),
     recentCommits: await repository.getRecentCommits({max: 10}),
@@ -91,6 +96,8 @@ export async function gitTabViewProps(atomEnv, repository, overrides = {}) {
     project: atomEnv.project,
     tooltips: atomEnv.tooltips,
 
+    toggleIdentityEditor: () => {},
+    closeIdentityEditor: () => {},
     openInitializeDialog: () => {},
     abortMerge: () => {},
     commit: () => {},

--- a/test/fixtures/props/git-tab-props.js
+++ b/test/fixtures/props/git-tab-props.js
@@ -13,6 +13,8 @@ export function gitTabItemProps(atomEnv, repository, overrides = {}) {
   return {
     repository,
     loginModel: new GithubLoginModel(InMemoryStrategy),
+    username: 'Me',
+    email: 'me@email.com',
     workspace: atomEnv.workspace,
     commands: atomEnv.commands,
     grammars: atomEnv.grammars,

--- a/test/fixtures/props/git-tab-props.js
+++ b/test/fixtures/props/git-tab-props.js
@@ -56,6 +56,7 @@ export async function gitTabControllerProps(atomEnv, repository, overrides = {})
     mergeConflicts: await repository.getMergeConflicts(),
     workingDirectoryPath: repository.getWorkingDirectoryPath(),
     fetchInProgress: false,
+    repositoryDrift: false,
     ...overrides,
   };
 

--- a/test/integration/file-patch.test.js
+++ b/test/integration/file-patch.test.js
@@ -41,6 +41,14 @@ describe('integration: file patches', function() {
     repoRoot = atomEnv.project.getPaths()[0];
     git = new GitShellOutStrategy(repoRoot);
 
+    const identity = await Promise.all(
+      ['user.name', 'user.email'].map(setting => git.getConfig(setting)),
+    );
+    if (!identity.every(Boolean)) {
+      await git.setConfig('user.name', 'Git Integration Tests');
+      await git.setConfig('user.email', 'atom@github.com');
+    }
+
     usesWorkspaceObserver = context.githubPackage.getContextPool().getContext(repoRoot).useWorkspaceChangeObserver();
 
     workspaceElement = atomEnv.views.getView(workspace);

--- a/test/integration/file-patch.test.js
+++ b/test/integration/file-patch.test.js
@@ -41,14 +41,6 @@ describe('integration: file patches', function() {
     repoRoot = atomEnv.project.getPaths()[0];
     git = new GitShellOutStrategy(repoRoot);
 
-    const identity = await Promise.all(
-      ['user.name', 'user.email'].map(setting => git.getConfig(setting)),
-    );
-    if (!identity.every(Boolean)) {
-      await git.setConfig('user.name', 'Git Integration Tests');
-      await git.setConfig('user.email', 'atom@github.com');
-    }
-
     usesWorkspaceObserver = context.githubPackage.getContextPool().getContext(repoRoot).useWorkspaceChangeObserver();
 
     workspaceElement = atomEnv.views.getView(workspace);

--- a/test/models/author.test.js
+++ b/test/models/author.test.js
@@ -32,9 +32,13 @@ describe('Author', function() {
   it('creates the correct avatar urls', function() {
     const a0 = new Author('same@same.com', 'Zero');
     const a1 = new Author('0000000+testing@users.noreply.github.com', 'One');
+    const a2 = new Author('', 'Blank Email');
+    const a3 = new Author(null, 'Null Email');
 
     assert.strictEqual('https://avatars.githubusercontent.com/u/e?email=same%40same.com&s=32', a0.getAvatarUrl());
     assert.strictEqual('https://avatars.githubusercontent.com/u/0000000?s=32', a1.getAvatarUrl());
+    assert.strictEqual('', a2.getAvatarUrl());
+    assert.strictEqual('', a3.getAvatarUrl());
     assert.strictEqual('', nullAuthor.getAvatarUrl());
   });
 

--- a/test/models/user-store.test.js
+++ b/test/models/user-store.test.js
@@ -25,12 +25,13 @@ describe('UserStore', function() {
     atomEnv.destroy();
   });
 
-  function nextUpdatePromise() {
+  function nextUpdatePromise(during = () => {}) {
     return new Promise(resolve => {
       const sub = store.onDidUpdate(() => {
         sub.dispose();
         resolve();
       });
+      during();
     });
   }
 
@@ -290,10 +291,8 @@ describe('UserStore', function() {
     const newEmail = 'foo@bar.com';
     const newName = 'Foo Bar';
 
-    await repository.setConfig('user.email', newEmail);
     await repository.setConfig('user.name', newName);
-    repository.refresh();
-    await nextUpdatePromise();
+    await nextUpdatePromise(() => repository.setConfig('user.email', newEmail));
 
     assert.deepEqual(store.committer, new Author(newEmail, newName));
   });

--- a/test/views/git-identity-view.test.js
+++ b/test/views/git-identity-view.test.js
@@ -30,9 +30,25 @@ describe('GitIdentityView', function() {
     assert.strictEqual(getEditor('email address').prop('buffer'), emailBuffer);
   });
 
+  it('disables the "Continue" button if the name is blank', function() {
+    const usernameBuffer = new TextBuffer();
+    const wrapper = mount(buildApp({usernameBuffer}));
+
+    assert.isTrue(wrapper.find('.btn').prop('disabled'));
+  });
+
+  it('disables the "Continue" button if the email is blank', function() {
+    const emailBuffer = new TextBuffer();
+    const wrapper = mount(buildApp({emailBuffer}));
+
+    assert.isTrue(wrapper.find('.btn').prop('disabled'));
+  });
+
   it('triggers a callback when "Continue" is clicked', function() {
+    const usernameBuffer = new TextBuffer({text: 'Me'});
+    const emailBuffer = new TextBuffer({text: 'me@email.com'});
     const close = sinon.spy();
-    const wrapper = mount(buildApp({close}));
+    const wrapper = mount(buildApp({usernameBuffer, emailBuffer, close}));
 
     wrapper.find('.btn').simulate('click');
 

--- a/test/views/git-identity-view.test.js
+++ b/test/views/git-identity-view.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {TextBuffer} from 'atom';
+
+import GitIdentityView from '../../lib/views/git-identity-view';
+
+describe('GitIdentityView', function() {
+  function buildApp(override = {}) {
+    return (
+      <GitIdentityView
+        usernameBuffer={new TextBuffer()}
+        emailBuffer={new TextBuffer()}
+        close={() => {}}
+        {...override}
+      />
+    );
+  }
+
+  it('displays buffers for username and email entry', function() {
+    const usernameBuffer = new TextBuffer();
+    const emailBuffer = new TextBuffer();
+
+    const wrapper = mount(buildApp({usernameBuffer, emailBuffer}));
+
+    function getEditor(placeholderText) {
+      return wrapper.find(`AtomTextEditor[placeholderText="${placeholderText}"]`);
+    }
+
+    assert.strictEqual(getEditor('name').prop('buffer'), usernameBuffer);
+    assert.strictEqual(getEditor('email address').prop('buffer'), emailBuffer);
+  });
+
+  it('triggers a callback when "Continue" is clicked', function() {
+    const close = sinon.spy();
+    const wrapper = mount(buildApp({close}));
+
+    wrapper.find('.btn').simulate('click');
+
+    assert.isTrue(close.called);
+  });
+});

--- a/test/views/git-tab-header-view.test.js
+++ b/test/views/git-tab-header-view.test.js
@@ -20,6 +20,7 @@ describe('GitTabHeaderView', function() {
       contextLocked: false,
       changingWorkDir: false,
       changingLock: false,
+      handleAvatarClick: () => {},
       handleWorkDirSelect: () => {},
       handleLockToggle: () => {},
       ...options,
@@ -59,6 +60,14 @@ describe('GitTabHeaderView', function() {
     });
   });
 
+  it('triggers the handler callback on avatar button click', function() {
+    const handleAvatarClick = sinon.spy();
+    const wrapper = build({handleAvatarClick});
+
+    wrapper.find('.github-Project-avatarBtn').simulate('click');
+    assert.isTrue(handleAvatarClick.called);
+  });
+
   describe('context lock control', function() {
     it('renders locked when the lock is engaged', function() {
       const wrapper = build({contextLocked: true});
@@ -76,7 +85,7 @@ describe('GitTabHeaderView', function() {
       const handleLockToggle = sinon.spy();
       const wrapper = build({handleLockToggle});
 
-      wrapper.find('button').simulate('click');
+      wrapper.find('.github-Project-lock').simulate('click');
       assert.isTrue(handleLockToggle.called);
     });
   });
@@ -91,7 +100,7 @@ describe('GitTabHeaderView', function() {
     it('disables the context lock toggle while the context lock is changing', function() {
       const wrapper = build({changingLock: true});
 
-      assert.isTrue(wrapper.find('button').prop('disabled'));
+      assert.isTrue(wrapper.find('.github-Project-lock').prop('disabled'));
     });
   });
 

--- a/test/views/git-tab-view.test.js
+++ b/test/views/git-tab-view.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
+import {TextBuffer} from 'atom';
 
 import {cloneRepository, buildRepository} from '../helpers';
 import GitTabView from '../../lib/views/git-tab-view';
@@ -219,6 +220,20 @@ describe('GitTabView', function() {
 
       assert.isFalse(event.stopPropagation.called);
     });
+  });
+
+  it('renders the identity panel when requested', async function() {
+    const usernameBuffer = new TextBuffer();
+    const emailBuffer = new TextBuffer();
+    const wrapper = shallow(await buildApp({
+      editingIdentity: true,
+      usernameBuffer,
+      emailBuffer,
+    }));
+
+    assert.isTrue(wrapper.exists('GitIdentityView'));
+    assert.strictEqual(wrapper.find('GitIdentityView').prop('usernameBuffer'), usernameBuffer);
+    assert.strictEqual(wrapper.find('GitIdentityView').prop('emailBuffer'), emailBuffer);
   });
 
   it('selects a staging item', async function() {


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Display and edit the values of `git config user.email` and `git config user.name` in an interstitial panel in the Git tab. The Identity panel is shown automatically if either are blank (which would prevent you from performing most git operations successfully anyway). Otherwise, it can be triggered manually by clicking on your avatar image in the Git tab header.

### Screenshot

![identity panel](https://user-images.githubusercontent.com/17565/78504681-ad739e00-773c-11ea-9fbc-00fee75a7d61.png)

### Alternate Designs

Some nice-to-haves that I opted not to include in this effort:

* Pre-fill with values from your GitHub account after you authenticate on the GitHub tab.
* Easily anonymize your email by [setting a `+noreply` address](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address#setting-your-commit-email-address-on-github).
* Flip between a set of known account values in some kind of "recently used" list.
* Control whether the config settings are local (per-repository) or global. (As written, this always writes to your global config.)

### Benefits

This unblocks one of the biggest pieces of missing functionality in the "getting started" path. Setting these values is necessary for doing anything related to git, but requires either a separate local git installation or hand-editing a config file in a way that isn't well communicated.

With this in place, it will be possible to download Atom onto an otherwise vanilla machine and get started working with version control.

### Possible Drawbacks

I still anticipate a fair amount of confusion related to the differences among:

* Your **git identity**, the username and email address used in the metadata of commits written by git
* The **GitHub OAuth token** you authenticate on the GitHub tab to get, which is used by this package to make API requests on your behalf, _and_ to push and fetch git changes to https remotes
* Your **SSH key** and **stored git credentials** used to push and fetch git changes to remotes

These are three different things and can all be changed independently! I'd love to find a way to unify them somehow, at least by default, or better communicate which is applicable where.

### Applicable Issues

Fixes #932 at long last. The next big chunk of #1934.

### Release Notes

* If `user.email` or `user.name` are not set, the Git tab will prompt for them to be populated.
* Click your avatar in the Git tab to modify the `user.email` and `user.name` used to author git commits.