### PR TITLE
CI: Use 'windows-2019' image for Windows tests (makes CI passing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: tests
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-2019]
         channel: [beta, nightly]
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Description of the Change

In CI, use the 'windows-2019' image instead of 'windows-latest'.

#### Reason for change

This gives us an older version of Visual Studio compatible with apm's old copy of node-gyp, so CI can proceed past installing dependencies/not get stuck, on the Windows jobs.

(context: apm is still built around npm 6 --> node-gyp 5.x. Visual Studio 2022 support was only added in [node-gyp 8.4.0](https://github.com/nodejs/node-gyp/blob/master/CHANGELOG.md#840-2021-11-05). So we need older Visual Studio to accommodate apm's old copy of node-gyp. the 'windows-2019' image has the older Visual Studio we're looking for.)

### Applicable Issues

None filed, but CI isn't passing.

#### More details about the issue

(I assume the Windows jobs started failing when the 'windows-latest' CI image tag was updated to point to/be an alias for the 'windows-2022' image.)

CI's Windows jobs get stuck on the "install dependencies" step, because they need to build native C/C++ code in some of the packages, but apm's old copy of node-gyp doesn't understand how to find find Visual Studio 2022 or newer, so the dependency installation steps fail. Normally the test step has a "fails allowed" setting, but this was failing even before the tests ran, causing the overall windows jobs to report failing, and thus all PRs are going to report as failing, making it much harder to tell at a glance which PRs actually pass CI on macOS and Linux. A reminder that the Windows tests have been known failing and allowed to fail without making CI red for a long time now. Failing before the tests ran is a new thing.