### PR TITLE
Update to promise api for some methods in the electron API

### DIFF
--- a/lib/views/directory-select.js
+++ b/lib/views/directory-select.js
@@ -45,15 +45,13 @@ export default class DirectorySelect extends React.Component {
     );
   }
 
-  chooseDirectory = () => new Promise(resolve => {
+  chooseDirectory = () =>
     this.props.showOpenDialog(this.props.currentWindow, {
       defaultPath: this.props.buffer.getText(),
       properties: ['openDirectory', 'createDirectory', 'promptToCreate'],
-    }, filePaths => {
-      if (filePaths !== undefined) {
+    }).then(({filePaths}) => {
+      if (filePaths.length) {
         this.props.buffer.setText(filePaths[0]);
       }
-      resolve();
     });
-  });
 }

--- a/lib/views/directory-select.js
+++ b/lib/views/directory-select.js
@@ -45,13 +45,13 @@ export default class DirectorySelect extends React.Component {
     );
   }
 
-  chooseDirectory = () =>
-    this.props.showOpenDialog(this.props.currentWindow, {
+  chooseDirectory = async () => {
+    const {filePaths} = await this.props.showOpenDialog(this.props.currentWindow, {
       defaultPath: this.props.buffer.getText(),
       properties: ['openDirectory', 'createDirectory', 'promptToCreate'],
-    }).then(({filePaths}) => {
-      if (filePaths.length) {
-        this.props.buffer.setText(filePaths[0]);
-      }
     });
+    if (filePaths.length) {
+      this.props.buffer.setText(filePaths[0]);
+    }
+  }
 }

--- a/lib/views/git-timings-view.js
+++ b/lib/views/git-timings-view.js
@@ -328,9 +328,9 @@ class WaterfallWidget extends React.Component {
     const buffer = new TextBuffer({text: json});
     dialog.showSaveDialog({
       defaultPath: 'git-timings.json',
-    }, filename => {
-      if (!filename) { return; }
-      buffer.saveAs(filename);
+    }).then(({filePath}) => {
+      if (!filePath) { return; }
+      buffer.saveAs(filePath);
     });
   }
 }
