### PR TITLE
Update shell.openExternal to promise due to electron update on atom

### DIFF
--- a/lib/controllers/issueish-list-controller.js
+++ b/lib/controllers/issueish-list-controller.js
@@ -90,15 +90,9 @@ export class BareIssueishListController extends React.Component {
     return null;
   }
 
-  openOnGitHub = url => {
-    return new Promise((resolve, reject) => {
-      shell.openExternal(url, {}, err => {
-        if (err) { reject(err); } else {
-          resolve();
-          addEvent('open-issueish-in-browser', {package: 'github', component: this.constructor.name});
-        }
-      });
-    });
+  openOnGitHub = async url => {
+    await shell.openExternal(url);
+    addEvent('open-issueish-in-browser', {package: 'github', component: this.constructor.name});
   }
 
   showActionsMenu = /* istanbul ignore next */ issueish => {

--- a/lib/controllers/issueish-searches-controller.js
+++ b/lib/controllers/issueish-searches-controller.js
@@ -113,13 +113,8 @@ export default class IssueishSearchesController extends React.Component {
     });
   }
 
-  onOpenSearch = search => {
+  onOpenSearch = async search => {
     const searchURL = search.getWebURL(this.props.remote);
-
-    return new Promise((resolve, reject) => {
-      shell.openExternal(searchURL, {}, err => {
-        if (err) { reject(err); } else { resolve(); }
-      });
-    });
+    await shell.openExternal(searchURL);
   }
 }

--- a/lib/controllers/remote-controller.js
+++ b/lib/controllers/remote-controller.js
@@ -67,15 +67,7 @@ export default class RemoteController extends React.Component {
     createPrUrl += '/compare/' + encodeURIComponent(currentBranch.getName());
     createPrUrl += '?expand=1';
 
-    return new Promise((resolve, reject) => {
-      shell.openExternal(createPrUrl, {}, err => {
-        if (err) {
-          reject(err);
-        } else {
-          incrementCounter('create-pull-request');
-          resolve();
-        }
-      });
-    });
+    await shell.openExternal(createPrUrl);
+    incrementCounter('create-pull-request');
   }
 }

--- a/lib/views/actionable-review-view.js
+++ b/lib/views/actionable-review-view.js
@@ -124,28 +124,17 @@ export default class ActionableReviewView extends React.Component {
     }
   }
 
