### PR TITLE
fix warning at #2680

### DIFF
--- a/lib/atom/commands.js
+++ b/lib/atom/commands.js
@@ -53,9 +53,9 @@ export class Command extends React.Component {
     this.observeTarget(this.props);
   }
 
-  componentWillReceiveProps(newProps) {
-    if (['registry', 'target', 'command', 'callback'].some(p => newProps[p] !== this.props[p])) {
-      this.observeTarget(newProps);
+  componentDidUpdate(prevProps) {
+    if (['registry', 'target', 'command', 'callback'].some(p => prevProps[p] !== this.props[p])) {
+      this.observeTarget(this.props);
     }
   }
 


### PR DESCRIPTION

**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Description of the Change

https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops says:
_"If you need to __perform a side effect__ (for example, data fetching or an animation) in response to a change in props, use `componentDidUpdate` lifecycle instead."_

`componentDidUpdate` is called after updating, rather than `componentWillRecieveProps`. If this (or some other subtle change) happens to break atom, feel free to restart this pr and simply rename the method to `UNSAFE_componentWillReceiveProps` instead.


Warning text:

___
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.
___

In this case, it's used for side effects (1st bullet point)

This implies there will still be a warning when using `UNSAFE_componentWillReceiveProps` in strict-mode, so trying `componentDidUpdate` first.

### Screenshot or Gif

N/A

### Applicable Issues

Fixes #2680