@@ -423,9 +423,9 @@ export default class GitTimingsView extends React.Component {
     e.preventDefault();
     dialog.showOpenDialog({
       properties: ['openFile'],
-    }, async filenames => {
-      if (!filenames) { return; }
-      const filename = filenames[0];
+    }).then(async ({filePaths}) => {
+      if (!filePaths.length) { return; }
+      const filename = filePaths[0];
       try {
         const contents = await fs.readFile(filename, {encoding: 'utf8'});
         const data = JSON.parse(contents);

--- a/lib/views/git-timings-view.js
+++ b/lib/views/git-timings-view.js
@@ -322,16 +322,17 @@ class WaterfallWidget extends React.Component {
     this.setState(s => ({collapsed: !s.collapsed}));
   }
 
-  handleExportClick(e) {
+  async handleExportClick(e) {
     e.preventDefault();
     const json = JSON.stringify(this.props.markers.map(m => m.serialize()), null, '  ');
     const buffer = new TextBuffer({text: json});
-    dialog.showSaveDialog({
+    const {filePath} = await dialog.showSaveDialog({
       defaultPath: 'git-timings.json',
-    }).then(({filePath}) => {
-      if (!filePath) { return; }
-      buffer.saveAs(filePath);
     });
+    if (!filePath) {
+      return;
+    }
+    buffer.saveAs(filePath);
   }
 }
 
@@ -419,22 +420,23 @@ export default class GitTimingsView extends React.Component {
     );
   }
 
-  handleImportClick(e) {
+  async handleImportClick(e) {
     e.preventDefault();
-    dialog.showOpenDialog({
+    const {filePaths} = await dialog.showOpenDialog({
       properties: ['openFile'],
-    }).then(async ({filePaths}) => {
-      if (!filePaths.length) { return; }
-      const filename = filePaths[0];
-      try {
-        const contents = await fs.readFile(filename, {encoding: 'utf8'});
-        const data = JSON.parse(contents);
-        const restoredMarkers = data.map(item => Marker.deserialize(item));
-        GitTimingsView.restoreGroup(restoredMarkers);
-      } catch (_err) {
-        atom.notifications.addError(`Could not import timings from ${filename}`);
-      }
     });
+    if (!filePaths.length) {
+      return;
+    }
+    const filename = filePaths[0];
+    try {
+      const contents = await fs.readFile(filename, {encoding: 'utf8'});
+      const data = JSON.parse(contents);
+      const restoredMarkers = data.map(item => Marker.deserialize(item));
+      GitTimingsView.restoreGroup(restoredMarkers);
+    } catch (_err) {
+      atom.notifications.addError(`Could not import timings from ${filename}`);
+    }
   }
 
   serialize() {

--- a/test/views/directory-select.test.js
+++ b/test/views/directory-select.test.js
@@ -47,7 +47,7 @@ describe('DirectorySelect', function() {
 
   describe('clicking the directory button', function() {
     it('populates the destination path buffer on accept', async function() {
-      const showOpenDialog = sinon.stub().callsArgWith(2, ['/some/directory/path']);
+      const showOpenDialog = sinon.stub().callsArgWith(2, {filePaths: ['/some/directory/path']});
       const buffer = new TextBuffer({text: '/original'});
 
       const wrapper = shallow(buildApp({showOpenDialog, buffer}));
@@ -58,7 +58,7 @@ describe('DirectorySelect', function() {
     });
 
     it('leaves the destination path buffer unmodified on cancel', async function() {
-      const showOpenDialog = sinon.stub().callsArgWith(2, undefined);
+      const showOpenDialog = sinon.stub().callsArgWith(2, {filePaths: undefined});
       const buffer = new TextBuffer({text: '/original'});
 
       const wrapper = shallow(buildApp({showOpenDialog, buffer}));

--- a/test/views/directory-select.test.js
+++ b/test/views/directory-select.test.js
@@ -47,7 +47,7 @@ describe('DirectorySelect', function() {
 
   describe('clicking the directory button', function() {
     it('populates the destination path buffer on accept', async function() {
-      const showOpenDialog = sinon.stub().callsArgWith(2, {filePaths: ['/some/directory/path']});
+      const showOpenDialog = sinon.stub().returns(Promise.resolve({filePaths: ['/some/directory/path']}));
       const buffer = new TextBuffer({text: '/original'});
 
       const wrapper = shallow(buildApp({showOpenDialog, buffer}));
@@ -58,7 +58,7 @@ describe('DirectorySelect', function() {
     });
 
     it('leaves the destination path buffer unmodified on cancel', async function() {
-      const showOpenDialog = sinon.stub().callsArgWith(2, {filePaths: undefined});
+      const showOpenDialog = sinon.stub().returns(Promise.resolve({filePaths: undefined}));
       const buffer = new TextBuffer({text: '/original'});
 
       const wrapper = shallow(buildApp({showOpenDialog, buffer}));

--- a/test/views/directory-select.test.js
+++ b/test/views/directory-select.test.js
@@ -24,7 +24,7 @@ describe('DirectorySelect', function() {
       <DirectorySelect
         currentWindow={atomEnv.getCurrentWindow()}
         buffer={buffer}
-        showOpenDialog={() => {}}
+        showOpenDialog={() => Promise.resolve()}
         tabGroup={new TabGroup()}
         {...override}
       />

--- a/test/views/directory-select.test.js
+++ b/test/views/directory-select.test.js
@@ -58,7 +58,7 @@ describe('DirectorySelect', function() {
     });
 
     it('leaves the destination path buffer unmodified on cancel', async function() {
-      const showOpenDialog = sinon.stub().returns(Promise.resolve({filePaths: undefined}));
+      const showOpenDialog = sinon.stub().returns(Promise.resolve({filePaths: []}));
       const buffer = new TextBuffer({text: '/original'});
 
       const wrapper = shallow(buildApp({showOpenDialog, buffer}));

--- a/test/worker-manager.test.js
+++ b/test/worker-manager.test.js
@@ -167,7 +167,7 @@ describe('WorkerManager', function() {
       });
       `;
 
-      await new Promise(resolve => browserWindow.webContents.executeJavaScript(script, resolve));
+      await browserWindow.webContents.executeJavaScript(script);
 
       workerManager.destroy(true);
       workerManager = new WorkerManager();


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR aims at using the promise version of

- showSaveDialog,
- showOpenDialog,
- executeJavascript

electron API

In order to ease the upgrade path to newer versions of electron where the callback is no more supported.

### Screenshot or Gif

<!-- If the changes are visual, add a screenshot or record a Gif. This doesn't have to be updated during implementation, but after a PR is merged, a final screenshot/gif should be added. It might get used for blog posts, documentation etc. Write "N/A" if not applicable. -->

### Applicable Issues

<!-- Cross-reference any applicable Issues here. Use "Fixes #NNN" or "Closes #NNN" syntax to automatically close linked issues on merge. -->
