### PR TITLE
[WIP] don't call method of destroyed webContents

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -45,10 +45,6 @@ const averageTracker = new AverageTracker({limit: operationCountLimit});
 const childPidsById = new Map();
 
 const destroyRenderer = () => {
-  if (!managerWebContents.isDestroyed()) {
-    managerWebContents.removeListener('crashed', destroyRenderer);
-    managerWebContents.removeListener('destroyed', destroyRenderer);
-  }
   const win = remote.BrowserWindow.fromWebContents(remote.getCurrentWebContents());
   if (win && !win.isDestroyed()) {
     win.destroy();


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

The ubuntu tests have been failing, even for perfectly valid prs

One of the complained errors says "Attempting to call a function in a renderer window that has been closed or released."
EDIT: This appears in all the tests, so this error (or warning?) doesn't actually fail the tests

So I think this attempt removes the function call - and hopefully fixes the tests
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Screenshot or Gif

![image](https://user-images.githubusercontent.com/58114641/138333542-6b70c8c9-2cc4-4393-af0e-106183fd927a.png)

<!-- If the changes are visual, add a screenshot or record a Gif. This doesn't have to be updated during implementation, but after a PR is merged, a final screenshot/gif should be added. It might get used for blog posts, documentation etc. Write "N/A" if not applicable. -->

### Applicable Issues

<!-- Cross-reference any applicable Issues here. Use "Fixes #NNN" or "Closes #NNN" syntax to automatically close linked issues on merge. -->
