### PR TITLE
Scroll to first conflict when opening editor

### DIFF
--- a/lib/controllers/editor-conflict-controller.js
+++ b/lib/controllers/editor-conflict-controller.js
@@ -48,6 +48,8 @@ export default class EditorConflictController extends React.Component {
       this.props.editor.onDidDestroy(() => this.props.refreshResolutionProgress(this.props.editor.getPath())),
       buffer.onDidReload(() => this.reparseConflicts()),
     );
+
+    this.scrollToFirstConflict();
   }
 
   render() {
@@ -217,6 +219,19 @@ export default class EditorConflictController extends React.Component {
     });
 
     this.updateMarkerCount();
+  }
+
+  scrollToFirstConflict() {
+    let firstConflict = null;
+    for (const conflict of this.state.conflicts) {
+      if (firstConflict == null || firstConflict.getRange().compare(conflict.getRange()) > 0) {
+        firstConflict = conflict;
+      }
+    }
+
+    if (firstConflict) {
+      this.props.editor.scrollToBufferPosition(firstConflict.getRange().start, {center: true});
+    }
   }
 
   reparseConflicts() {

--- a/test/controllers/editor-conflict-controller.test.js
+++ b/test/controllers/editor-conflict-controller.test.js
@@ -3,6 +3,7 @@ import temp from 'temp';
 import path from 'path';
 import React from 'react';
 import {mount} from 'enzyme';
+import {Point} from 'atom';
 
 import ResolutionProgress from '../../lib/models/conflicts/resolution-progress';
 import {OURS, BASE, THEIRS} from '../../lib/models/conflicts/source';
@@ -48,7 +49,7 @@ describe('EditorConflictController', function() {
     atomEnv.destroy();
   });
 
-  const useFixture = async function(fixtureName, {isRebase} = {isRebase: false}) {
+  const useFixture = async function(fixtureName, {isRebase, withEditor} = {isRebase: false}) {
     const fixturePath = path.join(
       path.dirname(__filename), '..', 'fixtures', 'conflict-marker-examples', fixtureName);
     const tempDir = temp.mkdirSync('conflict-fixture-');
@@ -56,6 +57,9 @@ describe('EditorConflictController', function() {
     fs.copySync(fixturePath, fixtureFile);
 
     editor = await workspace.open(fixtureFile);
+    if (withEditor) {
+      withEditor(editor);
+    }
     editorView = atomEnv.views.getView(editor);
 
     app = (
@@ -74,6 +78,14 @@ describe('EditorConflictController', function() {
   const textFromSide = function(side) {
     return editor.getTextInBufferRange(side.marker.getBufferRange());
   };
+
+  it('scrolls the first conflict into view', async function() {
+    await useFixture('triple-2way-diff.txt', {
+      withEditor(e) { sinon.stub(e, 'scrollToBufferPosition'); },
+    });
+
+    expect(editor.scrollToBufferPosition.calledWith(new Point(4, 0), {center: true}));
+  });
 
   describe('on a file with 2-way diff markers', function() {
     let conflicts;

--- a/test/controllers/editor-conflict-controller.test.js
+++ b/test/controllers/editor-conflict-controller.test.js
@@ -84,7 +84,7 @@ describe('EditorConflictController', function() {
       withEditor(e) { sinon.stub(e, 'scrollToBufferPosition'); },
     });
 
-    expect(editor.scrollToBufferPosition.calledWith(new Point(4, 0), {center: true}));
+    assert.isTrue(editor.scrollToBufferPosition.calledWith(new Point(4, 0), {center: true}));
   });
 
   describe('on a file with 2-way diff markers', function() {


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

When opening an editor on a path that contains recognized conflict markers, scroll to center the first conflict in the file.

### Applicable Issues

Fixes #1580.

### Release Notes

* When opening a file containing merge conflict markers, the first conflict will be scrolled into view.