### PR TITLE
script/redownload-electron-bins.js: Fix finding the Atom repo's package.json

### DIFF
--- a/script/redownload-electron-bins.js
+++ b/script/redownload-electron-bins.js
@@ -13,7 +13,7 @@ if (typeof(downloadMksnapshotPath) !== 'undefined') {
   const fs = require('fs');
 
   const atomRepoPath = path.join('..', '..', '..', '..', 'atom', 'package.json');
-  const electronVersion = fs.existsSync(atomRepoPath) ? require(atomrepoPath).electronVersion : '6.1.12'
+  const electronVersion = fs.existsSync(atomRepoPath) ? require(atomRepoPath).electronVersion : '6.1.12'
   // TODO: Keep the above "electronVersion" in sync with "electronVersion" from Atom's package.json
 
   if (process.env.ELECTRON_CUSTOM_VERSION !== electronVersion) {

--- a/script/redownload-electron-bins.js
+++ b/script/redownload-electron-bins.js
@@ -12,7 +12,7 @@ if (typeof(downloadMksnapshotPath) !== 'undefined') {
   const path = require('path');
   const fs = require('fs');
 
-  const atomRepoPath = path.join('..', '..', '..', '..', 'atom', 'package.json');
+  const atomRepoPath = path.join(__dirname, '..', '..', '..', '..', 'atom', 'package.json');
   const electronVersion = fs.existsSync(atomRepoPath) ? require(atomRepoPath).electronVersion : '6.1.12'
   // TODO: Keep the above "electronVersion" in sync with "electronVersion" from Atom's package.json
 


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

- :bug: Construct the path to Atom's `package.json` as an absolute path, because `fs.existsSync()` and `require()` interpret relative paths differently.
- :keyboard: Fix a typo (an incorrectly capitalized variable name) that would have meant `require([path/to/Atom's/package.json])` would have errored out.

### Screenshot/Gif

<!-- If the changes are visual, add a screenshot or record a Gif. This doesn't have to be updated during implementation, but after a PR is merged, a final screenshot/gif should be added. It might get used for blog posts, documentation etc. Write "N/A" if not applicable. -->

N/A

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

N/A. These are just typo/bug fixes. The overall design was reviewed in #2513, but this small typo and bug slipped past my/the reviewer's radars at the time.

### Benefits

<!-- What benefits will be realized by the code change? -->

Fixes the original intended behavior of `script/redownload-electron-bins.js`:

When installing this package as a dependency in the Atom repo, and running this package's tests in that context, this package now installs/tests against the version of Electron specified in Atom's `package.json`. Should provide more relevant results when running the package tests in Atom's CI.

(Was falling back on a "fallback" version [hard-coded in `script/redownload-electron-bins.js`](https://github.com/atom/github/blob/ee1502b273e1fe4964f419acd9773d3a8ec742a0/script/redownload-electron-bins.js#L16).)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

N/A, these are just bug-fixes.

(I don't think I missed anything this time! This is a very small change, only 12 characters of diff.)

### Applicable Issues

<!-- Enter any applicable Issues here -->

Follow-up to #2513

### Metrics

<!-- What metrics are associated with this code change and what questions can they help us answer? Write "N/A" if not applicable. -->

N/A

### Tests

<!-- 

How did you verify that your change has the desired effects?
- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

What unit or integration tests were (or will be) added to help protect against future regressions? 
For manual testing, be sure to describe in detail the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and the results you observed.
If you chose not to include a specific test, please explain why. 

Write "N/A" if not applicable. 

-->

<details><summary> Steps to confirm that this change works (click to expand): </summary>

#### Clone this repo (with fix), positioned as if it were a dependency in the Atom repo:
- `cd` into the Atom repo.
- backup the `github` dependency if already installed.
  - `mv node_modules/github node_modules/_github_backup`
- clone this repo under Atom's main `node_modules` dir
  - `cd node_modules && git clone https://github.com/DeeDeeG/github`
- Checkout the branch with this fix
  - `cd github && git checkout fix-redownload-electron-bins`

#### Confirm the fix is working:
- In the `github` folder we just cloned, do `npm install` to install all dependencies and devDevpendencies
  - Observe that the postinstall script says it wants to download Electron "6.1.12" (or whatever is in Atom's main `package.json` as the value for `electronVersion`)
- Edit the `electronVersion` in Atom's `package.json` and run `npm install` again in the `github` folder
  - Observe that the github postinstall script wants to install the Electron version you just edited into Atom's `package.json`
- Optionally, check that the filesize of the `mksnapshot` binary changes when instaling different major versions
  - `ls -lah ./node_modules/electron-mksnapshot/bin/mksnapshot`

#### Confirm this behavior doesn't work as intended without the fix from this PR:
- Checkout the `master` branch in the `github` folder, and run `npm install` again
  - `git checkout master && npm install`
  - Observe that the postinstall script now wants to install the "6.1.12" hard-coded in `script/redownload-electron-bins.js`
- Edit the hard-coded target Electron version in `script/redownload-electron-bins.js` and run `npm install` again
  - Observe that without the fix from this PR, the hard-coded Electron version from `script/redownload-electron-bins.js` is always downloaded.

</details>

I followed these steps, and I am able to confirm this fix makes things work as I originally intended them to.

### Documentation

<!-- Describe the documentation added or improved. Write "N/A" if not applicable. -->

N/A

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where the merge message did not show up in the commit message box.
- Increased the performance of rendering diffs.

-->

N/A

### User Experience Research (Optional)

<!-- If this change would benefit from UXR, please state assumptions or hypotheses and specify if they are to be validated before or after releasing. Examples include investigating discoverability, verifying performance improvements, tracking metrics, etc. -->

None.