### PR TITLE
Don't use deprecated `Buffer`

### DIFF
--- a/test/git-strategies.test.js
+++ b/test/git-strategies.test.js
@@ -837,7 +837,7 @@ import * as reporterProxy from '../lib/reporter-proxy';
           it('returns an empty diff', async function() {
             const workingDirPath = await cloneRepository('three-files');
             const git = createTestStrategy(workingDirPath);
-            const data = new Buffer(10);
+            const data = Buffer.alloc(10);
             for (let i = 0; i < 10; i++) {
               data.writeUInt8(i + 200, i);
             }


### PR DESCRIPTION
**Please be sure to read the [contributor's guide to the GitHub package](https://github.com/atom/github/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

According to https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/, `Buffer(number)` should be replaced by `Buffer.alloc(number)`
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Screenshot or Gif

<!-- If the changes are visual, add a screenshot or record a Gif. This doesn't have to be updated during implementation, but after a PR is merged, a final screenshot/gif should be added. It might get used for blog posts, documentation etc. Write "N/A" if not applicable. -->
![image](https://user-images.githubusercontent.com/58114641/138759785-d81000bd-7f18-4157-9f39-35c23fd5318b.png)


### Applicable Issues

<!-- Cross-reference any applicable Issues here. Use "Fixes #NNN" or "Closes #NNN" syntax to automatically close linked issues on merge. -->
