### PR TITLE
Increase priority of login prompt on GitHub tab

### DIFF
--- a/lib/containers/github-tab-container.js
+++ b/lib/containers/github-tab-container.js
@@ -9,7 +9,10 @@ import Refresher from '../models/refresher';
 import GitHubTabController from '../controllers/github-tab-controller';
 import ObserveModel from '../views/observe-model';
 import RemoteSet from '../models/remote-set';
+import {nullRemote} from '../models/remote';
 import BranchSet from '../models/branch-set';
+import {nullBranch} from '../models/branch';
+import {DOTCOM} from '../models/endpoint';
 
 export default class GitHubTabContainer extends React.Component {
   static propTypes = {
@@ -77,6 +80,8 @@ export default class GitHubTabContainer extends React.Component {
     });
   }
 
+  fetchToken = (loginModel, endpoint) => loginModel.getToken(endpoint.getLoginAccount());
+
   render() {
     return (
       <ObserveModel model={this.props.repository} fetchData={this.fetchRepositoryData}>
@@ -85,18 +90,47 @@ export default class GitHubTabContainer extends React.Component {
     );
   }
 
-  renderRepositoryData = data => {
-    if (!data || this.props.repository.isLoading()) {
+  renderRepositoryData = repoData => {
+    let endpoint = DOTCOM;
+
+    if (repoData) {
+      repoData.githubRemotes = repoData.allRemotes.filter(remote => remote.isGithubRepo());
+      repoData.currentBranch = repoData.branches.getHeadBranch();
+
+      repoData.currentRemote = repoData.githubRemotes.withName(repoData.selectedRemoteName);
+      repoData.manyRemotesAvailable = false;
+      if (!repoData.currentRemote.isPresent() && repoData.githubRemotes.size() === 1) {
+        repoData.currentRemote = Array.from(repoData.githubRemotes)[0];
+      } else if (!repoData.currentRemote.isPresent() && repoData.githubRemotes.size() > 1) {
+        repoData.manyRemotesAvailable = true;
+      }
+      repoData.endpoint = endpoint = repoData.currentRemote.getEndpointOrDotcom();
+    }
+
+    return (
+      <ObserveModel model={this.props.loginModel} fetchData={this.fetchToken} fetchParams={[endpoint]}>
+        {token => this.renderToken(token, repoData)}
+      </ObserveModel>
+    );
+  }
+
+  renderToken(token, repoData) {
+    if (!repoData || this.props.repository.isLoading()) {
       return (
         <GitHubTabController
           {...this.props}
           refresher={this.state.refresher}
 
           allRemotes={new RemoteSet()}
+          githubRemotes={new RemoteSet()}
+          currentRemote={nullRemote}
           branches={new BranchSet()}
+          currentBranch={nullBranch}
           aheadCount={0}
+          manyRemotesAvailable={false}
           pushInProgress={false}
           isLoading={true}
+          token={token}
         />
       );
     }
@@ -108,20 +142,26 @@ export default class GitHubTabContainer extends React.Component {
           refresher={this.state.refresher}
 
           allRemotes={new RemoteSet()}
+          githubRemotes={new RemoteSet()}
+          currentRemote={nullRemote}
           branches={new BranchSet()}
+          currentBranch={nullBranch}
           aheadCount={0}
+          manyRemotesAvailable={false}
           pushInProgress={false}
           isLoading={false}
+          token={token}
         />
       );
     }
 
     return (
       <GitHubTabController
-        {...data}
+        {...repoData}
         {...this.props}
         refresher={this.state.refresher}
         isLoading={false}
+        token={token}
       />
     );
   }

--- a/lib/containers/github-tab-header-container.js
+++ b/lib/containers/github-tab-header-container.js
@@ -2,18 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {QueryRenderer, graphql} from 'react-relay';
 
-import {EndpointPropType} from '../prop-types';
+import {EndpointPropType, TokenPropType} from '../prop-types';
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
 import {UNAUTHENTICATED, INSUFFICIENT} from '../shared/keytar-strategy';
-import ObserveModel from '../views/observe-model';
 import Author, {nullAuthor} from '../models/author';
 import GithubTabHeaderController from '../controllers/github-tab-header-controller';
 
 export default class GithubTabHeaderContainer extends React.Component {
   static propTypes = {
     // Connection
-    loginModel: PropTypes.object.isRequired,
     endpoint: EndpointPropType.isRequired,
+    token: TokenPropType,
 
     // Workspace
     currentWorkDir: PropTypes.string,
@@ -27,24 +26,16 @@ export default class GithubTabHeaderContainer extends React.Component {
   }
 
   render() {
-    return (
-      <ObserveModel model={this.props.loginModel} fetchData={this.fetchToken}>
-        {this.renderWithToken}
-      </ObserveModel>
-    );
-  }
-
-  renderWithToken = token => {
     if (
-      token == null
-      || token instanceof Error
-      || token === UNAUTHENTICATED
-      || token === INSUFFICIENT
+      this.props.token == null
+      || this.props.token instanceof Error
+      || this.props.token === UNAUTHENTICATED
+      || this.props.token === INSUFFICIENT
     ) {
       return this.renderNoResult();
     }
 
-    const environment = RelayNetworkLayerManager.getEnvironmentForHost(this.props.endpoint, token);
+    const environment = RelayNetworkLayerManager.getEnvironmentForHost(this.props.endpoint, this.props.token);
     const query = graphql`
       query githubTabHeaderContainerQuery {
         viewer {
@@ -61,12 +52,12 @@ export default class GithubTabHeaderContainer extends React.Component {
         environment={environment}
         variables={{}}
         query={query}
-        render={result => this.renderWithResult(result)}
+        render={this.renderWithResult}
       />
     );
   }
 
-  renderWithResult({error, props}) {
+  renderWithResult = ({error, props}) => {
     if (error || props === null) {
       return this.renderNoResult();
     }
@@ -107,9 +98,5 @@ export default class GithubTabHeaderContainer extends React.Component {
         onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
       />
     );
-  }
-
-  fetchToken = loginModel => {
-    return loginModel.getToken(this.props.endpoint.getLoginAccount());
   }
 }

--- a/lib/containers/remote-container.js
+++ b/lib/containers/remote-container.js
@@ -2,21 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {QueryRenderer, graphql} from 'react-relay';
 
-import {incrementCounter} from '../reporter-proxy';
-import {RemotePropType, RemoteSetPropType, BranchSetPropType, RefresherPropType, EndpointPropType} from '../prop-types';
+import {
+  RemotePropType, RemoteSetPropType, BranchSetPropType, RefresherPropType,
+  EndpointPropType, TokenPropType,
+} from '../prop-types';
 import RelayNetworkLayerManager from '../relay-network-layer-manager';
-import {UNAUTHENTICATED, INSUFFICIENT} from '../shared/keytar-strategy';
 import RemoteController from '../controllers/remote-controller';
-import ObserveModel from '../views/observe-model';
 import LoadingView from '../views/loading-view';
 import QueryErrorView from '../views/query-error-view';
-import GithubLoginView from '../views/github-login-view';
 
 export default class RemoteContainer extends React.Component {
   static propTypes = {
     // Connection
-    loginModel: PropTypes.object.isRequired,
     endpoint: EndpointPropType.isRequired,
+    token: TokenPropType.isRequired,
 
     // Repository attributes
     refresher: RefresherPropType.isRequired,
@@ -29,52 +28,13 @@ export default class RemoteContainer extends React.Component {
     aheadCount: PropTypes.number,
 
     // Action methods
+    handleLogin: PropTypes.func.isRequired,
+    handleLogout: PropTypes.func.isRequired,
     onPushBranch: PropTypes.func.isRequired,
   }
 
-  fetchToken = loginModel => {
-    return loginModel.getToken(this.props.endpoint.getLoginAccount());
-  }
-
   render() {
-    return (
-      <ObserveModel model={this.props.loginModel} fetchData={this.fetchToken}>
-        {this.renderWithToken}
-      </ObserveModel>
-    );
-  }
-
-  renderWithToken = token => {
-    if (token === null) {
-      return <LoadingView />;
-    }
-
-    if (token instanceof Error) {
-      return (
-        <QueryErrorView
-          error={token}
-          retry={this.handleTokenRetry}
-          login={this.handleLogin}
-          logout={this.handleLogout}
-        />
-      );
-    }
-
-    if (token === UNAUTHENTICATED) {
-      return <GithubLoginView onLogin={this.handleLogin} />;
-    }
-
-    if (token === INSUFFICIENT) {
-      return (
-        <GithubLoginView onLogin={this.handleLogin}>
-          <p>
-            Your token no longer has sufficient authorizations. Please re-authenticate and generate a new one.
-          </p>
-        </GithubLoginView>
-      );
-    }
-
-    const environment = RelayNetworkLayerManager.getEnvironmentForHost(this.props.endpoint, token);
+    const environment = RelayNetworkLayerManager.getEnvironmentForHost(this.props.endpoint, this.props.token);
     const query = graphql`
       query remoteContainerQuery($owner: String!, $name: String!) {
         repository(owner: $owner, name: $name) {
@@ -96,21 +56,21 @@ export default class RemoteContainer extends React.Component {
         environment={environment}
         variables={variables}
         query={query}
-        render={result => this.renderWithResult(result, token)}
+        render={this.renderWithResult}
       />
     );
   }
 
-  renderWithResult({error, props, retry}, token) {
+  renderWithResult = ({error, props, retry}) => {
     this.props.refresher.setRetryCallback(this, retry);
 
     if (error) {
       return (
         <QueryErrorView
           error={error}
-          login={this.handleLogin}
+          login={this.props.handleLogin}
+          logout={this.props.handleLogout}
           retry={retry}
-          logout={this.handleLogout}
         />
       );
     }
@@ -122,7 +82,7 @@ export default class RemoteContainer extends React.Component {
     return (
       <RemoteController
         endpoint={this.props.endpoint}
-        token={token}
+        token={this.props.token}
 
         repository={props.repository}
 
@@ -139,16 +99,4 @@ export default class RemoteContainer extends React.Component {
       />
     );
   }
-
-  handleLogin = token => {
-    incrementCounter('github-login');
-    this.props.loginModel.setToken(this.props.endpoint.getLoginAccount(), token);
-  }
-
-  handleLogout = () => {
-    incrementCounter('github-logout');
-    this.props.loginModel.removeToken(this.props.endpoint.getLoginAccount());
-  }
-
-  handleTokenRetry = () => this.props.loginModel.didUpdate();
 }

--- a/lib/controllers/github-tab-controller.js
+++ b/lib/controllers/github-tab-controller.js
@@ -2,23 +2,30 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  GithubLoginModelPropType, RefHolderPropType, RemoteSetPropType, BranchSetPropType, RefresherPropType,
+  GithubLoginModelPropType, TokenPropType, RefHolderPropType,
+  RemoteSetPropType, RemotePropType, BranchSetPropType, BranchPropType,
+  RefresherPropType,
 } from '../prop-types';
 import GitHubTabView from '../views/github-tab-view';
+import {incrementCounter} from '../reporter-proxy';
 
 export default class GitHubTabController extends React.Component {
   static propTypes = {
     workspace: PropTypes.object.isRequired,
     refresher: RefresherPropType.isRequired,
     loginModel: GithubLoginModelPropType.isRequired,
+    token: TokenPropType,
     rootHolder: RefHolderPropType.isRequired,
 
     workingDirectory: PropTypes.string,
     repository: PropTypes.object.isRequired,
     allRemotes: RemoteSetPropType.isRequired,
+    githubRemotes: RemoteSetPropType.isRequired,
+    currentRemote: RemotePropType.isRequired,
     branches: BranchSetPropType.isRequired,
-    selectedRemoteName: PropTypes.string,
-    aheadCount: PropTypes.number,
+    currentBranch: BranchPropType.isRequired,
+    aheadCount: PropTypes.number.isRequired,
+    manyRemotesAvailable: PropTypes.bool.isRequired,
     pushInProgress: PropTypes.bool.isRequired,
     isLoading: PropTypes.bool.isRequired,
     currentWorkDir: PropTypes.string,
@@ -35,21 +42,11 @@ export default class GitHubTabController extends React.Component {
   }
 
   render() {
-    const gitHubRemotes = this.props.allRemotes.filter(remote => remote.isGithubRepo());
-    const currentBranch = this.props.branches.getHeadBranch();
-
-    let currentRemote = gitHubRemotes.withName(this.props.selectedRemoteName);
-    let manyRemotesAvailable = false;
-    if (!currentRemote.isPresent() && gitHubRemotes.size() === 1) {
-      currentRemote = Array.from(gitHubRemotes)[0];
-    } else if (!currentRemote.isPresent() && gitHubRemotes.size() > 1) {
-      manyRemotesAvailable = true;
-    }
-
     return (
       <GitHubTabView
         // Connection
-        loginModel={this.props.loginModel}
+        endpoint={this.currentEndpoint()}
+        token={this.props.token}
 
         workspace={this.props.workspace}
         refresher={this.props.refresher}
@@ -59,14 +56,17 @@ export default class GitHubTabController extends React.Component {
         contextLocked={this.props.contextLocked}
         repository={this.props.repository}
         branches={this.props.branches}
-        currentBranch={currentBranch}
-        remotes={gitHubRemotes}
-        currentRemote={currentRemote}
-        manyRemotesAvailable={manyRemotesAvailable}
+        currentBranch={this.props.currentBranch}
+        remotes={this.props.githubRemotes}
+        currentRemote={this.props.currentRemote}
+        manyRemotesAvailable={this.props.manyRemotesAvailable}
         aheadCount={this.props.aheadCount}
         pushInProgress={this.props.pushInProgress}
         isLoading={this.props.isLoading}
 
+        handleLogin={this.handleLogin}
+        handleLogout={this.handleLogout}
+        handleTokenRetry={this.handleTokenRetry}
         handlePushBranch={this.handlePushBranch}
         handleRemoteSelect={this.handleRemoteSelect}
         changeWorkingDirectory={this.props.changeWorkingDirectory}
@@ -94,4 +94,20 @@ export default class GitHubTabController extends React.Component {
   }
 
   openBoundPublishDialog = () => this.props.openPublishDialog(this.props.repository);
+
+  handleLogin = token => {
+    incrementCounter('github-login');
+    this.props.loginModel.setToken(this.currentEndpoint().getLoginAccount(), token);
+  }
+
+  handleLogout = () => {
+    incrementCounter('github-logout');
+    this.props.loginModel.removeToken(this.currentEndpoint().getLoginAccount());
+  }
+
+  handleTokenRetry = () => this.props.loginModel.didUpdate();
+
+  currentEndpoint() {
+    return this.props.currentRemote.getEndpointOrDotcom();
+  }
 }

--- a/lib/controllers/remote-controller.js
+++ b/lib/controllers/remote-controller.js
@@ -2,9 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {shell} from 'electron';
 
-import {autobind} from '../helpers';
 import {incrementCounter} from '../reporter-proxy';
-import {RemotePropType, RemoteSetPropType, BranchSetPropType, EndpointPropType} from '../prop-types';
+import {RemotePropType, RemoteSetPropType, BranchSetPropType, EndpointPropType, TokenPropType} from '../prop-types';
 import IssueishSearchesController from './issueish-searches-controller';
 
 export default class RemoteController extends React.Component {
@@ -20,7 +19,7 @@ export default class RemoteController extends React.Component {
 
     // Connection
     endpoint: EndpointPropType.isRequired,
-    token: PropTypes.string.isRequired,
+    token: TokenPropType.isRequired,
 
     // Repository derived attributes
     workingDirectory: PropTypes.string,
@@ -33,11 +32,6 @@ export default class RemoteController extends React.Component {
 
     // Actions
     onPushBranch: PropTypes.func.isRequired,
-  }
-
-  constructor(props) {
-    super(props);
-    autobind(this, 'onCreatePr');
   }
 
   render() {
@@ -61,7 +55,7 @@ export default class RemoteController extends React.Component {
     );
   }
 
-  async onCreatePr() {
+  onCreatePr = async () => {
     const currentBranch = this.props.branches.getHeadBranch();
     const upstream = currentBranch.getUpstream();
     if (!upstream.isPresent() || this.props.aheadCount > 0) {

--- a/lib/models/endpoint.js
+++ b/lib/models/endpoint.js
@@ -30,11 +30,11 @@ class Endpoint {
 }
 
 // API endpoint for GitHub.com
-const dotcomEndpoint = new Endpoint('github.com', 'api.github.com', []);
+export const DOTCOM = new Endpoint('github.com', 'api.github.com', []);
 
 export function getEndpoint(host) {
   if (host === 'github.com') {
-    return dotcomEndpoint;
+    return DOTCOM;
   } else {
     return new Endpoint(host, host, ['api', 'v3']);
   }

--- a/lib/models/remote.js
+++ b/lib/models/remote.js
@@ -1,4 +1,4 @@
-import {getEndpoint} from './endpoint';
+import {getEndpoint, DOTCOM} from './endpoint';
 
 export default class Remote {
   constructor(name, url) {
@@ -55,6 +55,10 @@ export default class Remote {
 
   getEndpoint() {
     return this.domain === null ? null : getEndpoint(this.domain);
+  }
+
+  getEndpointOrDotcom() {
+    return this.getEndpoint() || DOTCOM;
   }
 
   isPresent() {
@@ -133,6 +137,10 @@ export const nullRemote = {
 
   getEndpoint() {
     return null;
+  },
+
+  getEndpointOrDotcom() {
+    return DOTCOM;
   },
 
   isPresent() {

--- a/lib/models/repository-states/state.js
+++ b/lib/models/repository-states/state.js
@@ -364,11 +364,11 @@ export default class State {
   }
 
   getAheadCount(branchName) {
-    return Promise.resolve(null);
+    return Promise.resolve(0);
   }
 
   getBehindCount(branchName) {
-    return Promise.resolve(null);
+    return Promise.resolve(0);
   }
 
   getConfig(optionName, options) {

--- a/lib/prop-types.js
+++ b/lib/prop-types.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 
+export const TokenPropType = PropTypes.oneOfType([PropTypes.string, PropTypes.symbol, PropTypes.instanceOf(Error)]);
+
 export const DOMNodePropType = (props, propName, componentName) => {
   if (props[propName] instanceof HTMLElement) {
     return null;

--- a/lib/views/github-tab-view.js
+++ b/lib/views/github-tab-view.js
@@ -2,18 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  GithubLoginModelPropType, RefHolderPropType, RemoteSetPropType, RemotePropType, BranchSetPropType, BranchPropType,
+  TokenPropType, EndpointPropType, RefHolderPropType,
+  RemoteSetPropType, RemotePropType, BranchSetPropType, BranchPropType,
   RefresherPropType,
 } from '../prop-types';
 import LoadingView from './loading-view';
+import QueryErrorView from '../views/query-error-view';
+import GithubLoginView from '../views/github-login-view';
 import RemoteSelectorView from './remote-selector-view';
 import GithubTabHeaderContainer from '../containers/github-tab-header-container';
-import GithubTabHeaderController from '../controllers/github-tab-header-controller';
 import GitHubBlankNoLocal from './github-blank-nolocal';
 import GitHubBlankUninitialized from './github-blank-uninitialized';
 import GitHubBlankNoRemote from './github-blank-noremote';
 import RemoteContainer from '../containers/remote-container';
-import {nullAuthor} from '../models/author';
+import {UNAUTHENTICATED, INSUFFICIENT} from '../shared/keytar-strategy';
 
 export default class GitHubTabView extends React.Component {
   static propTypes = {
@@ -21,7 +23,8 @@ export default class GitHubTabView extends React.Component {
     rootHolder: RefHolderPropType.isRequired,
 
     // Connection
-    loginModel: GithubLoginModelPropType.isRequired,
+    endpoint: EndpointPropType.isRequired,
+    token: TokenPropType,
 
     // Workspace
     workspace: PropTypes.object.isRequired,
@@ -43,6 +46,9 @@ export default class GitHubTabView extends React.Component {
     pushInProgress: PropTypes.bool.isRequired,
 
     // Event Handlers
+    handleLogin: PropTypes.func.isRequired,
+    handleLogout: PropTypes.func.isRequired,
+    handleTokenRetry: PropTypes.func.isRequired,
     handleWorkDirSelect: PropTypes.func,
     handlePushBranch: PropTypes.func.isRequired,
     handleRemoteSelect: PropTypes.func.isRequired,
@@ -65,6 +71,35 @@ export default class GitHubTabView extends React.Component {
   }
 
   renderRemote() {
+    if (this.props.token === null) {
+      return <LoadingView />;
+    }
+
+    if (this.props.token === UNAUTHENTICATED) {
+      return <GithubLoginView onLogin={this.props.handleLogin} />;
+    }
+
+    if (this.props.token === INSUFFICIENT) {
+      return (
+        <GithubLoginView onLogin={this.props.handleLogin}>
+          <p>
+            Your token no longer has sufficient authorizations. Please re-authenticate and generate a new one.
+          </p>
+        </GithubLoginView>
+      );
+    }
+
+    if (this.props.token instanceof Error) {
+      return (
+        <QueryErrorView
+          error={this.props.token}
+          retry={this.props.handleTokenRetry}
+          login={this.props.handleLogin}
+          logout={this.props.handleLogout}
+        />
+      );
+    }
+
     if (this.props.isLoading) {
       return <LoadingView />;
     }
@@ -92,22 +127,22 @@ export default class GitHubTabView extends React.Component {
       return (
         <RemoteContainer
           // Connection
-          loginModel={this.props.loginModel}
           endpoint={this.props.currentRemote.getEndpoint()}
+          token={this.props.token}
 
-          // Workspace
-          workspace={this.props.workspace}
+          // Repository attributes
+          refresher={this.props.refresher}
+          pushInProgress={this.props.pushInProgress}
           workingDirectory={this.props.workingDirectory}
-
-          // Remote
+          workspace={this.props.workspace}
           remote={this.props.currentRemote}
           remotes={this.props.remotes}
           branches={this.props.branches}
           aheadCount={this.props.aheadCount}
-          pushInProgress={this.props.pushInProgress}
-          refresher={this.props.refresher}
 
-          // Event Handlers
+          // Action methods
+          handleLogin={this.props.handleLogin}
+          handleLogout={this.props.handleLogout}
           onPushBranch={() => this.props.handlePushBranch(this.props.currentBranch, this.props.currentRemote)}
         />
       );
@@ -130,29 +165,11 @@ export default class GitHubTabView extends React.Component {
   }
 
   renderHeader() {
-    if (this.props.currentRemote.isPresent()) {
-      return (
-        <GithubTabHeaderContainer
-          // Connection
-          loginModel={this.props.loginModel}
-          endpoint={this.props.currentRemote.getEndpoint()}
-
-          // Workspace
-          currentWorkDir={this.props.workingDirectory}
-          contextLocked={this.props.contextLocked}
-          changeWorkingDirectory={this.props.changeWorkingDirectory}
-          setContextLock={this.props.setContextLock}
-          getCurrentWorkDirs={this.props.getCurrentWorkDirs}
-
-          // Event Handlers
-          // handleWorkDirSelect={e => this.props.changeWorkingDirectory(e.target.value)}
-          onDidChangeWorkDirs={this.props.onDidChangeWorkDirs}
-        />
-      );
-    }
     return (
-      <GithubTabHeaderController
-        user={nullAuthor}
+      <GithubTabHeaderContainer
+        // Connection
+        endpoint={this.props.endpoint}
+        token={this.props.token}
 
         // Workspace
         currentWorkDir={this.props.workingDirectory}

--- a/test/containers/github-tab-container.test.js
+++ b/test/containers/github-tab-container.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount, shallow} from 'enzyme';
+import {shallow} from 'enzyme';
 
 import {buildRepository, cloneRepository} from '../helpers';
 import GitHubTabContainer from '../../lib/containers/github-tab-container';

--- a/test/containers/github-tab-container.test.js
+++ b/test/containers/github-tab-container.test.js
@@ -7,6 +7,10 @@ import GitHubTabController from '../../lib/controllers/github-tab-controller';
 import Repository from '../../lib/models/repository';
 import {InMemoryStrategy} from '../../lib/shared/keytar-strategy';
 import GithubLoginModel from '../../lib/models/github-login-model';
+import Remote from '../../lib/models/remote';
+import RemoteSet from '../../lib/models/remote-set';
+import Branch, {nullBranch} from '../../lib/models/branch';
+import BranchSet from '../../lib/models/branch-set';
 import RefHolder from '../../lib/models/ref-holder';
 
 describe('GitHubTabContainer', function() {
@@ -37,6 +41,7 @@ describe('GitHubTabContainer', function() {
         repository={repository}
         loginModel={new GithubLoginModel(InMemoryStrategy)}
         rootHolder={new RefHolder()}
+        contextLocked={false}
 
         changeWorkingDirectory={() => {}}
         onDidChangeWorkDirs={() => {}}
@@ -45,6 +50,7 @@ describe('GitHubTabContainer', function() {
         openPublishDialog={() => {}}
         openCloneDialog={() => {}}
         openGitTab={() => {}}
+        setContextLock={() => {}}
 
         {...props}
       />
@@ -72,10 +78,11 @@ describe('GitHubTabContainer', function() {
 
     beforeEach(function() {
       wrapper = shallow(buildApp());
-      const childWrapper = wrapper.find('ObserveModel').renderProp('children')(defaultRepositoryData);
+      const repoWrapper = wrapper.find('ObserveModel').renderProp('children')(defaultRepositoryData);
+      const tokenWrapper = repoWrapper.find('ObserveModel').renderProp('children')('1234');
 
       retry = sinon.spy();
-      const refresher = childWrapper.find(GitHubTabController).prop('refresher');
+      const refresher = tokenWrapper.find(GitHubTabController).prop('refresher');
       refresher.setRetryCallback(Symbol('key'), retry);
 
       stubRepository(repository);
@@ -106,6 +113,13 @@ describe('GitHubTabContainer', function() {
       assert.isTrue(retry.called);
     });
 
+    it('preserves the observer when the repository is unchanged', function() {
+      wrapper.setProps({});
+
+      simulateOperation(repository, 'fetch');
+      assert.isTrue(retry.called);
+    });
+
     it('un-observes the repository when unmounting', function() {
       wrapper.unmount();
 
@@ -114,25 +128,152 @@ describe('GitHubTabContainer', function() {
     });
   });
 
+  describe('before loading', function() {
+    it('passes isLoading to the controller', async function() {
+      const loadingRepo = new Repository(await cloneRepository());
+      const wrapper = shallow(buildApp({repository: loadingRepo}));
+      const repoWrapper = wrapper.find('ObserveModel').renderProp('children')(null);
+      const tokenWrapper = repoWrapper.find('ObserveModel').renderProp('children')('1234');
+
+      assert.isTrue(tokenWrapper.find('GitHubTabController').prop('isLoading'));
+    });
+  });
+
   describe('while loading', function() {
-    it('passes isLoading to its view', async function() {
+    it('passes isLoading to the controller', async function() {
       const loadingRepo = new Repository(await cloneRepository());
       assert.isTrue(loadingRepo.isLoading());
-      const wrapper = mount(buildApp({repository: loadingRepo}));
+      const wrapper = shallow(buildApp({repository: loadingRepo}));
+      const repoData = await wrapper.find('ObserveModel').prop('fetchData')(loadingRepo);
+      const repoWrapper = wrapper.find('ObserveModel').renderProp('children')(repoData);
+      const tokenWrapper = repoWrapper.find('ObserveModel').renderProp('children')('1234');
 
-      assert.isTrue(wrapper.find('GitHubTabController').prop('isLoading'));
+      assert.isTrue(tokenWrapper.find('GitHubTabController').prop('isLoading'));
+    });
+  });
+
+  describe('when absent', function() {
+    it('passes placeholder data to the controller', async function() {
+      const absent = Repository.absent();
+      const wrapper = shallow(buildApp({repository: absent}));
+      const repoData = await wrapper.find('ObserveModel').prop('fetchData')(absent);
+      const repoWrapper = wrapper.find('ObserveModel').renderProp('children')(repoData);
+      const tokenWrapper = repoWrapper.find('ObserveModel').renderProp('children')('1234');
+      const controller = tokenWrapper.find('GitHubTabController');
+
+      assert.strictEqual(controller.prop('allRemotes').size(), 0);
+      assert.strictEqual(controller.prop('githubRemotes').size(), 0);
+      assert.isFalse(controller.prop('currentRemote').isPresent());
+      assert.strictEqual(controller.prop('branches').getNames().length, 0);
+      assert.isFalse(controller.prop('currentBranch').isPresent());
+      assert.strictEqual(controller.prop('aheadCount'), 0);
+      assert.isFalse(controller.prop('manyRemotesAvailable'));
+      assert.isFalse(controller.prop('pushInProgress'));
+      assert.isFalse(controller.prop('isLoading'));
     });
   });
 
   describe('once loaded', function() {
-    it('renders the controller', async function() {
-      const workdir = await cloneRepository();
-      const presentRepo = new Repository(workdir);
-      await presentRepo.getLoadPromise();
-      const wrapper = mount(buildApp({repository: presentRepo}));
+    let nonGitHub, github0, github1;
+    let loadedRepo, singleGitHubRemoteSet, multiGitHubRemoteSet;
+    let otherBranch, mainBranch;
+    let branches;
 
-      await assert.async.isFalse(wrapper.update().find('GitHubTabController').prop('isLoading'));
-      assert.strictEqual(wrapper.find('GitHubTabController').prop('workingDirectory'), workdir);
+    beforeEach(async function() {
+      loadedRepo = new Repository(await cloneRepository());
+      await loadedRepo.getLoadPromise();
+
+      nonGitHub = new Remote('no', 'git@elsewhere.com:abc/def.git');
+      github0 = new Remote('yes0', 'git@github.com:user/repo0.git');
+      github1 = new Remote('yes1', 'git@github.com:user/repo1.git');
+
+      singleGitHubRemoteSet = new RemoteSet([nonGitHub, github0]);
+      multiGitHubRemoteSet = new RemoteSet([nonGitHub, github0, github1]);
+
+      otherBranch = new Branch('other');
+      mainBranch = new Branch('main', nullBranch, nullBranch, true);
+      branches = new BranchSet([otherBranch, mainBranch]);
+    });
+
+    function installRemoteSet(remoteSet) {
+      return Promise.all(
+        Array.from(remoteSet, remote => loadedRepo.addRemote(remote.getName(), remote.getUrl())),
+      );
+    }
+
+    it('derives the subset of GitHub remotes', async function() {
+      await installRemoteSet(multiGitHubRemoteSet);
+
+      const wrapper = shallow(buildApp({repository: loadedRepo}));
+      const repoData = await wrapper.find('ObserveModel').prop('fetchData')(loadedRepo);
+      const repoWrapper = wrapper.find('ObserveModel').renderProp('children')(repoData);
+      const tokenWrapper = repoWrapper.find('ObserveModel').renderProp('children')('1234');
+      const githubRemotes = tokenWrapper.find('GitHubTabController').prop('githubRemotes');
+
+      assert.sameMembers(Array.from(githubRemotes, remote => remote.getName()), ['yes0', 'yes1']);
+    });
+
+    it('derives the current branch', async function() {
+      const wrapper = shallow(buildApp({repository: loadedRepo}));
+      const repoData = await wrapper.find('ObserveModel').prop('fetchData')(loadedRepo);
+      repoData.branches = branches;
+      const repoWrapper = wrapper.find('ObserveModel').renderProp('children')(repoData);
+      const tokenWrapper = repoWrapper.find('ObserveModel').renderProp('children')('1234');
+      const currentBranch = tokenWrapper.find('GitHubTabController').prop('currentBranch');
+
+      assert.strictEqual(mainBranch, currentBranch);
+    });
+
+    it('identifies the current remote from the config key', async function() {
+      await loadedRepo.setConfig('atomGithub.currentRemote', 'yes1');
+      await installRemoteSet(multiGitHubRemoteSet);
+
+      const wrapper = shallow(buildApp({repository: loadedRepo}));
+      const repoData = await wrapper.find('ObserveModel').prop('fetchData')(loadedRepo);
+      const repoWrapper = wrapper.find('ObserveModel').renderProp('children')(repoData);
+      const tokenWrapper = repoWrapper.find('ObserveModel').renderProp('children')('1234');
+      const currentRemote = tokenWrapper.find('GitHubTabController').prop('currentRemote');
+
+      assert.strictEqual(currentRemote.getUrl(), github1.getUrl());
+    });
+
+    it('identifies the current remote as the only GitHub remote', async function() {
+      await installRemoteSet(singleGitHubRemoteSet);
+
+      const wrapper = shallow(buildApp({repository: loadedRepo}));
+      const repoData = await wrapper.find('ObserveModel').prop('fetchData')(loadedRepo);
+      const repoWrapper = wrapper.find('ObserveModel').renderProp('children')(repoData);
+      const tokenWrapper = repoWrapper.find('ObserveModel').renderProp('children')('1234');
+      const currentRemote = tokenWrapper.find('GitHubTabController').prop('currentRemote');
+
+      assert.strictEqual(currentRemote.getUrl(), github0.getUrl());
+    });
+
+    it('identifies when there are multiple GitHub remotes available', async function() {
+      await installRemoteSet(multiGitHubRemoteSet);
+
+      const wrapper = shallow(buildApp({repository: loadedRepo}));
+      const repoData = await wrapper.find('ObserveModel').prop('fetchData')(loadedRepo);
+      const repoWrapper = wrapper.find('ObserveModel').renderProp('children')(repoData);
+      const tokenWrapper = repoWrapper.find('ObserveModel').renderProp('children')('1234');
+      const controller = tokenWrapper.find('GitHubTabController');
+
+      assert.isFalse(controller.prop('currentRemote').isPresent());
+      assert.isTrue(controller.prop('manyRemotesAvailable'));
+    });
+
+    it('renders the controller', async function() {
+      await installRemoteSet(singleGitHubRemoteSet);
+
+      const wrapper = shallow(buildApp({repository: loadedRepo}));
+      const repoData = await wrapper.find('ObserveModel').prop('fetchData')(loadedRepo);
+      const repoWrapper = wrapper.find('ObserveModel').renderProp('children')(repoData);
+      const tokenWrapper = repoWrapper.find('ObserveModel').renderProp('children')('1234');
+      const controller = tokenWrapper.find('GitHubTabController');
+
+      assert.isFalse(controller.prop('isLoading'));
+      assert.isFalse(controller.prop('manyRemotesAvailable'));
+      assert.strictEqual(controller.prop('token'), '1234');
     });
   });
 });

--- a/test/containers/github-tab-header-container.test.js
+++ b/test/containers/github-tab-header-container.test.js
@@ -4,18 +4,16 @@ import {QueryRenderer} from 'react-relay';
 
 import GithubTabHeaderContainer from '../../lib/containers/github-tab-header-container';
 import {queryBuilder} from '../builder/graphql/query';
-import GithubLoginModel from '../../lib/models/github-login-model';
-import {getEndpoint} from '../../lib/models/endpoint';
-import {InMemoryStrategy, INSUFFICIENT, UNAUTHENTICATED} from '../../lib/shared/keytar-strategy';
+import {DOTCOM} from '../../lib/models/endpoint';
+import {UNAUTHENTICATED, INSUFFICIENT} from '../../lib/shared/keytar-strategy';
 
 import tabHeaderQuery from '../../lib/containers/__generated__/githubTabHeaderContainerQuery.graphql';
 
 describe('GithubTabHeaderContainer', function() {
-  let atomEnv, model;
+  let atomEnv;
 
   beforeEach(function() {
     atomEnv = global.buildAtomEnvironment();
-    model = new GithubLoginModel(InMemoryStrategy);
   });
 
   afterEach(function() {
@@ -25,31 +23,46 @@ describe('GithubTabHeaderContainer', function() {
   function buildApp(overrideProps = {}) {
     return (
       <GithubTabHeaderContainer
-        loginModel={model}
-        endpoint={getEndpoint('github.com')}
+        endpoint={DOTCOM}
+        token="1234"
+
         currentWorkDir={null}
         contextLocked={false}
         changeWorkingDirectory={() => {}}
         setContextLock={() => {}}
         getCurrentWorkDirs={() => new Set()}
+
         onDidChangeWorkDirs={() => {}}
         {...overrideProps}
       />
     );
   }
 
-  it('renders a null user while the GraphQL query is being performed', async function() {
-    model.setToken('https://api.github.com', '1234');
+  it('renders a null user if the token is still loading', function() {
+    const wrapper = shallow(buildApp({token: null}));
+    assert.isFalse(wrapper.find('GithubTabHeaderController').prop('user').isPresent());
+  });
 
-    sinon.spy(model, 'getToken');
-    sinon.stub(model, 'getScopes').resolves(GithubLoginModel.REQUIRED_SCOPES);
+  it('renders a null user if no token is found', function() {
+    const wrapper = shallow(buildApp({token: UNAUTHENTICATED}));
+    assert.isFalse(wrapper.find('GithubTabHeaderController').prop('user').isPresent());
+  });
 
+  it('renders a null user if the token has insufficient OAuth scopes', function() {
+    const wrapper = shallow(buildApp({token: INSUFFICIENT}));
+    assert.isFalse(wrapper.find('GithubTabHeaderController').prop('user').isPresent());
+  });
+
+  it('renders a null user if there was an error acquiring the token', function() {
+    const e = new Error('oops');
+    e.rawStack = e.stack;
+    const wrapper = shallow(buildApp({token: e}));
+    assert.isFalse(wrapper.find('GithubTabHeaderController').prop('user').isPresent());
+  });
+
+  it('renders a null user while the GraphQL query is being performed', function() {
     const wrapper = shallow(buildApp());
-
-    assert.strictEqual(await wrapper.find('ObserveModel').prop('fetchData')(model), '1234');
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')('1234');
-
-    const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({
+    const resultWrapper = wrapper.find(QueryRenderer).renderProp('render')({
       error: null,
       props: null,
       retry: () => {},
@@ -58,32 +71,8 @@ describe('GithubTabHeaderContainer', function() {
     assert.isFalse(resultWrapper.find('GithubTabHeaderController').prop('user').isPresent());
   });
 
-  it('renders a null user if no token is found', function() {
-    const wrapper = shallow(buildApp());
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')(UNAUTHENTICATED);
-    assert.isFalse(tokenWrapper.find('GithubTabHeaderController').prop('user').isPresent());
-  });
-
-  it('renders a null user if the token has insufficient OAuth scopes', function() {
-    const wrapper = shallow(buildApp());
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')(INSUFFICIENT);
-
-    assert.isFalse(tokenWrapper.find('GithubTabHeaderController').prop('user').isPresent());
-  });
-
-  it('renders a null user if the user is offline', function() {
-    sinon.spy(model, 'didUpdate');
-
-    const wrapper = shallow(buildApp());
-    const e = new Error('oh no');
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')(e);
-    assert.isFalse(tokenWrapper.find('GithubTabHeaderController').prop('user').isPresent());
-  });
-
   it('renders the controller once results have arrived', function() {
     const wrapper = shallow(buildApp());
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')('1234');
-
     const props = queryBuilder(tabHeaderQuery)
       .viewer(v => {
         v.name('user');
@@ -92,7 +81,7 @@ describe('GithubTabHeaderContainer', function() {
         v.login('us3rh4nd13');
       })
       .build();
-    const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({error: null, props, retry: () => {}});
+    const resultWrapper = wrapper.find(QueryRenderer).renderProp('render')({error: null, props, retry: () => {}});
 
     const controller = resultWrapper.find('GithubTabHeaderController');
     assert.isTrue(controller.prop('user').isPresent());

--- a/test/containers/remote-container.test.js
+++ b/test/containers/remote-container.test.js
@@ -3,25 +3,21 @@ import {shallow} from 'enzyme';
 import {QueryRenderer} from 'react-relay';
 
 import RemoteContainer from '../../lib/containers/remote-container';
-import * as reporterProxy from '../../lib/reporter-proxy';
 import {queryBuilder} from '../builder/graphql/query';
 import Remote from '../../lib/models/remote';
 import RemoteSet from '../../lib/models/remote-set';
 import Branch, {nullBranch} from '../../lib/models/branch';
 import BranchSet from '../../lib/models/branch-set';
-import GithubLoginModel from '../../lib/models/github-login-model';
-import {getEndpoint} from '../../lib/models/endpoint';
+import {DOTCOM} from '../../lib/models/endpoint';
 import Refresher from '../../lib/models/refresher';
-import {InMemoryStrategy, INSUFFICIENT, UNAUTHENTICATED} from '../../lib/shared/keytar-strategy';
 
 import remoteQuery from '../../lib/containers/__generated__/remoteContainerQuery.graphql';
 
 describe('RemoteContainer', function() {
-  let atomEnv, model;
+  let atomEnv;
 
   beforeEach(function() {
     atomEnv = global.buildAtomEnvironment();
-    model = new GithubLoginModel(InMemoryStrategy);
   });
 
   afterEach(function() {
@@ -36,20 +32,20 @@ describe('RemoteContainer', function() {
 
     return (
       <RemoteContainer
-        loginModel={model}
-        endpoint={getEndpoint('github.com')}
+        endpoint={DOTCOM}
+        token="1234"
 
         refresher={new Refresher()}
+        pushInProgress={false}
         workingDirectory={__dirname}
-        notifications={atomEnv.notifications}
         workspace={atomEnv.workspace}
         remote={origin}
         remotes={remotes}
         branches={branches}
-
         aheadCount={0}
-        pushInProgress={false}
 
+        handleLogin={() => {}}
+        handleLogout={() => {}}
         onPushBranch={() => {}}
 
         {...overrideProps}
@@ -57,24 +53,9 @@ describe('RemoteContainer', function() {
     );
   }
 
-  it('renders a loading spinner while the token is being fetched', function() {
+  it('renders a loading spinner while the GraphQL query is being performed', function() {
     const wrapper = shallow(buildApp());
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')(null);
-    assert.isTrue(tokenWrapper.exists('LoadingView'));
-  });
-
-  it('renders a loading spinner while the GraphQL query is being performed', async function() {
-    model.setToken('https://api.github.com', '1234');
-
-    sinon.spy(model, 'getToken');
-    sinon.stub(model, 'getScopes').resolves(GithubLoginModel.REQUIRED_SCOPES);
-
-    const wrapper = shallow(buildApp());
-
-    assert.strictEqual(await wrapper.find('ObserveModel').prop('fetchData')(model), '1234');
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')('1234');
-
-    const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({
+    const resultWrapper = wrapper.find(QueryRenderer).renderProp('render')({
       error: null,
       props: null,
       retry: () => {},
@@ -83,68 +64,18 @@ describe('RemoteContainer', function() {
     assert.isTrue(resultWrapper.exists('LoadingView'));
   });
 
-  it('renders a login prompt if no token is found', function() {
-    const wrapper = shallow(buildApp());
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')(UNAUTHENTICATED);
-    assert.isTrue(tokenWrapper.exists('GithubLoginView'));
-  });
-
-  it('renders a login prompt if the token has insufficient OAuth scopes', function() {
-    const wrapper = shallow(buildApp());
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')(INSUFFICIENT);
-
-    assert.match(tokenWrapper.find('GithubLoginView').find('p').text(), /sufficient/);
-  });
-
-  it('renders an offline view if the user is offline', function() {
-    sinon.spy(model, 'didUpdate');
-
-    const wrapper = shallow(buildApp());
-    const e = new Error('oh no');
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')(e);
-    assert.isTrue(tokenWrapper.exists('QueryErrorView'));
-
-    tokenWrapper.find('QueryErrorView').prop('retry')();
-    assert.isTrue(model.didUpdate.called);
-  });
-
   it('renders an error message if the GraphQL query fails', function() {
     const wrapper = shallow(buildApp());
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')('1234');
 
     const error = new Error('oh shit!');
     error.rawStack = error.stack;
-    const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({error, props: null, retry: () => {}});
+    const resultWrapper = wrapper.find(QueryRenderer).renderProp('render')({error, props: null, retry: () => {}});
 
     assert.strictEqual(resultWrapper.find('QueryErrorView').prop('error'), error);
   });
 
-  it('increments a counter on login', function() {
-    const incrementCounterStub = sinon.stub(reporterProxy, 'incrementCounter');
-
-    const wrapper = shallow(buildApp());
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')(UNAUTHENTICATED);
-
-    tokenWrapper.find('GithubLoginView').prop('onLogin')();
-    assert.isTrue(incrementCounterStub.calledOnceWith('github-login'));
-  });
-
-  it('increments a counter on logout', function() {
-    const wrapper = shallow(buildApp());
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')('1234');
-
-    const error = new Error('just show the logout button');
-    error.rawStack = error.stack;
-    const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({error, props: null, retry: () => {}});
-
-    const incrementCounterStub = sinon.stub(reporterProxy, 'incrementCounter');
-    resultWrapper.find('QueryErrorView').prop('logout')();
-    assert.isTrue(incrementCounterStub.calledOnceWith('github-logout'));
-  });
-
   it('renders the controller once results have arrived', function() {
     const wrapper = shallow(buildApp());
-    const tokenWrapper = wrapper.find('ObserveModel').renderProp('children')('1234');
 
     const props = queryBuilder(remoteQuery)
       .repository(r => {
@@ -155,10 +86,9 @@ describe('RemoteContainer', function() {
         });
       })
       .build();
-    const resultWrapper = tokenWrapper.find(QueryRenderer).renderProp('render')({error: null, props, retry: () => {}});
+    const resultWrapper = wrapper.find(QueryRenderer).renderProp('render')({error: null, props, retry: () => {}});
 
     const controller = resultWrapper.find('RemoteController');
-    assert.strictEqual(controller.prop('token'), '1234');
     assert.deepEqual(controller.prop('repository'), {
       id: 'the-repo',
       defaultBranchRef: {

--- a/test/controllers/github-tab-controller.test.js
+++ b/test/controllers/github-tab-controller.test.js
@@ -6,11 +6,13 @@ import Repository from '../../lib/models/repository';
 import BranchSet from '../../lib/models/branch-set';
 import Branch, {nullBranch} from '../../lib/models/branch';
 import RemoteSet from '../../lib/models/remote-set';
-import Remote from '../../lib/models/remote';
-import {InMemoryStrategy} from '../../lib/shared/keytar-strategy';
+import Remote, {nullRemote} from '../../lib/models/remote';
+import {DOTCOM} from '../../lib/models/endpoint';
+import {InMemoryStrategy, UNAUTHENTICATED} from '../../lib/shared/keytar-strategy';
 import GithubLoginModel from '../../lib/models/github-login-model';
 import RefHolder from '../../lib/models/ref-holder';
 import Refresher from '../../lib/models/refresher';
+import * as reporterProxy from '../../lib/reporter-proxy';
 
 import {buildRepository, cloneRepository} from '../helpers';
 
@@ -34,12 +36,18 @@ describe('GitHubTabController', function() {
         workspace={atomEnv.workspace}
         refresher={new Refresher()}
         loginModel={new GithubLoginModel(InMemoryStrategy)}
+        token="1234"
         rootHolder={new RefHolder()}
 
         workingDirectory={repo.getWorkingDirectoryPath()}
         repository={repo}
         allRemotes={new RemoteSet()}
+        githubRemotes={new RemoteSet()}
+        currentRemote={nullRemote}
         branches={new BranchSet()}
+        currentBranch={nullBranch}
+        aheadCount={0}
+        manyRemotesAvailable={false}
         pushInProgress={false}
         isLoading={false}
         currentWorkDir={repo.getWorkingDirectoryPath()}
@@ -60,48 +68,15 @@ describe('GitHubTabController', function() {
   }
 
   describe('derived view props', function() {
-    const dotcom0 = new Remote('yes0', 'git@github.com:aaa/bbb.git');
-    const dotcom1 = new Remote('yes1', 'https://github.com/ccc/ddd.git');
-    const nonDotcom = new Remote('no0', 'git@sourceforge.net:eee/fff.git');
-
-    it('passes the current branch', function() {
-      const currentBranch = new Branch('aaa', nullBranch, nullBranch, true);
-      const otherBranch = new Branch('bbb');
-      const branches = new BranchSet([currentBranch, otherBranch]);
-      const wrapper = shallow(buildApp({branches}));
-
-      assert.strictEqual(wrapper.find('GitHubTabView').prop('currentBranch'), currentBranch);
+    it('passes the endpoint from the current GitHub remote when one exists', function() {
+      const remote = new Remote('hub', 'git@github.com:some/repo.git');
+      const wrapper = shallow(buildApp({currentRemote: remote}));
+      assert.strictEqual(wrapper.find('GitHubTabView').prop('endpoint'), remote.getEndpoint());
     });
 
-    it('passes remotes hosted on GitHub', function() {
-      const allRemotes = new RemoteSet([dotcom0, dotcom1, nonDotcom]);
-      const wrapper = shallow(buildApp({allRemotes}));
-
-      const passed = wrapper.find('GitHubTabView').prop('remotes');
-      assert.isTrue(passed.withName('yes0').isPresent());
-      assert.isTrue(passed.withName('yes1').isPresent());
-      assert.isFalse(passed.withName('no0').isPresent());
-    });
-
-    it('detects an explicitly specified current remote', function() {
-      const allRemotes = new RemoteSet([dotcom0, dotcom1, nonDotcom]);
-      const wrapper = shallow(buildApp({allRemotes, selectedRemoteName: 'yes1'}));
-      assert.strictEqual(wrapper.find('GitHubTabView').prop('currentRemote'), dotcom1);
-      assert.isFalse(wrapper.find('GitHubTabView').prop('manyRemotesAvailable'));
-    });
-
-    it('uses a single GitHub-hosted remote', function() {
-      const allRemotes = new RemoteSet([dotcom0, nonDotcom]);
-      const wrapper = shallow(buildApp({allRemotes}));
-      assert.strictEqual(wrapper.find('GitHubTabView').prop('currentRemote'), dotcom0);
-      assert.isFalse(wrapper.find('GitHubTabView').prop('manyRemotesAvailable'));
-    });
-
-    it('indicates when multiple remotes are available', function() {
-      const allRemotes = new RemoteSet([dotcom0, dotcom1]);
-      const wrapper = shallow(buildApp({allRemotes}));
-      assert.isFalse(wrapper.find('GitHubTabView').prop('currentRemote').isPresent());
-      assert.isTrue(wrapper.find('GitHubTabView').prop('manyRemotesAvailable'));
+    it('defaults the endpoint to dotcom', function() {
+      const wrapper = shallow(buildApp({currentRemote: nullRemote}));
+      assert.strictEqual(wrapper.find('GitHubTabView').prop('endpoint'), DOTCOM);
     });
   });
 
@@ -138,6 +113,27 @@ describe('GitHubTabController', function() {
 
       wrapper.find('GitHubTabView').prop('openBoundPublishDialog')();
       assert.isTrue(openPublishDialog.calledWith(someRepo));
+    });
+
+    it('handles and instruments a login', async function() {
+      sinon.stub(reporterProxy, 'incrementCounter');
+      const loginModel = new GithubLoginModel(InMemoryStrategy);
+
+      const wrapper = shallow(buildApp({loginModel}));
+      await wrapper.find('GitHubTabView').prop('handleLogin')('good-token');
+      assert.strictEqual(await loginModel.getToken(DOTCOM.getLoginAccount()), 'good-token');
+      assert.isTrue(reporterProxy.incrementCounter.calledWith('github-login'));
+    });
+
+    it('handles and instruments a logout', async function() {
+      sinon.stub(reporterProxy, 'incrementCounter');
+      const loginModel = new GithubLoginModel(InMemoryStrategy);
+      await loginModel.setToken(DOTCOM.getLoginAccount(), 'good-token');
+
+      const wrapper = shallow(buildApp({loginModel}));
+      await wrapper.find('GitHubTabView').prop('handleLogout')();
+      assert.strictEqual(await loginModel.getToken(DOTCOM.getLoginAccount()), UNAUTHENTICATED);
+      assert.isTrue(reporterProxy.incrementCounter.calledWith('github-logout'));
     });
   });
 });

--- a/test/models/remote.test.js
+++ b/test/models/remote.test.js
@@ -76,6 +76,7 @@ describe('Remote', function() {
     assert.isNull(nullRemote.getSlug());
     assert.strictEqual(nullRemote.getNameOr('else'), 'else');
     assert.isNull(nullRemote.getEndpoint());
+    assert.strictEqual(nullRemote.getEndpointOrDotcom().getGraphQLRoot(), 'https://api.github.com/graphql');
   });
 
   describe('getEndpoint', function() {
@@ -87,6 +88,18 @@ describe('Remote', function() {
     it('returns null for non-GitHub URLs', function() {
       const elsewhere = new Remote('mirror', 'https://me@bitbucket.org/team/repo.git');
       assert.isNull(elsewhere.getEndpoint());
+    });
+  });
+
+  describe('getEndpointOrDotcom', function() {
+    it('accesses the same Endpoint for the corresponding GitHub host', function() {
+      const remote = new Remote('origin', 'git@github.com:atom/github.git');
+      assert.strictEqual(remote.getEndpointOrDotcom().getGraphQLRoot(), 'https://api.github.com/graphql');
+    });
+
+    it('returns dotcom for non-GitHub URLs', function() {
+      const elsewhere = new Remote('mirror', 'https://me@bitbucket.org/team/repo.git');
+      assert.strictEqual(elsewhere.getEndpointOrDotcom().getGraphQLRoot(), 'https://api.github.com/graphql');
     });
   });
 });

--- a/test/models/repository.test.js
+++ b/test/models/repository.test.js
@@ -73,10 +73,13 @@ describe('Repository', function() {
       }
 
       // Methods that resolve to null
-      for (const method of [
-        'getAheadCount', 'getBehindCount', 'getLastHistorySnapshots', 'getCache',
-      ]) {
+      for (const method of ['getLastHistorySnapshots', 'getCache']) {
         assert.isNull(await repository[method]());
+      }
+
+      // Methods that resolve to 0
+      for (const method of ['getAheadCount', 'getBehindCount']) {
+        assert.strictEqual(await repository[method](), 0);
       }
 
       // Methods that resolve to an empty array


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Suggestion: You can use checklists to keep track of progress for the sections on metrics, tests, documentation, and user research.

### Description of the Change

When given an absent or an empty repository context, the GitHub tab shows the "create", "clone", or "publish" buttons even if you haven't authenticated to GitHub and acquired an API token yet. This causes problems because the create and publish dialog flows both assume that you have a token already, so they can populate the repository owner drop-down menus.

This elevates the priority of the login prompt so it'll be shown instead of the blank-slate flow buttons if you have no token. Once you authenticate and set a token, the blank-slate buttons appear as before.

### Applicable Issues

Partially addresses #2542, although you can still get into that state by opening the create or publish dialogs from the command palette.

### Release Notes

* The GitHub package prompts for login before offering to create, clone, or publish a repository.