### PR TITLE
Hotfix in restore discard history of files with same name

### DIFF
--- a/lib/models/discard-history.js
+++ b/lib/models/discard-history.js
@@ -127,7 +127,7 @@ export default class DiscardHistory {
         await this.expandBlobToFile(path.join(tempFolderPath, `${filePath}-before-discard`), beforeSha);
       const commonBasePath = !afterSha ? null :
         await this.expandBlobToFile(path.join(tempFolderPath, `${filePath}-after-discard`), afterSha);
-      const resultPath = path.join(tempFolderPath, `~${path.basename(filePath)}-merge-result`);
+      const resultPath = path.join(tempFolderPath, path.dirname(filePath), `~${path.basename(filePath)}-merge-result`);
       return {filePath, commonBasePath, theirsPath, resultPath, theirsSha: beforeSha, commonBaseSha: afterSha};
     });
     return await Promise.all(pathPromises);

--- a/lib/models/discard-history.js
+++ b/lib/models/discard-history.js
@@ -127,7 +127,7 @@ export default class DiscardHistory {
         await this.expandBlobToFile(path.join(tempFolderPath, `${filePath}-before-discard`), beforeSha);
       const commonBasePath = !afterSha ? null :
         await this.expandBlobToFile(path.join(tempFolderPath, `${filePath}-after-discard`), afterSha);
-      const resultPath = path.join(tempFolderPath, path.dirname(filePath), `~${path.basename(filePath)}-merge-result`);
+      const resultPath = path.join(dir, `~${path.basename(filePath)}-merge-result`);
       return {filePath, commonBasePath, theirsPath, resultPath, theirsSha: beforeSha, commonBaseSha: afterSha};
     });
     return await Promise.all(pathPromises);


### PR DESCRIPTION
### Description of the Change

This hotfix restores the discard history of two files with the same name correctly by including the directory of the file in the result path.

### Screenshot or Gif

N/A

### Applicable Issues

Fixes #2172