### PR TITLE
Catch the non-workdir error from git rev-parse

### DIFF
--- a/lib/models/workdir-cache.js
+++ b/lib/models/workdir-cache.js
@@ -38,10 +38,15 @@ export default class WorkdirCache {
       const startDir = (await fs.stat(startPath)).isDirectory() ? startPath : path.dirname(startPath);
 
       // Within a git worktree, return a non-empty string containing the path to the worktree root.
-      // Within a gitdir or outside of a worktree, return an empty string.
-      // Throw if startDir does not exist.
-      const topLevel = await CompositeGitStrategy.create(startDir).exec(['rev-parse', '--show-toplevel']);
-      if (/\S/.test(topLevel)) {
+      // Throw if a gitdir, outside of a worktree, or startDir does not exist.
+      const topLevel = await CompositeGitStrategy.create(startDir).exec(['rev-parse', '--show-toplevel'])
+        .catch(e => {
+          if (/this operation must be run in a work tree/.test(e.stdErr)) {
+            return null;
+          }
+          throw e;
+        });
+      if (topLevel !== null) {
         return toNativePathSep(topLevel.trim());
       }
 


### PR DESCRIPTION
I jumped the gun a little with the dugite bump that I just pushed. This fixes the failing test.