-  reportAbuse = (commentUrl, author) => {
-    return new Promise((resolve, reject) => {
-      const url = 'https://github.com/contact/report-content?report=' +
-        `${encodeURIComponent(author)}&content_url=${encodeURIComponent(commentUrl)}`;
-      shell.openExternal(url, {}, err => {
-        if (err) { reject(err); } else {
-          resolve();
-          addEvent('report-abuse', {package: 'github', component: this.constructor.name});
-        }
-      });
-    });
+  reportAbuse = async (commentUrl, author) => {
+    const url = 'https://github.com/contact/report-content?report=' +
+      `${encodeURIComponent(author)}&content_url=${encodeURIComponent(commentUrl)}`;
+
+    await shell.openExternal(url);
+    addEvent('report-abuse', {package: 'github', component: this.constructor.name});
   }
 
-  openOnGitHub = url => {
-    return new Promise((resolve, reject) => {
-      shell.openExternal(url, {}, err => {
-        if (err) { reject(err); } else {
-          resolve();
-          addEvent('open-comment-in-browser', {package: 'github', component: this.constructor.name});
-        }
-      });
-    });
+  openOnGitHub = async url => {
+    await shell.openExternal(url);
+    addEvent('open-comment-in-browser', {package: 'github', component: this.constructor.name});
   }
 
   showActionsMenu = (event, content, author) => {

--- a/lib/views/issueish-link.js
+++ b/lib/views/issueish-link.js
@@ -44,17 +44,9 @@ export function openIssueishLinkInNewTab(url, options = {}) {
   }
 }
 
-export function openLinkInBrowser(uri) {
-  return new Promise((resolve, reject) => {
-    shell.openExternal(uri, {}, err => {
-      if (err) {
-        reject(err);
-      } else {
-        addEvent('open-issueish-in-browser', {package: 'github', from: 'issueish-link'});
-        resolve();
-      }
-    });
-  });
+export async function openLinkInBrowser(uri) {
+  await shell.openExternal(uri);
+  addEvent('open-issueish-in-browser', {package: 'github', from: 'issueish-link'});
 }
 
 function getAtomUriForGithubUrl(githubUrl) {

--- a/test/controllers/issueish-list-controller.test.js
+++ b/test/controllers/issueish-list-controller.test.js
@@ -90,7 +90,7 @@ describe('IssueishListController', function() {
 
     it('calls shell.openExternal with specified url', async function() {
       const wrapper = shallow(buildApp());
-      sinon.stub(shell, 'openExternal').callsArg(2);
+      sinon.stub(shell, 'openExternal').callsFake(() => { });
 
       await wrapper.instance().openOnGitHub(url);
       assert.isTrue(shell.openExternal.calledWith(url));
@@ -98,7 +98,7 @@ describe('IssueishListController', function() {
 
     it('fires `open-issueish-in-browser` event upon success', async function() {
       const wrapper = shallow(buildApp());
-      sinon.stub(shell, 'openExternal').callsArg(2);
+      sinon.stub(shell, 'openExternal').callsFake(() => {});
       sinon.stub(reporterProxy, 'addEvent');
 
       await wrapper.instance().openOnGitHub(url);
@@ -109,7 +109,7 @@ describe('IssueishListController', function() {
 
     it('handles error when openOnGitHub fails', async function() {
       const wrapper = shallow(buildApp());
-      sinon.stub(shell, 'openExternal').callsArgWith(2, new Error('oh noes'));
+      sinon.stub(shell, 'openExternal').throws(new Error('oh noes'));
       sinon.stub(reporterProxy, 'addEvent');
 
       try {

--- a/test/controllers/remote-controller.test.js
+++ b/test/controllers/remote-controller.test.js
@@ -52,7 +52,7 @@ describe('RemoteController', function() {
 
   it('increments a counter when onCreatePr is called', async function() {
     const wrapper = shallow(createApp());
-    sinon.stub(shell, 'openExternal').callsArg(2);
+    sinon.stub(shell, 'openExternal').callsFake(() => {});
     sinon.stub(reporterProxy, 'incrementCounter');
 
     await wrapper.instance().onCreatePr();
@@ -62,7 +62,7 @@ describe('RemoteController', function() {
 
   it('handles error when onCreatePr fails', async function() {
     const wrapper = shallow(createApp());
-    sinon.stub(shell, 'openExternal').callsArgWith(2, new Error('oh noes'));
+    sinon.stub(shell, 'openExternal').throws(new Error('oh noes'));
     sinon.stub(reporterProxy, 'incrementCounter');
 
     try {

--- a/test/views/actionable-review-view.test.js
+++ b/test/views/actionable-review-view.test.js
@@ -69,17 +69,17 @@ describe('ActionableReviewView', function() {
       }
 
       it("opens the content object's URL with 'Open on GitHub'", async function() {
-        sinon.stub(shell, 'openExternal').callsArg(2);
+        sinon.stub(shell, 'openExternal').callsFake(() => {});
 
         const item = triggerMenu({url: 'https://github.com'}, {}).items.find(i => i.label === 'Open on GitHub');
         await item.click();
 
-        assert.isTrue(shell.openExternal.calledWith('https://github.com', {}));
+        assert.isTrue(shell.openExternal.calledWith('https://github.com'));
         assert.isTrue(reporterProxy.addEvent.calledWith('open-comment-in-browser'));
       });
 
       it("rejects the promise when 'Open on GitHub' fails", async function() {
-        sinon.stub(shell, 'openExternal').callsArgWith(2, new Error("I don't feel like it"));
+        sinon.stub(shell, 'openExternal').throws(new Error("I don't feel like it"));
 
         const item = triggerMenu({url: 'https://github.com'}, {}).items.find(i => i.label === 'Open on GitHub');
         await assert.isRejected(item.click());
@@ -87,7 +87,7 @@ describe('ActionableReviewView', function() {
       });
 
       it('opens a prepopulated abuse-reporting link with "Report abuse"', async function() {
-        sinon.stub(shell, 'openExternal').callsArg(2);
+        sinon.stub(shell, 'openExternal').callsFake(() => {});
 
         const item = triggerMenu({url: 'https://github.com/a/b'}, {login: 'tyrion'})
           .items.find(i => i.label === 'Report abuse');
@@ -95,13 +95,12 @@ describe('ActionableReviewView', function() {
 
         assert.isTrue(shell.openExternal.calledWith(
           'https://github.com/contact/report-content?report=tyrion&content_url=https%3A%2F%2Fgithub.com%2Fa%2Fb',
-          {},
         ));
         assert.isTrue(reporterProxy.addEvent.calledWith('report-abuse'));
       });
 
       it("rejects the promise when 'Report abuse' fails", async function() {
-        sinon.stub(shell, 'openExternal').callsArgWith(2, new Error('nah'));
+        sinon.stub(shell, 'openExternal').throws(new Error('nah'));
 
         const item = triggerMenu({url: 'https://github.com/a/b'}, {login: 'tyrion'})
           .items.find(i => i.label === 'Report abuse');

--- a/test/views/github-dotcom-markdown.test.js
+++ b/test/views/github-dotcom-markdown.test.js
@@ -213,7 +213,7 @@ describe('GithubDotcomMarkdown', function() {
     });
 
     it('records event for opening issueish in browser', async function() {
-      sinon.stub(shell, 'openExternal').callsArg(2);
+      sinon.stub(shell, 'openExternal').callsFake(() => {});
       sinon.stub(reporterProxy, 'addEvent');
 
       const issueishLink = wrapper.getDOMNode().querySelector('a.issue-link');
@@ -228,7 +228,7 @@ describe('GithubDotcomMarkdown', function() {
     });
 
     it('does not record event if opening issueish in browser fails', function() {
-      sinon.stub(shell, 'openExternal').callsArgWith(2, new Error('oh noes'));
+      sinon.stub(shell, 'openExternal').throws(new Error('oh noes'));
       sinon.stub(reporterProxy, 'addEvent');
 
       // calling `handleClick` directly rather than dispatching event so that we can catch the error thrown and prevent errors in the console


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change
There are some Electron APIs that changed to only return Promises (and not run callbacks passed to them), mostly as of Electron 7+. Updating to be compatible with those would be great for updating Atom's Electron version.

### Screenshot or Gif


### Applicable Issues
https://github.com/atom/github/issues/2624