### PR TITLE
defaultBranchName of 'main' for empty repo

### DIFF
--- a/lib/views/create-dialog.js
+++ b/lib/views/create-dialog.js
@@ -46,7 +46,7 @@ export async function publishRepository(
   if (repository.isEmpty()) {
     wasEmpty = true;
     await repository.init();
-    defaultBranchName = 'master';
+    defaultBranchName = 'main';
   } else {
     wasEmpty = false;
     const branchSet = await repository.getBranches();


### PR DESCRIPTION
### Description of the Change
switch defaultBranchName to use main 'main' for an empty / new repo

L54 is kept in for legacy compatibility

This is an incremental fix: ideally it should create the branch name from git config `init.defaultBranch`

### Screenshot or Gif

<!-- If the changes are visual, add a screenshot or record a Gif. This doesn't have to be updated during implementation, but after a PR is merged, a final screenshot/gif should be added. It might get used for blog posts, documentation etc. Write "N/A" if not applicable. -->

### Applicable Issues

fixes #2755
