### PR TITLE
Remote module defaults to false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,6 @@ jobs:
       with:
         channel: ${{ matrix.channel }}
 
-    - name: install windows build tools
-      if: contains(matrix.os, 'windows')
-      run: |
-        choco install visualcpp-build-tools --version=14.0.25420.1 --ignore-dependencies -y --params "'/IncludeRequired'"
-        echo "VCTargetsPath='C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140'" >> $GITHUB_ENV
     - name: install dependencies
       run: apm ci
 

--- a/lib/worker-manager.js
+++ b/lib/worker-manager.js
@@ -268,7 +268,7 @@ export class RendererProcess {
     this.onExecStarted = onExecStarted;
 
     this.win = new BrowserWindow({show: !!process.env.ATOM_GITHUB_SHOW_RENDERER_WINDOW,
-      webPreferences: {nodeIntegration: true}});
+      webPreferences: {nodeIntegration: true, enableRemoteModule: true}});
     this.webContents = this.win.webContents;
     // this.webContents.openDevTools();
 


### PR DESCRIPTION

**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

- `enableRemoteModule` now defaults to false and is on the verge of being deprecated. We must therefore set it to true in order to maintain the previous behaviour that depends on it.
   This change also makes electron upgrade to 11.4.7 possible.


### Screenshot or Gif


### Applicable Issues
https://github.com/atom/atom/pull/22687
