### PR TITLE
Give dialog text editors room to expand

### DIFF
--- a/styles/dialog.less
+++ b/styles/dialog.less
@@ -147,6 +147,7 @@
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
+  width: 100%;
 
   &-owner {
     flex: 1;
@@ -253,6 +254,7 @@
     label {
       display: flex;
       align-items: center;
+      width: 100%;
 
       .github-AtomTextEditor-container {
         flex: 1;


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

Supply missing `width: 100%` styles to give TextEditors in dialog boxes room to fill.

### Screenshot

| Dialog | Before | After |
| -- | -- | -- |
| Create | <img width="645" alt="create-before" src="https://user-images.githubusercontent.com/17565/79125010-6f453280-7d6b-11ea-88d9-f52502f957a1.png"> |<img width="642" alt="create-after" src="https://user-images.githubusercontent.com/17565/79125029-753b1380-7d6b-11ea-9e6e-34a438f002bd.png"> |
| Publish | <img width="652" alt="publish-before" src="https://user-images.githubusercontent.com/17565/79125050-7cfab800-7d6b-11ea-92b5-80318612fddc.png"> | <img width="655" alt="publish-after" src="https://user-images.githubusercontent.com/17565/79125067-83892f80-7d6b-11ea-988c-370152cfe6f8.png"> |

### Applicable Issues

Fixes #2433.

### Release Notes

* Corrected an issue where text boxes in the "create repository" and "publish repository" dialogs were too short to enter text.